### PR TITLE
Implementation of the Filter data structure.

### DIFF
--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -284,6 +284,7 @@ mod tests {
             local: Local {
                 port: local_addr.port(),
             },
+            filters: vec![],
             connections: ConnectionConfig::Server {
                 endpoints: vec![
                     EndPoint {
@@ -324,6 +325,7 @@ mod tests {
             local: Local {
                 port: local_addr.port(),
             },
+            filters: vec![],
             connections: ConnectionConfig::Client {
                 address: endpoint_addr,
                 connection_id: String::from(""),
@@ -343,6 +345,7 @@ mod tests {
     async fn server_bind() {
         let config = Config {
             local: Local { port: 12345 },
+            filters: vec![],
             connections: ConnectionConfig::Server {
                 endpoints: Vec::new(),
             },
@@ -363,6 +366,7 @@ mod tests {
 
         let config = Arc::new(Config {
             local: Local { port: 0 },
+            filters: vec![],
             connections: ConnectionConfig::Client {
                 address: local_addr,
                 connection_id: String::from(""),


### PR DESCRIPTION
Using serde_yaml::Value for the arbitrary config value for now, may need to replace it later on, or it may be possible to use serde-transcode (https://serde.rs/transcode.html) when we need to support protobuf.