### PR TITLE
Add per-session filter chain

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ use std::net::SocketAddr;
 use base64_serde::base64_serde_type;
 use serde::export::Formatter;
 use serde::{Deserialize, Serialize};
+use std::error::Error;
 
 base64_serde_type!(Base64Standard, base64::STANDARD);
 
@@ -29,12 +30,18 @@ base64_serde_type!(Base64Standard, base64::STANDARD);
 #[derive(Debug, PartialEq)]
 pub enum ValidationError {
     NotUnique(String),
+    FieldInvalid { field: String, reason: String },
 }
+
+impl Error for ValidationError {}
 
 impl fmt::Display for ValidationError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ValidationError::NotUnique(field) => write!(f, "field {} is not unique", field),
+            ValidationError::FieldInvalid { field, reason } => {
+                write!(f, "field {} is invalid: {}", field, reason)
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,10 @@ async fn main() {
 
     let config = Arc::new(Config::from_reader(File::open(filename).unwrap()).unwrap());
     config.validate().unwrap();
+    filter_registry
+        .validate_filter_configs(&config.filters)
+        .unwrap();
+
     let server = Server::new(
         base_logger,
         filter_registry,


### PR DESCRIPTION
* Add a filter chain to each session instance
* Add FilterFactory method to validate a filter's config so
  that we can validate config on startup rather than when
  later at runtime when the first session is created.
* Use Vec::truncate instead of slice::to_vec to avoid unneeded
  packet cloning.

Fixes #75