### PR TITLE
Ability to be a library and binary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod config;
+pub mod extensions;
+pub mod server;
+pub mod test_utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,14 +20,9 @@ use std::sync::Arc;
 use clap::App;
 use slog::{info, o, Drain, Logger};
 
-use crate::config::from_reader;
-use crate::extensions::default_filters;
-use crate::server::Server;
-
-mod config;
-mod extensions;
-mod server;
-mod test_utils;
+use quilkin::config::from_reader;
+use quilkin::extensions::default_filters;
+use quilkin::server::Server;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 


### PR DESCRIPTION
Include a lib.rs such that Quilkin can be used as a library and as a standalone binary.

This is also a precursor to being able to do integration tests.