### PR TITLE
Upgrade Rust toolchain

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM rust:1.45.0
+FROM rust:1.47.0
 
 RUN rustup component add rustfmt clippy && rustup toolchain install nightly
 


### PR DESCRIPTION
Update rust to 1.47.0 and also update the linting tools alongside it.

Will update the build image once this PR is merged.