### PR TITLE
Docs: Config is an object not an any

### DIFF
--- a/docs/extensions/filters/filters.md
+++ b/docs/extensions/filters/filters.md
@@ -79,11 +79,11 @@ properties:
       This value is unique for every filter type - please consult the documentation for the particular filter for this value.
 
   config:
-    type: any
+    type: object
     description: |
       The configuration value to be passed onto the created filter.
-      This can be any value since it is specific to the filter's type and is validated by the filter implementation.
-      please consult the documentation for the particular filter for its schema.
+      This is passed as an object value since it is specific to the filter's type and is validated by the filter
+      implementation. Please consult the documentation for the particular filter for its schema.
 
 required: [ 'name', 'config' ]
 ```


### PR DESCRIPTION
Small documentation fixup. Configs on a Filter are objects (essentially maps), they aren't an Any -- so just updating the docs to reflect this.