### PR TITLE
on_read & on-write config for ConcatenateBytes 

### DIFF
--- a/docs/extensions/filters/concatenate_bytes.md
+++ b/docs/extensions/filters/concatenate_bytes.md
@@ -16,7 +16,8 @@ static:
   filters:
     - name: quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes
       config:
-          strategy: APPEND
+          on_read: APPEND
+          on_write: DO_NOTHING
           bytes: MXg3aWp5Ng==
   endpoints:
     - name: server-1
@@ -31,16 +32,22 @@ static:
 
 ```yaml
 properties:
-  strategy:
+  on_read:
     type: string
     description: |
-      Either append or prepend the `bytes` data to each packet filtered.
-    default: "APPEND"
-    enum: ['APPEND', 'PREPEND']
+      Either append or prepend the `bytes` data to each packet filtered on read of the listening port.
+    default: DO_NOTHING
+    enum: ['DO_NOTHING', 'APPEND', 'PREPEND']
+  on_write:
+    type: string
+    description: |
+      Either append or prepend the `bytes` data to each packet filtered on write of the listening port.
+    default: DO_NOTHING
+    enum: ['DO_NOTHING', 'APPEND', 'PREPEND']    
   bytes:
     type: string
     description: |
-      Base64 encoded string of the byte array to add to each packet as it is filtered.  
+      Base64 encoded string of the byte array to add to each packet as it is filtered.
 ```
 
 ### Metrics

--- a/proto/quilkin/extensions/filters/concatenate_bytes/v1alpha1/concatenate_bytes.proto
+++ b/proto/quilkin/extensions/filters/concatenate_bytes/v1alpha1/concatenate_bytes.proto
@@ -4,15 +4,17 @@ package quilkin.extensions.filters.concatenate_bytes.v1alpha1;
 
 message ConcatenateBytes {
   enum Strategy {
-    Append = 0;
-    Prepend = 1;
+    DoNothing = 0;
+    Append = 1;
+    Prepend = 2;
   }
 
   message StrategyValue {
     Strategy value = 1;
   }
 
-  StrategyValue strategy = 1;
-  bytes bytes = 2;
+  StrategyValue on_write = 1;
+  StrategyValue on_read = 2;
+  bytes bytes = 3;
 }
 

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -29,7 +29,7 @@ mod tests {
     async fn concatenate_bytes() {
         let mut t = TestHelper::default();
         let yaml = "
-strategy: APPEND
+on_read: APPEND
 bytes: YWJj #abc
 ";
         let echo = t.run_echo_server().await;


### PR DESCRIPTION
This allows for concatenating bytes both on_write and on_read - whereas previously you could only do on_read.

This is also useful to implement an integration test that checks to see if correct Filter ordering happens both on listening port read and write.