### PR TITLE
Added ConnectionConfig to CreateFilterArgs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,7 +57,7 @@ pub struct Local {
 
 /// LoadBalancerPolicy represents how a proxy load-balances
 /// traffic between endpoints.
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub enum LoadBalancerPolicy {
     /// Send all traffic to all endpoints.
     #[serde(rename = "BROADCAST")]
@@ -88,7 +88,7 @@ impl From<&str> for ConnectionId {
 }
 
 /// ConnectionConfig is the configuration for either a Client or Server proxy
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum ConnectionConfig {
     /// Client is the configuration for a client proxy, for sitting behind a game client.
     #[serde(rename = "client")]

--- a/src/extensions/filter_registry.rs
+++ b/src/extensions/filter_registry.rs
@@ -81,21 +81,24 @@ impl From<MetricsError> for Error {
 }
 
 /// Arguments needed to create a new filter.
-pub struct CreateFilterArgs {
+pub struct CreateFilterArgs<'a> {
     /// Configuration for the filter.
-    pub config: serde_yaml::Value,
+    pub config: &'a serde_yaml::Value,
     /// metrics_registry is used to register filter metrics collectors.
     pub metrics_registry: Registry,
     /// connection is used to pass the connection configuration
-    pub connection: ConnectionConfig,
+    pub connection: &'a ConnectionConfig,
 }
 
-impl CreateFilterArgs {
-    pub fn new(connection: &ConnectionConfig, config: &serde_yaml::Value) -> CreateFilterArgs {
+impl CreateFilterArgs<'_> {
+    pub fn new<'a>(
+        connection: &'a ConnectionConfig,
+        config: &'a serde_yaml::Value,
+    ) -> CreateFilterArgs<'a> {
         CreateFilterArgs {
-            config: config.clone(),
+            config,
             metrics_registry: Registry::default(),
-            connection: connection.clone(),
+            connection,
         }
     }
 

--- a/src/extensions/filters/debug_filter.rs
+++ b/src/extensions/filters/debug_filter.rs
@@ -77,7 +77,7 @@ impl FilterFactory for DebugFilterFactory {
 
     fn create_filter(&self, args: CreateFilterArgs) -> Result<Box<dyn Filter>, Error> {
         // pull out the Option<&Value>
-        let prefix = match &args.config {
+        let prefix = match args.config {
             serde_yaml::Value::Mapping(map) => map.get(&serde_yaml::Value::from("id")),
             _ => None,
         };

--- a/src/extensions/filters/local_rate_limit/mod.rs
+++ b/src/extensions/filters/local_rate_limit/mod.rs
@@ -92,7 +92,7 @@ impl FilterFactory for RateLimitFilterFactory {
     }
 
     fn create_filter(&self, args: CreateFilterArgs) -> Result<Box<dyn Filter>, Error> {
-        let config: Config = serde_yaml::to_string(&args.config)
+        let config: Config = serde_yaml::to_string(args.config)
             .and_then(|raw_config| serde_yaml::from_str(raw_config.as_str()))
             .map_err(|err| Error::DeserializeFailed(err.to_string()))?;
 


### PR DESCRIPTION
Some filters will need to be aware of whether they are client/server, and also authentication connection details.

To provide this functionality, this PR added ConnectionConfig to the CreateFilterArgs, so it can be passed into FilterFactory's when needed.

Work on #1