### PR TITLE
Align Filter trait with documented terminology

### DIFF
--- a/src/extensions/filter_chain.rs
+++ b/src/extensions/filter_chain.rs
@@ -86,26 +86,26 @@ impl FilterChain {
 }
 
 impl Filter for FilterChain {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn on_upstream(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
         let from = ctx.from;
         for f in &self.filters {
-            match f.on_downstream_receive(ctx) {
+            match f.on_upstream(ctx) {
                 None => return None,
-                Some(response) => ctx = DownstreamContext::with_response(from, response),
+                Some(response) => ctx = UpstreamContext::with_response(from, response),
             }
         }
         Some(ctx.into())
     }
 
-    fn on_upstream_receive(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
+    fn on_downstream(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
         let endpoint = ctx.endpoint;
         let from = ctx.from;
         let to = ctx.to;
         for f in &self.filters {
-            match f.on_upstream_receive(ctx) {
+            match f.on_downstream(ctx) {
                 None => return None,
                 Some(response) => {
-                    ctx = UpstreamContext::with_response(endpoint, from, to, response);
+                    ctx = DownstreamContext::with_response(endpoint, from, to, response);
                 }
             }
         }
@@ -179,7 +179,7 @@ mod tests {
         let endpoints_fixture = endpoints();
 
         let response = chain
-            .on_downstream_receive(DownstreamContext::new(
+            .on_upstream(UpstreamContext::new(
                 upstream_endpoints(endpoints_fixture.clone()),
                 "127.0.0.1:70".parse().unwrap(),
                 b"hello".to_vec(),
@@ -203,7 +203,7 @@ mod tests {
         );
 
         let response = chain
-            .on_upstream_receive(UpstreamContext::new(
+            .on_downstream(DownstreamContext::new(
                 &endpoints_fixture[0],
                 endpoints_fixture[0].address,
                 "127.0.0.1:70".parse().unwrap(),
@@ -230,7 +230,7 @@ mod tests {
         let endpoints_fixture = endpoints();
 
         let response = chain
-            .on_downstream_receive(DownstreamContext::new(
+            .on_upstream(UpstreamContext::new(
                 upstream_endpoints(endpoints_fixture.clone()),
                 "127.0.0.1:70".parse().unwrap(),
                 b"hello".to_vec(),
@@ -254,7 +254,7 @@ mod tests {
         );
 
         let response = chain
-            .on_upstream_receive(UpstreamContext::new(
+            .on_downstream(DownstreamContext::new(
                 &endpoints_fixture[0],
                 endpoints_fixture[0].address,
                 "127.0.0.1:70".parse().unwrap(),

--- a/src/extensions/filter_manager.rs
+++ b/src/extensions/filter_manager.rs
@@ -145,7 +145,7 @@ impl FilterManager {
 #[cfg(test)]
 mod tests {
     use super::FilterManager;
-    use crate::extensions::{DownstreamContext, DownstreamResponse, Filter, FilterChain};
+    use crate::extensions::{Filter, FilterChain, UpstreamContext, UpstreamResponse};
     use crate::test_utils::logger;
 
     use std::sync::Arc;
@@ -179,7 +179,7 @@ mod tests {
             "127.0.0.1:8080".parse().unwrap(),
         )])
         .unwrap();
-        let response = filter_chain.on_downstream_receive(DownstreamContext::new(
+        let response = filter_chain.on_upstream(UpstreamContext::new(
             UpstreamEndpoints::from(test_endpoints.clone()),
             "127.0.0.1:8081".parse().unwrap(),
             vec![],
@@ -189,7 +189,7 @@ mod tests {
         // A simple test filter that drops all packets flowing upstream.
         struct Drop;
         impl Filter for Drop {
-            fn on_downstream_receive(&self, _: DownstreamContext) -> Option<DownstreamResponse> {
+            fn on_upstream(&self, _: UpstreamContext) -> Option<UpstreamResponse> {
                 None
             }
         }
@@ -205,7 +205,7 @@ mod tests {
                 manager_guard.get_filter_chain().clone().unwrap()
             };
             if filter_chain
-                .on_downstream_receive(DownstreamContext::new(
+                .on_upstream(UpstreamContext::new(
                     UpstreamEndpoints::from(test_endpoints.clone()),
                     "127.0.0.1:8081".parse().unwrap(),
                     vec![],

--- a/src/extensions/filters/concatenate_bytes.rs
+++ b/src/extensions/filters/concatenate_bytes.rs
@@ -18,7 +18,7 @@ use base64_serde::base64_serde_type;
 use serde::{Deserialize, Serialize};
 
 use crate::extensions::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
+    CreateFilterArgs, Error, Filter, FilterFactory, UpstreamContext, UpstreamResponse,
 };
 
 base64_serde_type!(Base64Standard, base64::STANDARD);
@@ -93,7 +93,7 @@ impl ConcatenateBytes {
 }
 
 impl Filter for ConcatenateBytes {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn on_upstream(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
         match self.strategy {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());
@@ -110,7 +110,7 @@ impl Filter for ConcatenateBytes {
 #[cfg(test)]
 mod tests {
     use crate::config::Endpoints;
-    use crate::test_utils::assert_filter_on_downstream_receive_no_change;
+    use crate::test_utils::assert_filter_on_upstream_no_change;
     use serde_yaml::{Mapping, Value};
 
     use super::*;
@@ -176,27 +176,27 @@ mod tests {
     }
 
     #[test]
-    fn on_downstream_receive_append() {
+    fn on_upstream_append() {
         let strategy = Strategy::Append;
         let expected = "abchello";
         assert_create_filter(strategy, expected);
     }
 
     #[test]
-    fn on_downstream_receive_prepend() {
+    fn on_upstream_prepend() {
         let strategy = Strategy::Prepend;
         let expected = "helloabc";
         assert_create_filter(strategy, expected);
     }
 
     #[test]
-    fn on_upstream_receive() {
+    fn on_upstream() {
         let config = Config {
             strategy: Default::default(),
             bytes: vec![],
         };
         let filter = ConcatenateBytes::new(config);
-        assert_filter_on_downstream_receive_no_change(&filter);
+        assert_filter_on_upstream_no_change(&filter);
     }
 
     fn assert_create_filter(strategy: Strategy, expected: &str) {
@@ -216,7 +216,7 @@ mod tests {
     {
         let endpoints = vec![Endpoint::from_address("127.0.0.1:81".parse().unwrap())];
         let response = filter
-            .on_downstream_receive(DownstreamContext::new(
+            .on_upstream(UpstreamContext::new(
                 Endpoints::new(endpoints.clone()).unwrap().into(),
                 "127.0.0.1:80".parse().unwrap(),
                 "abc".to_string().into_bytes(),

--- a/src/extensions/filters/debug.rs
+++ b/src/extensions/filters/debug.rs
@@ -115,12 +115,12 @@ impl FilterFactory for DebugFactory {
 }
 
 impl Filter for Debug {
-    fn on_downstream_receive(&self, ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn on_upstream(&self, ctx: UpstreamContext) -> Option<UpstreamResponse> {
         info!(self.log, "on local receive"; "from" => ctx.from, "contents" => packet_to_string(ctx.contents.clone()));
         Some(ctx.into())
     }
 
-    fn on_upstream_receive(&self, ctx: UpstreamContext) -> Option<UpstreamResponse> {
+    fn on_downstream(&self, ctx: DownstreamContext) -> Option<DownstreamResponse> {
         info!(self.log, "received endpoint packet"; "endpoint" => ctx.endpoint.address,
         "from" => ctx.from,
         "to" => ctx.to,
@@ -144,22 +144,21 @@ mod tests {
     use serde_yaml::Value;
 
     use crate::test_utils::{
-        assert_filter_on_downstream_receive_no_change, assert_filter_on_upstream_receive_no_change,
-        logger,
+        assert_filter_on_downstream_no_change, assert_filter_on_upstream_no_change, logger,
     };
 
     use super::*;
 
     #[test]
-    fn on_downstream_receive() {
+    fn on_upstream() {
         let df = Debug::new(&logger(), None);
-        assert_filter_on_downstream_receive_no_change(&df);
+        assert_filter_on_upstream_no_change(&df);
     }
 
     #[test]
-    fn on_upstream_receive() {
+    fn on_downstream() {
         let df = Debug::new(&logger(), None);
-        assert_filter_on_upstream_receive_no_change(&df);
+        assert_filter_on_downstream_no_change(&df);
     }
 
     #[test]

--- a/src/extensions/filters/load_balancer/mod.rs
+++ b/src/extensions/filters/load_balancer/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::UpstreamEndpoints;
 use crate::extensions::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
+    CreateFilterArgs, Error, Filter, FilterFactory, UpstreamContext, UpstreamResponse,
 };
 
 /// Policy represents how a [`LoadBalancerFilter`] distributes
@@ -126,7 +126,7 @@ impl FilterFactory for LoadBalancerFilterFactory {
 }
 
 impl Filter for LoadBalancerFilter {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn on_upstream(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
         self.endpoint_chooser.choose_endpoints(&mut ctx.endpoints);
         Some(ctx.into())
     }
@@ -139,7 +139,7 @@ mod tests {
 
     use crate::cluster::Endpoint;
     use crate::config::Endpoints;
-    use crate::extensions::filter_registry::DownstreamContext;
+    use crate::extensions::filter_registry::UpstreamContext;
     use crate::extensions::filters::load_balancer::LoadBalancerFilterFactory;
     use crate::extensions::{CreateFilterArgs, Filter, FilterFactory};
 
@@ -157,7 +157,7 @@ mod tests {
         input_addresses: &[SocketAddr],
     ) -> Vec<SocketAddr> {
         filter
-            .on_downstream_receive(DownstreamContext::new(
+            .on_upstream(UpstreamContext::new(
                 Endpoints::new(
                     input_addresses
                         .iter()

--- a/src/proxy/server/mod.rs
+++ b/src/proxy/server/mod.rs
@@ -32,7 +32,7 @@ use metrics::Metrics as ProxyMetrics;
 use crate::cluster::cluster_manager::SharedClusterManager;
 use crate::cluster::Endpoint;
 use crate::config::{Config, Source};
-use crate::extensions::{DownstreamContext, Filter, FilterChain, FilterRegistry};
+use crate::extensions::{Filter, FilterChain, FilterRegistry, UpstreamContext};
 use crate::proxy::server::error::{Error, RecvFromError};
 use crate::proxy::sessions::{
     Packet, Session, SESSION_EXPIRY_POLL_INTERVAL, SESSION_TIMEOUT_SECONDS,
@@ -280,11 +280,9 @@ impl Server {
                 }
             };
 
-            let result = args.chain.on_downstream_receive(DownstreamContext::new(
-                endpoints,
-                recv_addr,
-                packet.to_vec(),
-            ));
+            let result =
+                args.chain
+                    .on_upstream(UpstreamContext::new(endpoints, recv_addr, packet.to_vec()));
 
             if let Some(response) = result {
                 for endpoint in response.endpoints.iter() {

--- a/src/proxy/sessions/session.rs
+++ b/src/proxy/sessions/session.rs
@@ -27,7 +27,7 @@ use tokio::sync::{mpsc, watch};
 use tokio::time::{Duration, Instant};
 
 use crate::cluster::Endpoint;
-use crate::extensions::{Filter, FilterChain, UpstreamContext};
+use crate::extensions::{DownstreamContext, Filter, FilterChain};
 use crate::proxy::sessions::error::Error;
 use crate::proxy::sessions::metrics::Metrics;
 use crate::utils::debug;
@@ -221,7 +221,7 @@ impl Session {
         }
 
         if let Some(response) =
-            chain.on_upstream_receive(UpstreamContext::new(endpoint, from, to, packet.to_vec()))
+            chain.on_downstream(DownstreamContext::new(endpoint, from, to, packet.to_vec()))
         {
             if let Err(err) = sender.send(Packet::new(to, response.contents)).await {
                 metrics.rx_errors_total.inc();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -47,7 +47,7 @@ impl FilterFactory for TestFilterFactory {
 pub struct TestFilter {}
 
 impl Filter for TestFilter {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn on_upstream(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
         // append values on each run
         ctx.metadata
             .entry("downstream".into())
@@ -59,7 +59,7 @@ impl Filter for TestFilter {
         Some(ctx.into())
     }
 
-    fn on_upstream_receive(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
+    fn on_downstream(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
         // append values on each run
         ctx.metadata
             .entry("upstream".into())
@@ -279,8 +279,8 @@ impl TestHelper {
     }
 }
 
-/// assert that on_downstream_receive makes no changes
-pub fn assert_filter_on_downstream_receive_no_change<F>(filter: &F)
+/// assert that on_upstream makes no changes
+pub fn assert_filter_on_upstream_no_change<F>(filter: &F)
 where
     F: Filter,
 {
@@ -288,7 +288,7 @@ where
     let from = "127.0.0.1:90".parse().unwrap();
     let contents = "hello".to_string().into_bytes();
 
-    match filter.on_downstream_receive(DownstreamContext::new(
+    match filter.on_upstream(UpstreamContext::new(
         Endpoints::new(endpoints.clone()).unwrap().into(),
         from,
         contents.clone(),
@@ -304,15 +304,15 @@ where
     }
 }
 
-/// assert that on_upstream_receive makes no changes
-pub fn assert_filter_on_upstream_receive_no_change<F>(filter: &F)
+/// assert that on_downstream makes no changes
+pub fn assert_filter_on_downstream_no_change<F>(filter: &F)
 where
     F: Filter,
 {
     let endpoint = Endpoint::from_address("127.0.0.1:90".parse().unwrap());
     let contents = "hello".to_string().into_bytes();
 
-    match filter.on_upstream_receive(UpstreamContext::new(
+    match filter.on_downstream(DownstreamContext::new(
         &endpoint,
         endpoint.address,
         "127.0.0.1:70".parse().unwrap(),

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -189,8 +189,8 @@ mod tests {
     use super::ListenerManager;
     use crate::extensions::filter_manager::ListenerManagerArgs;
     use crate::extensions::{
-        CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
-        FilterRegistry,
+        CreateFilterArgs, Error, Filter, FilterFactory, FilterRegistry, UpstreamContext,
+        UpstreamResponse,
     };
     use crate::test_utils::logger;
     use crate::xds::envoy::config::listener::v3::{
@@ -220,7 +220,7 @@ mod tests {
     }
 
     impl Filter for Append {
-        fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+        fn on_upstream(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
             ctx.contents = format!(
                 "{}{}",
                 String::from_utf8(ctx.contents).unwrap(),
@@ -349,7 +349,7 @@ mod tests {
 
         // Test the new filter chain's functionality. It should append to payloads.
         let response = filter_chain
-            .on_downstream_receive(DownstreamContext::new(
+            .on_upstream(UpstreamContext::new(
                 UpstreamEndpoints::from(
                     Endpoints::new(vec![Endpoint::from_address(
                         "127.0.0.1:8080".parse().unwrap(),
@@ -466,7 +466,7 @@ mod tests {
 
             // Test the new filter chain's functionality.
             let response = filter_chain
-                .on_downstream_receive(DownstreamContext::new(
+                .on_upstream(UpstreamContext::new(
                     UpstreamEndpoints::from(
                         Endpoints::new(vec![Endpoint::from_address(
                             "127.0.0.1:8080".parse().unwrap(),


### PR DESCRIPTION
I was finding it hard to reconcile `on_upstream_receive` with the (almost) documented `direction: downstream` and similar
`on_downstream_receive` with `direction: upstream`.

Therefore, I refactored `on_upstream_receive` to `on_downstream` and `on_downstream_receive` to `on_upstream`, as well as renaming the context and response objects.

I found this easier to understand as the Filter event is processing data either moving upstream or downstream. I no longer have to think about where it was received from -- the bytes are just moving in one direction or other.

I feel like now the Filter pattern directly matches what we have in our documentation, and there is no contextual mismatch, and it will be much easier to learn and write filters for.