### PR TITLE
Remove doctest workaround for proto generated comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ regex = "1.3.9"
 
 [build-dependencies]
 tonic-build = { version = "0.4.0", default_features = false, features = ["transport", "prost"] }
+prost-build = "0.7.0"

--- a/build.rs
+++ b/build.rs
@@ -45,16 +45,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .map(|i| std::env::current_dir().unwrap().join(i))
     .collect::<Vec<_>>();
 
-    tonic_build::configure().build_server(false).compile(
-        &proto_files
-            .iter()
-            .map(|path| path.to_str().unwrap())
-            .collect::<Vec<_>>(),
-        &include_dirs
-            .iter()
-            .map(|p| p.to_str().unwrap())
-            .collect::<Vec<_>>(),
-    )?;
+    let config = {
+        let mut c = prost_build::Config::new();
+        c.disable_comments(Some("."));
+        c
+    };
+    tonic_build::configure()
+        .build_server(false)
+        .compile_with_config(
+            config,
+            &proto_files
+                .iter()
+                .map(|path| path.to_str().unwrap())
+                .collect::<Vec<_>>(),
+            &include_dirs
+                .iter()
+                .map(|p| p.to_str().unwrap())
+                .collect::<Vec<_>>(),
+        )?;
 
     // This tells cargo to re-run this build script only when the proto files
     // we're interested in change or the any of the proto directories were updated.

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -19,15 +19,7 @@ use serde_json::value::Value;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 
-#[cfg(not(doctest))]
 pub(crate) mod cluster_manager;
-
-// Stub module to work-around not including cluster_manager in doc tests.
-#[cfg(doctest)]
-pub(crate) mod cluster_manager {
-    pub struct ClusterManager;
-    pub struct SharedClusterManager;
-}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Endpoint {

--- a/src/xds/mod.rs
+++ b/src/xds/mod.rs
@@ -17,7 +17,6 @@
 mod udpa {
     pub mod core {
         pub mod v1 {
-            #![cfg(not(doctest))]
             #![doc(hidden)]
             tonic::include_proto!("udpa.core.v1");
         }
@@ -28,27 +27,23 @@ mod envoy {
     pub mod r#type {
         pub mod matcher {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.r#type.matcher.v3");
             }
         }
         pub mod metadata {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.r#type.metadata.v3");
             }
         }
         pub mod tracing {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.r#type.tracing.v3");
             }
         }
         pub mod v3 {
-            #![cfg(not(doctest))]
             #![doc(hidden)]
             tonic::include_proto!("envoy.r#type.v3");
         }
@@ -56,14 +51,12 @@ mod envoy {
     pub mod config {
         pub mod accesslog {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.config.accesslog.v3");
             }
         }
         pub mod cluster {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.config.cluster.v3");
             }
@@ -71,28 +64,24 @@ mod envoy {
         pub mod core {
             pub mod v3 {
                 #![allow(clippy::large_enum_variant)]
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.config.core.v3");
             }
         }
         pub mod endpoint {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.config.endpoint.v3");
             }
         }
         pub mod listener {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.config.listener.v3");
             }
         }
         pub mod route {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.config.route.v3");
             }
@@ -101,14 +90,12 @@ mod envoy {
     pub mod service {
         pub mod discovery {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.service.discovery.v3");
             }
         }
         pub mod cluster {
             pub mod v3 {
-                #![cfg(not(doctest))]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.service.cluster.v3");
             }
@@ -118,7 +105,6 @@ mod envoy {
 
 mod google {
     pub mod rpc {
-        #![cfg(not(doctest))]
         #![doc(hidden)]
         tonic::include_proto!("google.rpc");
     }
@@ -127,10 +113,7 @@ mod google {
 const ENDPOINT_TYPE: &str = "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment";
 const CLUSTER_TYPE: &str = "type.googleapis.com/envoy.config.cluster.v3.Cluster";
 
-#[cfg(not(doctest))]
 pub mod ads_client;
-#[cfg(not(doctest))]
 mod cluster;
 mod error;
-#[cfg(not(doctest))]
 mod metadata;


### PR DESCRIPTION
The fix in the latest version of prost was to disable comments in the
generated code so we can now remove our workaround