### PR TITLE
Cloud Build timeout to 30m

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,9 +14,6 @@
 
 steps:
   - name: gcr.io/$PROJECT_ID/ci
-    args: ["check"]
-    id: check
-  - name: gcr.io/$PROJECT_ID/ci
     args: ["check", "--tests"]
     id: check-tests
   - name: gcr.io/$PROJECT_ID/ci
@@ -25,3 +22,4 @@ steps:
   - name: gcr.io/$PROJECT_ID/ci
     args: ["test"]
     id: test
+timeout: 30m


### PR DESCRIPTION
10m is a bit short. Also removed the extraneous `cargo check`, when we're already doing a `cargo check --tests`, so there is no point in doing both.