### PR TITLE
Refactor Filter Values to Dynamic Metadata

### DIFF
--- a/docs/extensions/filters/capture_bytes.md
+++ b/docs/extensions/filters/capture_bytes.md
@@ -1,7 +1,7 @@
 # CaptureBytes
 
 The `CaptureBytes` filter's job is to find a series of bytes within a packet, and capture it into
-[Filter invocation values]`(TODO: add link to filter invocation docs)`, so that it can be utilised by filters further
+[Filter dynamic metadata]`(TODO: add link to dynamic metadata docs)`, so that it can be utilised by filters further
 down the chain.
 
 This is often used as a way of retrieving authentication tokens from a packet, and used in combination with
@@ -22,7 +22,7 @@ filters:
   - name: quilkin.extensions.filters.capture_bytes.v1alpha1.CaptureBytes
     config:
         strategy: PREFIX
-        valuesKey: myapp.com/myownkey
+        metadataKey: myapp.com/myownkey
         size: 3
         remove: false
 client:
@@ -48,7 +48,7 @@ properties:
        - PREFIX: Retrieve bytes from the beginnning of the packet.
     default: "SUFFIX"
     enum: ['PREFIX', 'SUFFIX']
-  valuesKey:
+  metadataKey:
     type: string
     default: quilkin.dev/captured_bytes
     description: | 

--- a/src/extensions/filter_chain.rs
+++ b/src/extensions/filter_chain.rs
@@ -200,7 +200,7 @@ mod tests {
         );
         assert_eq!(
             "receive",
-            response.values["downstream"]
+            response.metadata["downstream"]
                 .downcast_ref::<String>()
                 .unwrap()
         );
@@ -216,7 +216,7 @@ mod tests {
 
         assert_eq!(
             "receive",
-            response.values["upstream"]
+            response.metadata["upstream"]
                 .downcast_ref::<String>()
                 .unwrap()
         );
@@ -250,7 +250,7 @@ mod tests {
         );
         assert_eq!(
             "receive:receive",
-            response.values["downstream"]
+            response.metadata["downstream"]
                 .downcast_ref::<String>()
                 .unwrap()
         );
@@ -269,7 +269,7 @@ mod tests {
         );
         assert_eq!(
             "receive:receive",
-            response.values["upstream"]
+            response.metadata["upstream"]
                 .downcast_ref::<String>()
                 .unwrap()
         );

--- a/src/extensions/filter_registry.rs
+++ b/src/extensions/filter_registry.rs
@@ -33,7 +33,7 @@ pub struct DownstreamContext {
     /// Contents of the received packet.
     pub contents: Vec<u8>,
     /// Arbitrary values that can be passed from one filter to another
-    pub values: HashMap<String, Box<dyn Any + Send>>,
+    pub metadata: HashMap<String, Box<dyn Any + Send>>,
     // Enforce using constructor to create this struct.
     phantom: PhantomData<()>,
 }
@@ -54,7 +54,7 @@ pub struct DownstreamResponse {
     /// Contents of the packet to be forwarded.
     pub contents: Vec<u8>,
     /// Arbitrary values that can be passed from one filter to another
-    pub values: HashMap<String, Box<dyn Any + Send>>,
+    pub metadata: HashMap<String, Box<dyn Any + Send>>,
     // Enforce using constructor to create this struct.
     phantom: PhantomData<()>,
 }
@@ -70,7 +70,7 @@ pub struct UpstreamContext<'a> {
     /// Contents of the received packet.
     pub contents: Vec<u8>,
     /// Arbitrary values that can be passed from one filter to another
-    pub values: HashMap<String, Box<dyn Any + Send>>,
+    pub metadata: HashMap<String, Box<dyn Any + Send>>,
     // Enforce using constructor to create this struct.
     phantom: PhantomData<()>,
 }
@@ -89,7 +89,7 @@ pub struct UpstreamResponse {
     /// Contents of the packet to be sent back to the original sender.
     pub contents: Vec<u8>,
     /// Arbitrary values that can be passed from one filter to another
-    pub values: HashMap<String, Box<dyn Any + Send>>,
+    pub metadata: HashMap<String, Box<dyn Any + Send>>,
     // Enforce using constructor to create this struct.
     phantom: PhantomData<()>,
 }
@@ -101,7 +101,7 @@ impl DownstreamContext {
             endpoints,
             from,
             contents,
-            values: HashMap::new(),
+            metadata: HashMap::new(),
             phantom: PhantomData,
         }
     }
@@ -112,7 +112,7 @@ impl DownstreamContext {
             endpoints: response.endpoints,
             from,
             contents: response.contents,
-            values: response.values,
+            metadata: response.metadata,
             phantom: PhantomData,
         }
     }
@@ -123,7 +123,7 @@ impl From<DownstreamContext> for DownstreamResponse {
         Self {
             endpoints: ctx.endpoints,
             contents: ctx.contents,
-            values: ctx.values,
+            metadata: ctx.metadata,
             phantom: ctx.phantom,
         }
     }
@@ -142,7 +142,7 @@ impl UpstreamContext<'_> {
             from,
             to,
             contents,
-            values: HashMap::new(),
+            metadata: HashMap::new(),
             phantom: PhantomData,
         }
     }
@@ -159,7 +159,7 @@ impl UpstreamContext<'_> {
             from,
             to,
             contents: response.contents,
-            values: response.values,
+            metadata: response.metadata,
             phantom: PhantomData,
         }
     }
@@ -170,7 +170,7 @@ impl From<UpstreamContext<'_>> for UpstreamResponse {
         Self {
             contents: ctx.contents,
             phantom: ctx.phantom,
-            values: ctx.values,
+            metadata: ctx.metadata,
         }
     }
 }

--- a/src/extensions/filters/capture_bytes/mod.rs
+++ b/src/extensions/filters/capture_bytes/mod.rs
@@ -46,16 +46,16 @@ struct Config {
     #[serde(rename = "size")]
     size: usize,
     /// the key to use when storing the captured bytes in the filter context
-    #[serde(rename = "valuesKey")]
-    #[serde(default = "default_values_key")]
-    values_key: String,
+    #[serde(rename = "metadataKey")]
+    #[serde(default = "default_metadata_key")]
+    metadata_key: String,
     /// whether or not to remove the set of the bytes from the packet once captured
     #[serde(default)]
     remove: bool,
 }
 
 /// default value for the context key in the Config
-fn default_values_key() -> String {
+fn default_metadata_key() -> String {
     CAPTURED_BYTES.into()
 }
 
@@ -114,7 +114,7 @@ impl CaptureBytes {
             log: base.new(o!("source" => "extensions::CaptureBytes")),
             capture,
             metrics,
-            context_key: config.values_key,
+            context_key: config.metadata_key,
             size: config.size,
             remove: config.remove,
         }
@@ -140,7 +140,8 @@ impl Filter for CaptureBytes {
             .capture
             .capture(&mut ctx.contents, self.size, self.remove);
 
-        ctx.values.insert(self.context_key.clone(), Box::new(token));
+        ctx.metadata
+            .insert(self.context_key.clone(), Box::new(token));
 
         Some(ctx.into())
     }
@@ -214,7 +215,7 @@ mod tests {
             Value::String("SUFFIX".into()),
         );
         map.insert(
-            Value::String("valuesKey".into()),
+            Value::String("metadataKey".into()),
             Value::String(TOKEN_KEY.into()),
         );
         map.insert(Value::String("size".into()), Value::Number(3.into()));
@@ -262,7 +263,7 @@ mod tests {
     fn on_downstream_receive() {
         let config = Config {
             strategy: Strategy::Suffix,
-            values_key: TOKEN_KEY.into(),
+            metadata_key: TOKEN_KEY.into(),
             size: 3,
             remove: true,
         };
@@ -274,7 +275,7 @@ mod tests {
     fn on_downstream_receive_overflow_capture_size() {
         let config = Config {
             strategy: Strategy::Suffix,
-            values_key: TOKEN_KEY.into(),
+            metadata_key: TOKEN_KEY.into(),
             size: 99,
             remove: true,
         };
@@ -299,7 +300,7 @@ mod tests {
     fn on_upstream_receive() {
         let config = Config {
             strategy: Strategy::Suffix,
-            values_key: TOKEN_KEY.into(),
+            metadata_key: TOKEN_KEY.into(),
             size: 0,
             remove: false,
         };
@@ -358,7 +359,7 @@ mod tests {
         }
 
         let token = response
-            .values
+            .metadata
             .get(key)
             .unwrap()
             .downcast_ref::<Vec<u8>>()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -63,7 +63,7 @@ impl Filter for TestFilter {
         ctx.endpoints.push(noop_endpoint());
 
         // append values on each run
-        ctx.values
+        ctx.metadata
             .entry("downstream".into())
             .and_modify(|e| e.downcast_mut::<String>().unwrap().push_str(":receive"))
             .or_insert_with(|| Box::new("receive".to_string()));
@@ -75,7 +75,7 @@ impl Filter for TestFilter {
 
     fn on_upstream_receive(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
         // append values on each run
-        ctx.values
+        ctx.metadata
             .entry("upstream".into())
             .and_modify(|e| e.downcast_mut::<String>().unwrap().push_str(":receive"))
             .or_insert_with(|| Box::new("receive".to_string()));


### PR DESCRIPTION
This includes:
* The rename of `values` to `metadata` in both Context and Response objects.
* Rename of `valuesKey` to `metadataKey` within Filter configuration.

Work on #121