### PR TITLE
Removal of client->connection_id

### DIFF
--- a/docs/extensions/filters/concatenate_bytes.md
+++ b/docs/extensions/filters/concatenate_bytes.md
@@ -21,7 +21,6 @@ filters:
 client:
   addresses:
     - 127.0.0.1:7001
-  connection_id: MXg3aWp5Ng==
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.len(), 1);

--- a/docs/extensions/filters/debug.md
+++ b/docs/extensions/filters/debug.md
@@ -21,7 +21,6 @@ filters:
 client:
   addresses:
     - 127.0.0.1:7001
-  connection_id: MXg3aWp5Ng==
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.len(), 1);

--- a/docs/extensions/filters/filters.md
+++ b/docs/extensions/filters/filters.md
@@ -46,7 +46,6 @@ filters:
 client:
   addresses:
     - 127.0.0.1:7001
-  connection_id: MXg3aWp5Ng==
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.validate().unwrap(), ());

--- a/docs/extensions/filters/local_rate_limit.md
+++ b/docs/extensions/filters/local_rate_limit.md
@@ -22,7 +22,6 @@ filters:
 client:
   addresses:
     - 127.0.0.1:7001
-  connection_id: MXg3aWp5Ng==
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 #   assert_eq!(config.filters.len(), 1);

--- a/examples/client-proxy.yaml
+++ b/examples/client-proxy.yaml
@@ -24,7 +24,6 @@ client:
   addresses: # array of potential endpoints to send traffic to
     - 127.0.0.1:7000
     - 127.0.0.1:7001
-  connection_id: MXg3aWp5Ng== # the connection byte array to attach to the traffic, encoded as base64 (string value: 1x7ijy6)
   lb_policy: ROUND_ROBIN # (Optional) load balancing policy for selecting endpoints.
                          # Possible values are: `ROUND_ROBIN` `RANDOM` `BROADCAST`
                          # Defaults to `BROADCAST` if not set.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -89,7 +89,6 @@ pub enum ConnectionConfig {
     #[serde(rename = "client")]
     Client {
         addresses: Vec<SocketAddr>,
-        connection_id: ConnectionId,
         lb_policy: Option<LoadBalancerPolicy>,
     },
 
@@ -148,7 +147,6 @@ impl Config {
             }
             ConnectionConfig::Client {
                 addresses,
-                connection_id: _,
                 lb_policy: _,
             } => {
                 if addresses.iter().collect::<HashSet<_>>().len() != addresses.len() {
@@ -170,8 +168,7 @@ mod tests {
     use serde_yaml::Value;
 
     use crate::config::{
-        Builder, Config, ConnectionConfig, ConnectionId, EndPoint, LoadBalancerPolicy, Local,
-        ValidationError,
+        Builder, Config, ConnectionConfig, EndPoint, LoadBalancerPolicy, Local, ValidationError,
     };
 
     #[test]
@@ -180,7 +177,6 @@ mod tests {
             .with_local(Local { port: 7000 })
             .with_connections(ConnectionConfig::Client {
                 addresses: vec!["127.0.0.1:25999".parse().unwrap()],
-                connection_id: "1234".into(),
                 lb_policy: Some(LoadBalancerPolicy::RoundRobin),
             })
             .build();
@@ -228,7 +224,6 @@ filters: # new filters section
 client:
   addresses:
     - 127.0.0.1:7001
-  connection_id: MXg3aWp5Ng== # 1x7ijy6
         ";
         let config = Config::from_reader(yaml.as_bytes()).unwrap();
 
@@ -259,7 +254,6 @@ local:
 client:
   addresses:
     - 127.0.0.1:25999
-  connection_id: MXg3aWp5Ng== # 1x7ijy6
   lb_policy: ROUND_ROBIN
   ";
         let config = Config::from_reader(yaml.as_bytes()).unwrap();
@@ -267,10 +261,8 @@ client:
         match config.connections {
             ConnectionConfig::Client {
                 addresses,
-                connection_id,
                 lb_policy,
             } => {
-                assert_eq!(ConnectionId::from("1x7ijy6"), connection_id);
                 assert_eq!(
                     vec!["127.0.0.1:25999".parse::<SocketAddr>().unwrap()],
                     addresses
@@ -331,7 +323,6 @@ server:
                     "127.0.0.1:25999".parse().unwrap(),
                     "127.0.0.1:25998".parse().unwrap(),
                 ],
-                connection_id: "1234".into(),
                 lb_policy: Some(LoadBalancerPolicy::RoundRobin),
             })
             .build();
@@ -346,7 +337,6 @@ server:
                     "127.0.0.1:25999".parse().unwrap(),
                     "127.0.0.1:25999".parse().unwrap(),
                 ],
-                connection_id: "1234".into(),
                 lb_policy: Some(LoadBalancerPolicy::RoundRobin),
             })
             .build();

--- a/src/extensions/filter_chain.rs
+++ b/src/extensions/filter_chain.rs
@@ -138,7 +138,6 @@ mod tests {
             }])
             .with_connections(ConnectionConfig::Client {
                 addresses: vec!["127.0.0.1:2456".parse().unwrap()],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();
@@ -156,7 +155,6 @@ mod tests {
             }])
             .with_connections(ConnectionConfig::Client {
                 addresses: vec!["127.0.0.1:2456".parse().unwrap()],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();

--- a/src/extensions/filters/debug.rs
+++ b/src/extensions/filters/debug.rs
@@ -36,7 +36,6 @@ use crate::extensions::Filter;
 /// client:
 ///   addresses:
 ///     - 127.0.0.1:7001
-///   connection_id: 1x7ijy6
 /// ```
 ///  `config.id` (optional) adds a "id" field with a given value to each log line.
 ///     This can be useful to identify debug log positioning within a filter config if you have

--- a/src/extensions/filters/local_rate_limit/mod.rs
+++ b/src/extensions/filters/local_rate_limit/mod.rs
@@ -46,7 +46,6 @@ mod metrics;
 /// client:
 ///   addresses:
 ///     - 127.0.0.1:7001
-///   connection_id: 1x7ijy6
 /// ```
 ///  `config.max_packets` is the maximum number of packets allowed
 ///  to be forwarded by the rate limiter in a given duration.

--- a/src/load_balancer_policy.rs
+++ b/src/load_balancer_policy.rs
@@ -142,7 +142,6 @@ mod tests {
 
         let lb = LoadBalancerPolicy::new(&ConnectionConfig::Client {
             addresses: addresses.clone(),
-            connection_id: "".into(),
             lb_policy: Some(RoundRobin),
         });
 
@@ -172,7 +171,6 @@ mod tests {
 
         let lb = LoadBalancerPolicy::new(&ConnectionConfig::Client {
             addresses: addresses.clone(),
-            connection_id: "".into(),
             lb_policy: Some(Random),
         });
 
@@ -222,7 +220,6 @@ mod tests {
 
             let lb = LoadBalancerPolicy::new(&ConnectionConfig::Client {
                 addresses: addresses.clone(),
-                connection_id: "".into(),
                 lb_policy,
             });
 

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -394,7 +394,6 @@ mod tests {
             })
             .with_connections(ConnectionConfig::Client {
                 addresses: vec![endpoint.addr],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();
@@ -428,7 +427,6 @@ mod tests {
             }])
             .with_connections(ConnectionConfig::Client {
                 addresses: vec![endpoint.addr],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();
@@ -490,7 +488,6 @@ mod tests {
 
             let lb_policy = Arc::new(LoadBalancerPolicy::new(&ConnectionConfig::Client {
                 addresses: vec![endpoint.addr],
-                connection_id: "".into(),
                 lb_policy: None,
             }));
 
@@ -578,7 +575,6 @@ mod tests {
         let endpoint = t.open_socket_and_recv_single_packet().await;
         let lb_policy = Arc::new(LoadBalancerPolicy::new(&ConnectionConfig::Client {
             addresses: vec![endpoint.addr],
-            connection_id: "".into(),
             lb_policy: None,
         }));
         let SplitSocket {

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -71,7 +71,6 @@ mod tests {
                     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                     server_port,
                 )],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();
@@ -154,7 +153,6 @@ mod tests {
                     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                     server_port,
                 )],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -59,7 +59,6 @@ mod tests {
                     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                     server_port,
                 )],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -66,7 +66,6 @@ mod tests {
                     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                     server_port,
                 )],
-                connection_id: "".into(),
                 lb_policy: None,
             })
             .build();


### PR DESCRIPTION
Since the inclusion of the connection id token is being processed as a filter, we no longer have a need for connection_id in the client configuration.

Work on #8