### PR TITLE
Refactor UDP Test Utils to be more flexible

### DIFF
--- a/src/server/sessions.rs
+++ b/src/server/sessions.rs
@@ -202,7 +202,7 @@ mod tests {
     use tokio::time;
     use tokio::time::delay_for;
 
-    use crate::test_utils::{assert_recv_udp, ephemeral_socket, logger};
+    use crate::test_utils::{ephemeral_socket, logger, recv_udp};
 
     use super::*;
 
@@ -260,14 +260,15 @@ mod tests {
     #[tokio::test]
     async fn session_send_to() {
         let log = logger();
+        let msg = "hello";
         let (sender, _) = mpsc::channel::<Packet>(1);
-        let (local_addr, wait) = assert_recv_udp().await;
+        let (local_addr, wait) = recv_udp().await;
 
         let mut session = Session::new(&log, local_addr, local_addr, sender)
             .await
             .unwrap();
-        session.send_to("hello".as_bytes()).await.unwrap();
-        wait.await.unwrap();
+        session.send_to(msg.as_bytes()).await.unwrap();
+        assert_eq!(msg, wait.await.unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Refactored the UDP test utilities, such that they return the message that is received, rather than expecting a standard "hello" message.

Since Filters will manipulate strings, we can't expect there to only be one string value that gets passed through when testing. So let's return it so we can test for values that are expected in the test.