### PR TITLE
Add Validation to Config

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ async fn main() {
     info!(log, "Starting Quilkin"; "version" => VERSION);
 
     let config = Arc::new(Config::from_reader(File::open(filename).unwrap()).unwrap());
+    config.validate().unwrap();
     let server = Server::new(base_logger, filter_registry);
 
     let (close, stop) = oneshot::channel::<()>();

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -49,6 +49,7 @@ mod tests {
                 }],
             },
         };
+        assert_eq!(Ok(()), server_config.validate());
 
         let mut registry = default_filters(&base_logger);
         registry.insert("TestFilter".to_string(), TestFilter {});
@@ -71,6 +72,8 @@ mod tests {
                 lb_policy: None,
             },
         };
+        assert_eq!(Ok(()), client_config.validate());
+
         let mut registry = default_filters(&base_logger);
         registry.insert("TestFilter".to_string(), TestFilter {});
         let close_client = run_proxy(&base_logger, registry, client_config);

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -55,6 +55,7 @@ mod tests {
                 ],
             },
         };
+        assert_eq!(Ok(()), server_config.validate());
 
         let close_server = run_proxy(&base_logger, default_filters(&base_logger), server_config);
 
@@ -72,6 +73,7 @@ mod tests {
                 lb_policy: None,
             },
         };
+        assert_eq!(Ok(()), client_config.validate());
 
         let close_client = run_proxy(&base_logger, default_filters(&base_logger), client_config);
 


### PR DESCRIPTION
We needed validation that endpoint names are unique, so implemented a validation function for config. This had a few ripple on effects:

- impl block for Config, so made sense to pull `from_reader` into that as a static method.
- Needed concrete Error types (impacts #67) for validation and other potential error conditions.

`from_reader` will now call validate() to ensure that the struct is valid before completing.

`validate` was also left as public, since Config's can be manually created before passing them into `Server.run()`