### PR TITLE
Don't panic on debug when packets aren't utf-8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,11 +23,11 @@
 
 mod cluster;
 pub mod config;
-pub(crate) mod debug;
 pub mod extensions;
 pub mod metrics;
 pub mod proxy;
 pub mod test_utils;
+pub(crate) mod utils;
 pub(crate) mod xds;
 
 #[cfg(doctest)]

--- a/src/proxy/server/mod.rs
+++ b/src/proxy/server/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Arc;
 
-use slog::{debug, error, info, warn, Logger};
+use slog::{debug, error, info, trace, warn, Logger};
 use tokio::net::udp::{RecvHalf, SendHalf};
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, watch};
@@ -29,10 +29,10 @@ use metrics::Metrics as ProxyMetrics;
 
 use crate::cluster::cluster_manager::{ClusterManager, SharedClusterManager};
 use crate::config::{Config, EndPoint, Source};
-use crate::debug;
 use crate::extensions::{DownstreamContext, Filter, FilterChain};
 use crate::proxy::server::error::{Error, RecvFromError};
 use crate::proxy::sessions::{Packet, Session, SESSION_TIMEOUT_SECONDS};
+use crate::utils::debug;
 
 use super::metrics::{start_metrics_server, Metrics};
 
@@ -204,7 +204,7 @@ impl Server {
         tokio::spawn(async move {
             let packet = &buf[..size];
 
-            debug!(
+            trace!(
                 args.log,
                 "Packet Received";
                 "from" => recv_addr,

--- a/src/proxy/sessions/session.rs
+++ b/src/proxy/sessions/session.rs
@@ -20,7 +20,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
 
-use slog::{debug, error, o, Logger};
+use slog::{debug, error, o, trace, Logger};
 use tokio::net::udp::{RecvHalf, SendHalf};
 use tokio::net::UdpSocket;
 use tokio::select;
@@ -28,10 +28,10 @@ use tokio::sync::{mpsc, watch, RwLock};
 use tokio::time::{Duration, Instant};
 
 use crate::config::EndPoint;
-use crate::debug;
 use crate::extensions::{Filter, FilterChain, UpstreamContext};
 use crate::proxy::sessions::error::Error;
 use crate::proxy::sessions::metrics::Metrics;
+use crate::utils::debug;
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -213,7 +213,7 @@ impl Session {
             to,
         } = packet_ctx;
 
-        debug!(log, "Received packet"; "from" => from, "endpoint_name" => &endpoint.name,
+        trace!(log, "Received packet"; "from" => from, "endpoint_name" => &endpoint.name,
             "endpoint_addr" => &endpoint.address, 
             "contents" => debug::bytes_to_string(packet.to_vec()));
         Session::inc_expiration(expiration).await;
@@ -244,7 +244,7 @@ impl Session {
 
     /// Sends a packet to the Session's dest.
     pub async fn send_to(&mut self, buf: &[u8]) -> Result<Option<usize>> {
-        debug!(self.log, "Sending packet"; "dest_name" => &self.dest.name,
+        trace!(self.log, "Sending packet"; "dest_name" => &self.dest.name,
         "dest_address" => &self.dest.address, 
         "contents" => debug::bytes_to_string(buf.to_vec()));
 

--- a/src/utils/debug.rs
+++ b/src/utils/debug.rs
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+//!
+//! The `debug` module is for functionality related to realtime debugging of this project.
+//!
 
 /// Attempt to convert a packet into a string, if it is one, otherwise return some human
 /// readable details about the packet.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2020 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+pub(crate) mod debug;


### PR DESCRIPTION
The current debug logging assumes a packet is utf-8, and if not, it panics, which is bad.

This provides a fallback output if the packet is not utf-8, and introduces a `debug` module to add tools to for debug builds and
debugging in general.

Closes #151