### PR TITLE
Be able to pass data between Filters

### DIFF
--- a/src/extensions/filter_registry.rs
+++ b/src/extensions/filter_registry.rs
@@ -96,17 +96,23 @@ pub struct UpstreamResponse {
 
 impl DownstreamContext {
     /// Creates a new [`DownstreamContext`]
-    pub fn new(
-        endpoints: Vec<EndPoint>,
-        from: SocketAddr,
-        contents: Vec<u8>,
-        values: HashMap<String, Box<dyn Any + Send>>,
-    ) -> Self {
+    pub fn new(endpoints: Vec<EndPoint>, from: SocketAddr, contents: Vec<u8>) -> Self {
         Self {
             endpoints,
             from,
             contents,
-            values,
+            values: HashMap::new(),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Creates a new [`DownstreamContext`] from a [`DownstreamResponse`]
+    pub fn with_response(from: SocketAddr, response: DownstreamResponse) -> Self {
+        Self {
+            endpoints: response.endpoints,
+            from,
+            contents: response.contents,
+            values: response.values,
             phantom: PhantomData,
         }
     }
@@ -130,14 +136,30 @@ impl UpstreamContext<'_> {
         from: SocketAddr,
         to: SocketAddr,
         contents: Vec<u8>,
-        values: HashMap<String, Box<dyn Any + Send>>,
     ) -> UpstreamContext {
         UpstreamContext {
             endpoint,
             from,
             to,
             contents,
-            values,
+            values: HashMap::new(),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Creates a new [`UpstreamContext`] from a [`UpstreamResponse`]
+    pub fn with_response(
+        endpoint: &EndPoint,
+        from: SocketAddr,
+        to: SocketAddr,
+        response: UpstreamResponse,
+    ) -> UpstreamContext {
+        UpstreamContext {
+            endpoint,
+            from,
+            to,
+            contents: response.contents,
+            values: response.values,
             phantom: PhantomData,
         }
     }
@@ -335,16 +357,10 @@ mod tests {
         };
 
         assert!(filter
-            .on_downstream_receive(DownstreamContext::new(vec![], addr, vec![], HashMap::new()))
+            .on_downstream_receive(DownstreamContext::new(vec![], addr, vec![]))
             .is_some());
         assert!(filter
-            .on_upstream_receive(UpstreamContext::new(
-                &endpoint,
-                addr,
-                addr,
-                vec![],
-                HashMap::new()
-            ))
+            .on_upstream_receive(UpstreamContext::new(&endpoint, addr, addr, vec![],))
             .is_some());
     }
 }

--- a/src/extensions/filters/local_rate_limit/mod.rs
+++ b/src/extensions/filters/local_rate_limit/mod.rs
@@ -199,7 +199,6 @@ impl Filter for RateLimitFilter {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use std::time::Duration;
 
     use prometheus::Registry;
@@ -288,7 +287,6 @@ mod tests {
                 vec![],
                 "127.0.0.1:8080".parse().unwrap(),
                 vec![9],
-                HashMap::new(),
             ))
             .is_none(),);
     }
@@ -305,7 +303,6 @@ mod tests {
                 vec![],
                 "127.0.0.1:8080".parse().unwrap(),
                 vec![9],
-                HashMap::new(),
             ))
             .unwrap();
         assert_eq!((result.endpoints, result.contents), (vec![], vec![9]));

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -165,7 +165,6 @@ impl Server {
                 lb_policy.choose_endpoints(),
                 recv_addr,
                 packet.to_vec(),
-                HashMap::new(),
             ));
 
             if let Some(response) = result {

--- a/src/proxy/sessions/session.rs
+++ b/src/proxy/sessions/session.rs
@@ -29,10 +29,10 @@ use tokio::select;
 use tokio::sync::{mpsc, watch, RwLock};
 use tokio::time::{Duration, Instant};
 
-use super::metrics::Metrics;
 use crate::config::EndPoint;
 use crate::extensions::{Filter, FilterChain, UpstreamContext};
-use std::collections::HashMap;
+
+use super::metrics::Metrics;
 
 /// SESSION_TIMEOUT_SECONDS is the default session timeout - which is one minute.
 pub const SESSION_TIMEOUT_SECONDS: u64 = 60;
@@ -211,13 +211,9 @@ impl Session {
         debug!(log, "Received packet"; "from" => from, "endpoint_name" => &endpoint.name, "endpoint_addr" => &endpoint.address, "contents" => from_utf8(packet).unwrap());
         Session::inc_expiration(expiration).await;
 
-        if let Some(response) = chain.on_upstream_receive(UpstreamContext::new(
-            endpoint,
-            from,
-            to,
-            packet.to_vec(),
-            HashMap::new(),
-        )) {
+        if let Some(response) =
+            chain.on_upstream_receive(UpstreamContext::new(endpoint, from, to, packet.to_vec()))
+        {
             if let Err(err) = sender.send(Packet::new(to, response.contents)).await {
                 metrics.errors_total.inc();
                 error!(log, "Error sending packet to channel"; "error" => %err);


### PR DESCRIPTION
Add a `values` of with a `HashMap` of `Any` to the filter context objects and results, and update the FilterChain to pass that Map between each invocation of a Filter in the chain.

Work on #8