### PR TITLE
Rename sender/receiver to client/server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ It is designed to be used behind game clients as well as in front of dedicated g
 
 ## Planned Roadmap
 
-- [x] Sender: Configuration with a connection token
-- [x] Receiver: Configuration of endpoints with multiple connection token attached, that provide routing 
-- [ ] 👷 Basic non-transparent UDP forwarding from Sender to Receiver
-- [ ] 👷 Basic non-transparent UDP forwarding from Receiver to all endpoints
-- [ ] Simple UDP routing via an appended connection ID to UDP packet (sender and receiver implementation)
-- [ ] QUIC based security and UDP routing (sender and receiver implementation)
+- [x] Client Proxy: Configuration with a connection token
+- [x] Server Proxy: Configuration of endpoints with multiple connection token attached, that provide routing 
+- [ ] 👷 Basic non-transparent UDP forwarding from Client Proxy to Server Proxy
+- [ ] 👷 Basic non-transparent UDP forwarding from Server Proxy to all Endpoints
+- [ ] Simple UDP routing via an appended connection ID to UDP packet (Client and Server Proxy implementation)
+- [ ] QUIC based security and UDP routing (Client and Server Proxy implementation)
 - [ ] gRPC configuration management control plane API
 - [ ] Add Open Telemetry metrics
 
@@ -24,28 +24,28 @@ Not to be used in production systems.
 
 ## Proposed Architecture
 ```
-                                    +                          +
-                                    |                          |
-                                 Internet                   Private
-                                    |                       Network
-                                    |      +-------------+     |          +----------------+
-                                    |      |Quilkin Proxy|     |          | Dedicated Game |
-                                    |  +-->+(Receiver)   +---------+------> Server         |
-+---------+       +-------------+   |  |   |             |     |   |      |                |
-|  Game   |       |Quilkin Proxy+------+   --------------+     |   |      +----------------+
-|  Client +------>+(Sender)     |   |  |                       |   |
-+---------+       +-------------+   |  |   +-------------+     |   |      +----------------+
-                                    |  |   |Quilkin Proxy|     |   |      | Dedicated Game |
-                                    |  +-->+(Receiver)   +---------+      | Server         |
-                                    |      |             |     |          |                |
-                                    |      +-------------+     |          +----------------+
-                                    |                          |
-                                    |      +-------------+     |          +----------------+
-                                    |      |Quilkin Proxy|     |          | Dedicated Game |
-                                    |      |(Receiver)   |     |          | Server         |
-                                    |      |             |     |          |                |
-                                    |      +-------------+     |          +----------------+
-                                    +                          +
+                                       +                          +
+                                       +                          |
+                                    Internet                   Private
+                                       +                       Network
+                                       |     +----------------+   +          +----------------+
+                                       |     | Quilkin        |   |          | Dedicated      |
+                                       |  +--> (Server Proxy) +-------+------> Game Server    |
++---------+      +----------------+    |  |  |                |   |   |      |                |
+|  Game   |      | Quilkin        +-------+  +----------------+   |   |      +----------------+
+|  Client +------+ (Client Proxy) |    |  |                       |   |
++---------+      +----------------+    |  |  +----------------+   |   |      +----------------+
+                                       |  |  | Quilkin        |   |   |      | Dedicated      |
+                                       |  +--> (Server Proxy) +-------+      | Game Server    |
+                                       |     |                |   |          |                |
+                                       |     +----------------+   |          +----------------+
+                                       |                          |
+                                       |     +----------------+   |          +----------------+
+                                       |     | Quilkin        |   |          | Dedicated      |
+                                       |     | (Server Proxy) |   |          | Game Server    |
+                                       |     |                |   |          |                |
+                                       |     +----------------+   |          +----------------+
+                                       +                          +
 ```
 
 ## Usage

--- a/examples/client-proxy.yaml
+++ b/examples/client-proxy.yaml
@@ -15,11 +15,11 @@
 #
 
 #
-# Example configuration for a game client sender
+# Example configuration for a Quilkin Proxy that sits behind a game clients
 #
 
 local:
   port: 7000 # the port to receive traffic to locally
-sender_config:
+client:
   address: 127.0.0.1:7001 # the address to send traffic to
   connection_id: 1x7ijy6 # the connection string to attach to the traffic

--- a/examples/server-proxy.yaml
+++ b/examples/server-proxy.yaml
@@ -15,12 +15,12 @@
 #
 
 #
-# Example configuration for Game server receivers
+# Example configuration for a Quilkin Proxy that sits in front of dedicated game servers
 #
 
 local:
   port: 7001 # the port to receive traffic to locally
-receiver_config:
+server:
   endpoints: # array of potential endpoints to send on traffic to
     - name: Game Server No. 1
       address: 127.0.0.1:26000

--- a/src/server.rs
+++ b/src/server.rs
@@ -145,11 +145,11 @@ impl Server {
     fn log_config(&self, config: &Arc<Config>) {
         info!(self.log, "Starting on port {}", config.local.port);
         match &config.connections {
-            ConnectionConfig::Sender { address, .. } => {
-                info!(self.log, "Sender configuration"; "address" => address)
+            ConnectionConfig::Client { address, .. } => {
+                info!(self.log, "Client proxy configuration"; "address" => address)
             }
-            ConnectionConfig::Receiver { endpoints } => {
-                info!(self.log, "Receiver configuration"; "endpoints" => endpoints.len())
+            ConnectionConfig::Server { endpoints } => {
+                info!(self.log, "Server proxy configuration"; "endpoints" => endpoints.len())
             }
         };
     }
@@ -288,7 +288,7 @@ mod tests {
     async fn server_bind() {
         let config = Config {
             local: Local { port: 12345 },
-            connections: ConnectionConfig::Receiver {
+            connections: ConnectionConfig::Server {
                 endpoints: Vec::new(),
             },
         };
@@ -306,7 +306,7 @@ mod tests {
 
         let config = Arc::new(Config {
             local: Local { port: 0 },
-            connections: ConnectionConfig::Sender {
+            connections: ConnectionConfig::Client {
                 address: local_addr,
                 connection_id: String::from(""),
             },


### PR DESCRIPTION
Changes the nomenclature to being "client proxy" and "server proxy", which is far easier to understand, both from a user perspective, and from a code perspective.

Closes #22