### PR TITLE
Refactor: debug_filter -> debug

### DIFF
--- a/docs/extensions/filters/debug.md
+++ b/docs/extensions/filters/debug.md
@@ -15,7 +15,7 @@ quilkin.extensions.filters.debug_filter.v1alpha1.DebugFilter
 local:
   port: 7000
 filters:
-  - name: quilkin.extensions.filters.debug_filter.v1alpha1.DebugFilter
+  - name: quilkin.extensions.filters.debug.v1alpha1.DebugFilter
     config:
       id: debug-1
 client:

--- a/docs/extensions/filters/filters.md
+++ b/docs/extensions/filters/filters.md
@@ -55,7 +55,7 @@ client:
 
 We specify our filter chain in the `.filters` section of the proxy's configuration which has takes a sequence of [FilterConfig](#filter-config) objects. Each object describes all information necessary to create a single filter.
 
-The above example creates a filter chain comprising a [Debug](./debug_filter.md) filter followed by a [Rate limiter](./local_rate_limit.md) filter - the effect is that every packet will be logged and the proxy will not forward more than 20 packets per second.
+The above example creates a filter chain comprising a [Debug](debug.md) filter followed by a [Rate limiter](./local_rate_limit.md) filter - the effect is that every packet will be logged and the proxy will not forward more than 20 packets per second.
 
 > The sequence determines the filter chain order so its ordering matters - the chain starts with the filter corresponding the first filter config and ends with the filter conrresponding the last filter config in the sequence.
 
@@ -64,7 +64,7 @@ Quilkin includes several filters out of the box.
 
 | Filter                                    | Description                    |
 | ----------------------------------------- | ------------------------------ |
-| [Debug](./debug_filter.md)                | Logs every packet              |
+| [Debug](debug.md)                | Logs every packet              |
 | [LocalRateLimiter](./local_rate_limit.md) | Limit the frequency of packets |
 
 ### FilterConfig <a name="filter-config"></a>

--- a/src/extensions/filters/debug.rs
+++ b/src/extensions/filters/debug.rs
@@ -30,7 +30,7 @@ use crate::extensions::Filter;
 /// local:
 ///   port: 7000 # the port to receive traffic to locally
 /// filters:
-///   - name: quilkin.extensions.filters.debug_filter.v1alpha1.DebugFilter
+///   - name: quilkin.extensions.filters.debug.v1alpha1.DebugFilter
 ///     config:
 ///       id: "debug-1"
 /// client:
@@ -72,7 +72,7 @@ impl DebugFilterFactory {
 
 impl FilterFactory for DebugFilterFactory {
     fn name(&self) -> String {
-        "quilkin.extensions.filters.debug_filter.v1alpha1.DebugFilter".into()
+        "quilkin.extensions.filters.debug.v1alpha1.DebugFilter".into()
     }
 
     fn create_filter(&self, args: CreateFilterArgs) -> Result<Box<dyn Filter>, Error> {

--- a/src/extensions/filters/mod.rs
+++ b/src/extensions/filters/mod.rs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-pub use debug_filter::DebugFilterFactory;
+pub use debug::DebugFilterFactory;
 pub use local_rate_limit::RateLimitFilterFactory;
 
-mod debug_filter;
+mod debug;
 mod local_rate_limit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,5 +36,5 @@ pub mod external_doc_tests {
     // To run them locally run e.g `cargo +nightly test --doc`
     #![doc(include = "../docs/extensions/filters/filters.md")]
     #![doc(include = "../docs/extensions/filters/local_rate_limit.md")]
-    #![doc(include = "../docs/extensions/filters/debug_filter.md")]
+    #![doc(include = "../docs/extensions/filters/debug.md")]
 }


### PR DESCRIPTION
Felt like it was redundant to have "filter" in the module name, since it is already in the parent module name, so took it out.