### PR TITLE
Improve Cloud Build build times

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,9 +34,6 @@ steps:
     args: ["clippy", "--tests"]
     id: clippy
   - name: gcr.io/$PROJECT_ID/ci
-    args: ["check", "--tests"]
-    id: check-tests
-  - name: gcr.io/$PROJECT_ID/ci
     args: ["fmt", "--", "--check"]
     id: fmt-check
   - name: gcr.io/$PROJECT_ID/ci
@@ -45,5 +42,9 @@ steps:
   - name: gcr.io/$PROJECT_ID/ci
     args: ["+nightly", "test", "--doc"]
     id: external-doc-test
+options:
+  env:
+    - "CARGO_HOME=/workspace/.cargo"
+  machineType: N1_HIGHCPU_8
 timeout: 30m
 logsBucket: "gs://quilkin-build-logs"


### PR DESCRIPTION
This implements several performance improvements:
* Persist CARGO_HOME between CI steps through the CARGO_HOME env
  variable.
* Removes the redundant `cargo check` step
* Increases size of the build VM to a N1_HIGHCPU_8

This moves the build time down from ~25m to ~5m raised_hands

Closes #173