### PR TITLE
Use Plain Terminal Logging for test output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ slog = "2.5.2"
 slog-async = "2.4.0"
 slog-json = "2.3.0"
 tokio = { version = "0.2.11", features = ["full", "test-util"] }
+
+[dev-dependencies]
+slog-term = "2.5.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 
 mod config;
 mod server;
+mod test_utils;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -18,4 +18,3 @@ pub use server::Server;
 
 mod server;
 mod sessions;
-mod test_utils;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -247,7 +247,6 @@ impl Server {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::collections::HashMap;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::sync::Arc;
@@ -260,9 +259,10 @@ mod tests {
     use tokio::time::{Duration, Instant};
 
     use crate::config::{Config, ConnectionConfig, EndPoint, Local};
-    use crate::logger;
     use crate::server::sessions::{Packet, SESSION_TIMEOUT_SECONDS};
-    use crate::server::test_utils::test::{assert_recv_udp, ephemeral_socket, recv_socket_done};
+    use crate::test_utils::test::{assert_recv_udp, ephemeral_socket, logger, recv_socket_done};
+
+    use super::*;
 
     #[tokio::test]
     async fn server_run_server() {

--- a/src/server/sessions.rs
+++ b/src/server/sessions.rs
@@ -202,8 +202,7 @@ mod tests {
     use tokio::time;
     use tokio::time::delay_for;
 
-    use crate::logger;
-    use crate::server::test_utils::test::{assert_recv_udp, ephemeral_socket};
+    use crate::test_utils::test::{assert_recv_udp, ephemeral_socket, logger};
 
     use super::*;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -21,9 +21,19 @@ pub mod test {
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     use std::str::from_utf8;
 
+    use slog::{o, Drain, Logger};
+    use slog_term::{FullFormat, PlainSyncDecorator};
     use tokio::net::udp::RecvHalf;
     use tokio::net::UdpSocket;
     use tokio::sync::oneshot;
+
+    // logger returns a standard out, non structured terminal logger, suitable for using in tests,
+    // since it's more human readable.
+    pub fn logger() -> Logger {
+        let plain = PlainSyncDecorator::new(std::io::stdout());
+        let drain = FullFormat::new(plain).build().fuse();
+        Logger::root(drain, o!())
+    }
 
     /// assert_recv_udp asserts that the returned SockerAddr received a UDP packet
     /// with the contents of "hello"


### PR DESCRIPTION
Implemented a sync, plain text logger for usage in tests, as it's easier to read by humans than JSON.

Pulled all the test_utils package into root when doing so. Down the line this might become a prelude package, but we'll see.