### PR TITLE
Integration Test for client->server and back

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ slog = "2.5.2"
 slog-async = "2.4.0"
 slog-json = "2.3.0"
 tokio = { version = "0.2.11", features = ["full", "test-util"] }
+slog-term = "2.5.0"
 
 [dev-dependencies]
-slog-term = "2.5.0"

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -269,7 +269,7 @@ mod tests {
 
     use crate::config::{Config, ConnectionConfig, EndPoint, Local};
     use crate::server::sessions::{Packet, SESSION_TIMEOUT_SECONDS};
-    use crate::test_utils::test::{assert_recv_udp, ephemeral_socket, logger, recv_socket_done};
+    use crate::test_utils::{assert_recv_udp, ephemeral_socket, logger, recv_socket_done};
 
     use super::*;
 

--- a/src/server/sessions.rs
+++ b/src/server/sessions.rs
@@ -202,7 +202,7 @@ mod tests {
     use tokio::time;
     use tokio::time::delay_for;
 
-    use crate::test_utils::test::{assert_recv_udp, ephemeral_socket, logger};
+    use crate::test_utils::{assert_recv_udp, ephemeral_socket, logger};
 
     use super::*;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,51 +15,47 @@
  */
 
 /// Common utilities for testing
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::str::from_utf8;
 
-#[cfg(test)]
-pub mod test {
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-    use std::str::from_utf8;
+use slog::{o, Drain, Logger};
+use slog_term::{FullFormat, PlainSyncDecorator};
+use tokio::net::udp::RecvHalf;
+use tokio::net::UdpSocket;
+use tokio::sync::oneshot;
 
-    use slog::{o, Drain, Logger};
-    use slog_term::{FullFormat, PlainSyncDecorator};
-    use tokio::net::udp::RecvHalf;
-    use tokio::net::UdpSocket;
-    use tokio::sync::oneshot;
+// logger returns a standard out, non structured terminal logger, suitable for using in tests,
+// since it's more human readable.
+pub fn logger() -> Logger {
+    let plain = PlainSyncDecorator::new(std::io::stdout());
+    let drain = FullFormat::new(plain).build().fuse();
+    Logger::root(drain, o!())
+}
 
-    // logger returns a standard out, non structured terminal logger, suitable for using in tests,
-    // since it's more human readable.
-    pub fn logger() -> Logger {
-        let plain = PlainSyncDecorator::new(std::io::stdout());
-        let drain = FullFormat::new(plain).build().fuse();
-        Logger::root(drain, o!())
-    }
+/// assert_recv_udp asserts that the returned SockerAddr received a UDP packet
+/// with the contents of "hello"
+/// call wait.await.unwrap() to see if the message was received
+pub async fn assert_recv_udp() -> (SocketAddr, oneshot::Receiver<()>) {
+    let socket = ephemeral_socket().await;
+    let local_addr = socket.local_addr().unwrap();
+    let (recv, _) = socket.split();
+    let (done, wait) = oneshot::channel::<()>();
+    recv_socket_done(recv, done);
+    (local_addr, wait)
+}
 
-    /// assert_recv_udp asserts that the returned SockerAddr received a UDP packet
-    /// with the contents of "hello"
-    /// call wait.await.unwrap() to see if the message was received
-    pub async fn assert_recv_udp() -> (SocketAddr, oneshot::Receiver<()>) {
-        let socket = ephemeral_socket().await;
-        let local_addr = socket.local_addr().unwrap();
-        let (recv, _) = socket.split();
-        let (done, wait) = oneshot::channel::<()>();
-        recv_socket_done(recv, done);
-        (local_addr, wait)
-    }
+/// ephemeral_socket provides a socket bound to an ephemeral port
+pub async fn ephemeral_socket() -> UdpSocket {
+    let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0);
+    UdpSocket::bind(addr).await.unwrap()
+}
 
-    /// ephemeral_socket provides a socket bound to an ephemeral port
-    pub async fn ephemeral_socket() -> UdpSocket {
-        let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0);
-        UdpSocket::bind(addr).await.unwrap()
-    }
-
-    /// recv_socket_done will send a value to done when receiving the "hello" UDP packet.
-    pub fn recv_socket_done(mut recv: RecvHalf, done: oneshot::Sender<()>) {
-        tokio::spawn(async move {
-            let mut buf = vec![0; 1024];
-            let size = recv.recv(&mut buf).await.unwrap();
-            assert_eq!("hello", from_utf8(&buf[..size]).unwrap());
-            done.send(()).unwrap();
-        });
-    }
+/// recv_socket_done will send a value to done when receiving the "hello" UDP packet.
+pub fn recv_socket_done(mut recv: RecvHalf, done: oneshot::Sender<()>) {
+    tokio::spawn(async move {
+        let mut buf = vec![0; 1024];
+        let size = recv.recv(&mut buf).await.unwrap();
+        assert_eq!("hello", from_utf8(&buf[..size]).unwrap());
+        done.send(()).unwrap();
+    });
 }

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+extern crate quilkin;
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::str::from_utf8;
+    use std::sync::Arc;
+
+    use tokio::select;
+    use tokio::sync::{mpsc, oneshot};
+
+    use quilkin::config::{Config, ConnectionConfig, EndPoint, Local};
+    use quilkin::extensions::default_filters;
+    use quilkin::server::Server;
+    use quilkin::test_utils::{ephemeral_socket, logger, recv_socket_done};
+    use tokio::time::{delay_for, Duration};
+
+    #[tokio::test]
+    async fn echo() {
+        let base_logger = logger();
+
+        // create two echo servers as endpoints
+        let server1 = echo_server().await;
+        let server2 = echo_server().await;
+
+        // create server configuration
+        let server_port = 12345;
+        let server_config = Config {
+            local: Local { port: server_port },
+            filters: vec![],
+            connections: ConnectionConfig::Server {
+                endpoints: vec![
+                    EndPoint {
+                        name: "server1".to_string(),
+                        address: server1,
+                        connection_ids: vec![],
+                    },
+                    EndPoint {
+                        name: "server2".to_string(),
+                        address: server2,
+                        connection_ids: vec![],
+                    },
+                ],
+            },
+        };
+
+        let server = Server::new(base_logger.clone(), default_filters(&base_logger));
+        // run the server
+        tokio::spawn(async move {
+            server.run(Arc::new(server_config)).await.unwrap();
+        });
+
+        // create a local client
+        let client_port = 12344;
+        let client_config = Config {
+            local: Local { port: client_port },
+            filters: vec![],
+            connections: ConnectionConfig::Client {
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port),
+                connection_id: String::from(""),
+            },
+        };
+        let client = Server::new(base_logger.clone(), default_filters(&base_logger));
+        // run the client
+        tokio::spawn(async move {
+            client.run(Arc::new(client_config)).await.unwrap();
+        });
+
+        // let's send the packet
+        let (mut send_chan, mut recv_chan) = mpsc::channel::<String>(10);
+        let (mut recv, mut send) = ephemeral_socket().await.split();
+        // a channel, so we can wait for packets coming back.
+        tokio::spawn(async move {
+            let mut buf = vec![0; 1024];
+            loop {
+                let (size, _) = recv.recv_from(&mut buf).await.unwrap();
+                let str = from_utf8(&buf[..size]).unwrap().to_string();
+                send_chan.send(str).await.unwrap();
+            }
+        });
+
+        // game_client
+        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
+        send.send_to("hello".as_bytes(), &local_addr).await.unwrap();
+
+        assert_eq!("hello", recv_chan.recv().await.unwrap());
+        assert_eq!("hello", recv_chan.recv().await.unwrap());
+
+        // should only be two returned items
+        select! {
+            res = recv_chan.recv() => {
+                assert!(false, format!("Should not receive a third packet: {}", res.unwrap()));
+            }
+            _ = delay_for(Duration::from_secs(2)) => {}
+        };
+    }
+
+    #[tokio::test]
+    // gate to make sure our test functions do what we expect.
+    async fn test_echo_server() {
+        let echo_addr = echo_server().await;
+        let (recv, mut send) = ephemeral_socket().await.split();
+        let (done, wait) = oneshot::channel::<()>();
+        recv_socket_done(recv, done);
+        send.send_to("hello".as_bytes(), &echo_addr).await.unwrap();
+        wait.await.unwrap();
+    }
+
+    async fn echo_server() -> SocketAddr {
+        let mut socket = ephemeral_socket().await;
+        let addr = socket.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut buf = vec![0; 1024];
+            let (size, sender) = socket.recv_from(&mut buf).await.unwrap();
+            socket.send_to(&buf[..size], sender).await.unwrap();
+        });
+        addr
+    }
+}


### PR DESCRIPTION
Integration test that sends data from a udp client->client proxy->server proxy->2 echo endpoints and back again.

Long term we'll want to take parts of the integration tests and make a small framework for running more complicated scenarios.