### PR TITLE
Refactor Filter to two functions

### DIFF
--- a/src/extensions/filter_registry.rs
+++ b/src/extensions/filter_registry.rs
@@ -24,42 +24,27 @@ use crate::config::EndPoint;
 
 /// Filter is a trait for routing and manipulating packets.
 pub trait Filter: Send + Sync {
-    /// local_receive_filter filters packets received from the local port, and potentially sends them
+    /// on_downstream_receive filters packets received from the local port, and potentially sends them
     /// to configured endpoints.
     /// This function should return the array of endpoints that the packet should be sent to,
     /// and the packet that should be sent (which may be manipulated) as well.
     /// If the packet should be rejected, return None.
-    fn local_receive_filter(
+    fn on_downstream_receive(
         &self,
         endpoints: &Vec<EndPoint>,
         from: SocketAddr,
         contents: Vec<u8>,
     ) -> Option<(Vec<EndPoint>, Vec<u8>)>;
 
-    /// local_send_filter intercepts packets that are being sent back to the original local port sender
-    /// This function should return the packet to be sent (which may be manipulated).
-    /// If the packet should be rejected, return None.
-    fn local_send_filter(&self, to: SocketAddr, contents: Vec<u8>) -> Option<Vec<u8>>;
-
-    /// endpoint_receive_filter filters packets received from recv_addr, but expected from the given endpoint,
+    /// on_upstream_receive filters packets received from `from`, to a given endpoint,
     /// that are going back to the original sender.
     /// This function should return the packet to be sent (which may be manipulated).
     /// If the packet should be rejected, return None.
-    fn endpoint_receive_filter(
-        &self,
-        endpoint: &EndPoint,
-        recv_addr: SocketAddr,
-        contents: Vec<u8>,
-    ) -> Option<Vec<u8>>;
-
-    /// endpoint_send_filter intercepts packets that are being sent back to the original
-    /// endpoint sender address
-    /// This function should return the packet to be sent (which may be manipulated).
-    /// If the packet should be rejected, return None.
-    fn endpoint_send_filter(
+    fn on_upstream_receive(
         &self,
         endpoint: &EndPoint,
         from: SocketAddr,
+        to: SocketAddr,
         contents: Vec<u8>,
     ) -> Option<Vec<u8>>;
 }
@@ -134,7 +119,7 @@ mod tests {
     struct TestFilter {}
 
     impl Filter for TestFilter {
-        fn local_receive_filter(
+        fn on_downstream_receive(
             &self,
             _: &Vec<EndPoint>,
             _: SocketAddr,
@@ -143,20 +128,13 @@ mod tests {
             None
         }
 
-        fn local_send_filter(&self, _: SocketAddr, _: Vec<u8>) -> Option<Vec<u8>> {
-            None
-        }
-
-        fn endpoint_receive_filter(
+        fn on_upstream_receive(
             &self,
             _: &EndPoint,
             _: SocketAddr,
+            _: SocketAddr,
             _: Vec<u8>,
         ) -> Option<Vec<u8>> {
-            None
-        }
-
-        fn endpoint_send_filter(&self, _: &EndPoint, _: SocketAddr, _: Vec<u8>) -> Option<Vec<u8>> {
             None
         }
     }
@@ -183,9 +161,11 @@ mod tests {
             connection_ids: vec![],
         };
 
-        assert!(filter.local_receive_filter(&vec![], addr, vec![]).is_some());
         assert!(filter
-            .endpoint_receive_filter(&endpoint, addr, vec![])
+            .on_downstream_receive(&vec![], addr, vec![])
+            .is_some());
+        assert!(filter
+            .on_upstream_receive(&endpoint, addr, addr, vec![])
             .is_some());
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -54,7 +54,7 @@ impl FilterFactory for TestFilterFactory {
 pub struct TestFilter {}
 
 impl Filter for TestFilter {
-    fn local_receive_filter(
+    fn on_downstream_receive(
         &self,
         endpoints: &Vec<EndPoint>,
         from: SocketAddr,
@@ -67,35 +67,19 @@ impl Filter for TestFilter {
         e.push(noop_endpoint());
 
         let mut c = contents;
-        c.append(&mut format!(":lrf:{}", from).into_bytes());
+        c.append(&mut format!(":odr:{}", from).into_bytes());
         Some((e, c))
     }
 
-    fn local_send_filter(&self, to: SocketAddr, contents: Vec<u8>) -> Option<Vec<u8>> {
-        let mut c = contents;
-        c.append(&mut format!(":lsf:{}", to).into_bytes());
-        Some(c)
-    }
-
-    fn endpoint_receive_filter(
-        &self,
-        endpoint: &EndPoint,
-        recv_addr: SocketAddr,
-        contents: Vec<u8>,
-    ) -> Option<Vec<u8>> {
-        let mut c = contents;
-        c.append(&mut format!(":erf:{}:{}", endpoint.name, recv_addr).into_bytes());
-        Some(c)
-    }
-
-    fn endpoint_send_filter(
+    fn on_upstream_receive(
         &self,
         endpoint: &EndPoint,
         from: SocketAddr,
+        to: SocketAddr,
         contents: Vec<u8>,
     ) -> Option<Vec<u8>> {
         let mut c = contents;
-        c.append(&mut format!(":esf:{}:{}", endpoint.name, from).into_bytes());
+        c.append(&mut format!(":our:{}:{}:{}", endpoint.name, from, to).into_bytes());
         Some(c)
     }
 }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -96,26 +96,14 @@ mod tests {
         // the round-tripped packets.
         assert_eq!(
             2,
-            result.matches("lrf").count(),
-            "Should be 2 local_receive_filter calls in {}",
+            result.matches("odr").count(),
+            "Should be 2 on_downstream_receive calls in {}",
             result
         );
         assert_eq!(
             2,
-            result.matches("lsf").count(),
-            "Should be 2 local_send_filter calls in {}",
-            result
-        );
-        assert_eq!(
-            2,
-            result.matches("esf").count(),
-            "Should be 2 endpoint_send_filter calls in {}",
-            result
-        );
-        assert_eq!(
-            2,
-            result.matches("erf").count(),
-            "Should be 2 endpoint_receive_filter calls in {}",
+            result.matches("our").count(),
+            "Should be 2 on_upstream_receive calls in {}",
             result
         );
 


### PR DESCRIPTION
This refactors the Filter trait to simplify its implementation down to two functions, rather than the previous four.

In doing so, we see a simplification of the API and the required understanding, while having no drop in functionality.

Closes #80