### PR TITLE
Rename Filter to align with Envoy concepts

### DIFF
--- a/src/extensions/filter_manager.rs
+++ b/src/extensions/filter_manager.rs
@@ -146,7 +146,7 @@ impl FilterManager {
 #[cfg(test)]
 mod tests {
     use super::FilterManager;
-    use crate::extensions::{DownstreamContext, DownstreamResponse, Filter, FilterChain};
+    use crate::extensions::{Filter, FilterChain, ReadContext, ReadResponse};
     use crate::test_utils::logger;
 
     use std::sync::Arc;
@@ -180,7 +180,7 @@ mod tests {
             "127.0.0.1:8080".parse().unwrap(),
         )])
         .unwrap();
-        let response = filter_chain.on_downstream_receive(DownstreamContext::new(
+        let response = filter_chain.read(ReadContext::new(
             UpstreamEndpoints::from(test_endpoints.clone()),
             "127.0.0.1:8081".parse().unwrap(),
             vec![],
@@ -190,7 +190,7 @@ mod tests {
         // A simple test filter that drops all packets flowing upstream.
         struct Drop;
         impl Filter for Drop {
-            fn on_downstream_receive(&self, _: DownstreamContext) -> Option<DownstreamResponse> {
+            fn read(&self, _: ReadContext) -> Option<ReadResponse> {
                 None
             }
         }
@@ -206,7 +206,7 @@ mod tests {
                 manager_guard.get_filter_chain().clone()
             };
             if filter_chain
-                .on_downstream_receive(DownstreamContext::new(
+                .read(ReadContext::new(
                     UpstreamEndpoints::from(test_endpoints.clone()),
                     "127.0.0.1:8081".parse().unwrap(),
                     vec![],

--- a/src/extensions/filter_registry.rs
+++ b/src/extensions/filter_registry.rs
@@ -26,8 +26,8 @@ use prometheus::{Error as MetricsError, Registry};
 use crate::cluster::Endpoint;
 use crate::config::{UpstreamEndpoints, ValidationError};
 
-/// Contains the input arguments to [on_downstream_receive](crate::extensions::filter_registry::Filter::on_downstream_receive)
-pub struct DownstreamContext {
+/// Contains the input arguments to [read](crate::extensions::filter_registry::Filter::read)
+pub struct ReadContext {
     /// The upstream endpoints that the packet will be forwarded to.
     pub endpoints: UpstreamEndpoints,
     /// The source of the received packet.
@@ -40,17 +40,17 @@ pub struct DownstreamContext {
     phantom: PhantomData<()>,
 }
 
-/// Contains the output of [on_downstream_receive](crate::extensions::filter_registry::Filter::on_downstream_receive)
+/// Contains the output of [read](crate::extensions::filter_registry::Filter::read)
 ///
-/// New instances are created from a [`DownstreamContext`]
+/// New instances are created from a [`ReadContext`]
 ///
 /// ```rust
-/// # use quilkin::extensions::{DownstreamContext, DownstreamResponse};
-///   fn on_downstream_receive(ctx: DownstreamContext) -> Option<DownstreamResponse> {
+/// # use quilkin::extensions::{ReadContext, ReadResponse};
+///   fn read(ctx: ReadContext) -> Option<ReadResponse> {
 ///       Some(ctx.into())
 ///   }
 /// ```
-pub struct DownstreamResponse {
+pub struct ReadResponse {
     /// The upstream endpoints that the packet should be forwarded to.
     pub endpoints: UpstreamEndpoints,
     /// Contents of the packet to be forwarded.
@@ -61,8 +61,8 @@ pub struct DownstreamResponse {
     phantom: PhantomData<()>,
 }
 
-/// Contains the input arguments to [on_upstream_receive](crate::extensions::filter_registry::Filter::on_upstream_receive)
-pub struct UpstreamContext<'a> {
+/// Contains the input arguments to [write](crate::extensions::filter_registry::Filter::write)
+pub struct WriteContext<'a> {
     /// The upstream endpoint that we're expecting packets from.
     pub endpoint: &'a Endpoint,
     /// The source of the received packet.
@@ -77,17 +77,17 @@ pub struct UpstreamContext<'a> {
     phantom: PhantomData<()>,
 }
 
-/// Contains the output of [on_upstream_receive](crate::extensions::filter_registry::Filter::on_upstream_receive)
+/// Contains the output of [write](crate::extensions::filter_registry::Filter::write)
 ///
-/// New instances are created from an [`UpstreamContext`]
+/// New instances are created from an [`WriteContext`]
 ///
 /// ```rust
-/// # use quilkin::extensions::{UpstreamContext, UpstreamResponse};
-///   fn on_upstream_receive(ctx: UpstreamContext) -> Option<UpstreamResponse> {
+/// # use quilkin::extensions::{WriteContext, WriteResponse};
+///   fn write(ctx: WriteContext) -> Option<WriteResponse> {
 ///       Some(ctx.into())
 ///   }
 /// ```
-pub struct UpstreamResponse {
+pub struct WriteResponse {
     /// Contents of the packet to be sent back to the original sender.
     pub contents: Vec<u8>,
     /// Arbitrary values that can be passed from one filter to another
@@ -96,8 +96,8 @@ pub struct UpstreamResponse {
     phantom: PhantomData<()>,
 }
 
-impl DownstreamContext {
-    /// Creates a new [`DownstreamContext`]
+impl ReadContext {
+    /// Creates a new [`ReadContext`]
     pub fn new(endpoints: UpstreamEndpoints, from: SocketAddr, contents: Vec<u8>) -> Self {
         Self {
             endpoints,
@@ -108,8 +108,8 @@ impl DownstreamContext {
         }
     }
 
-    /// Creates a new [`DownstreamContext`] from a [`DownstreamResponse`]
-    pub fn with_response(from: SocketAddr, response: DownstreamResponse) -> Self {
+    /// Creates a new [`ReadContext`] from a [`ReadResponse`]
+    pub fn with_response(from: SocketAddr, response: ReadResponse) -> Self {
         Self {
             endpoints: response.endpoints,
             from,
@@ -120,8 +120,8 @@ impl DownstreamContext {
     }
 }
 
-impl From<DownstreamContext> for DownstreamResponse {
-    fn from(ctx: DownstreamContext) -> Self {
+impl From<ReadContext> for ReadResponse {
+    fn from(ctx: ReadContext) -> Self {
         Self {
             endpoints: ctx.endpoints,
             contents: ctx.contents,
@@ -131,15 +131,15 @@ impl From<DownstreamContext> for DownstreamResponse {
     }
 }
 
-impl UpstreamContext<'_> {
-    /// Creates a new [`UpstreamContext`]
+impl WriteContext<'_> {
+    /// Creates a new [`WriteContext`]
     pub fn new(
         endpoint: &Endpoint,
         from: SocketAddr,
         to: SocketAddr,
         contents: Vec<u8>,
-    ) -> UpstreamContext {
-        UpstreamContext {
+    ) -> WriteContext {
+        WriteContext {
             endpoint,
             from,
             to,
@@ -149,14 +149,14 @@ impl UpstreamContext<'_> {
         }
     }
 
-    /// Creates a new [`UpstreamContext`] from a [`UpstreamResponse`]
+    /// Creates a new [`WriteContext`] from a [`WriteResponse`]
     pub fn with_response(
         endpoint: &Endpoint,
         from: SocketAddr,
         to: SocketAddr,
-        response: UpstreamResponse,
-    ) -> UpstreamContext {
-        UpstreamContext {
+        response: WriteResponse,
+    ) -> WriteContext {
+        WriteContext {
             endpoint,
             from,
             to,
@@ -167,8 +167,8 @@ impl UpstreamContext<'_> {
     }
 }
 
-impl From<UpstreamContext<'_>> for UpstreamResponse {
-    fn from(ctx: UpstreamContext) -> Self {
+impl From<WriteContext<'_>> for WriteResponse {
+    fn from(ctx: WriteContext) -> Self {
         Self {
             contents: ctx.contents,
             phantom: ctx.phantom,
@@ -179,24 +179,24 @@ impl From<UpstreamContext<'_>> for UpstreamResponse {
 
 /// Filter is a trait for routing and manipulating packets.
 pub trait Filter: Send + Sync {
-    /// on_downstream_receive filters packets received from the local port, and potentially sends them
-    /// to configured endpoints.
-    /// This function should return a [`DownstreamResponse`] containing the array of
+    /// Read is invoked when the proxy receives data from a downstream connection on the
+    /// listening port.
+    /// This function should return a [`ReadResponse`] containing the array of
     /// endpoints that the packet should be sent to and the packet that should be
     /// sent (which may be manipulated) as well.
     /// If the packet should be rejected, return None.
     /// By default, passes the context through unchanged
-    fn on_downstream_receive(&self, ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
         Some(ctx.into())
     }
 
-    /// on_upstream_receive filters packets received upstream and destined
-    /// for a given endpoint, that are going back to the original sender.
-    /// This function should return an [`UpstreamResponse`] containing the packet to
+    /// Write is invoked when the proxy is about to send data to a downstream connection
+    /// via the listening port after receiving it via one of the upstream Endpoints.
+    /// This function should return an [`WriteResponse`] containing the packet to
     /// be sent (which may be manipulated).
     /// If the packet should be rejected, return None.
     /// By default, passes the context through unchanged
-    fn on_upstream_receive(&self, ctx: UpstreamContext) -> Option<UpstreamResponse> {
+    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
         Some(ctx.into())
     }
 }
@@ -368,11 +368,11 @@ mod tests {
     struct TestFilter {}
 
     impl Filter for TestFilter {
-        fn on_downstream_receive(&self, _: DownstreamContext) -> Option<DownstreamResponse> {
+        fn read(&self, _: ReadContext) -> Option<ReadResponse> {
             None
         }
 
-        fn on_upstream_receive(&self, _: UpstreamContext) -> Option<UpstreamResponse> {
+        fn write(&self, _: WriteContext) -> Option<WriteResponse> {
             None
         }
     }
@@ -399,7 +399,7 @@ mod tests {
         let endpoint = Endpoint::from_address(addr);
 
         assert!(filter
-            .on_downstream_receive(DownstreamContext::new(
+            .read(ReadContext::new(
                 Endpoints::new(vec![Endpoint::from_address(
                     "127.0.0.1:8080".parse().unwrap(),
                 )])
@@ -410,7 +410,7 @@ mod tests {
             ))
             .is_some());
         assert!(filter
-            .on_upstream_receive(UpstreamContext::new(&endpoint, addr, addr, vec![],))
+            .write(WriteContext::new(&endpoint, addr, addr, vec![],))
             .is_some());
     }
 }

--- a/src/extensions/filters/capture_bytes/mod.rs
+++ b/src/extensions/filters/capture_bytes/mod.rs
@@ -21,7 +21,7 @@ use metrics::Metrics;
 
 use crate::extensions::filters::CAPTURED_BYTES;
 use crate::extensions::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
+    CreateFilterArgs, Error, Filter, FilterFactory, ReadContext, ReadResponse,
 };
 
 mod metrics;
@@ -125,7 +125,7 @@ impl CaptureBytes {
 }
 
 impl Filter for CaptureBytes {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         // if the capture size is bigger than the packet size, then we drop the packet,
         // and occasionally warn
         if ctx.contents.len() < self.size {
@@ -190,7 +190,7 @@ mod tests {
     use serde_yaml::{Mapping, Value};
 
     use crate::config::Endpoints;
-    use crate::test_utils::{assert_filter_on_upstream_receive_no_change, logger};
+    use crate::test_utils::{assert_write_no_change, logger};
 
     use super::*;
     use crate::cluster::Endpoint;
@@ -248,7 +248,7 @@ mod tests {
     }
 
     #[test]
-    fn on_downstream_receive() {
+    fn read() {
         let config = Config {
             strategy: Strategy::Suffix,
             metadata_key: TOKEN_KEY.into(),
@@ -260,7 +260,7 @@ mod tests {
     }
 
     #[test]
-    fn on_downstream_receive_overflow_capture_size() {
+    fn read_overflow_capture_size() {
         let config = Config {
             strategy: Strategy::Suffix,
             metadata_key: TOKEN_KEY.into(),
@@ -269,7 +269,7 @@ mod tests {
         };
         let filter = capture_bytes(config);
         let endpoints = vec![Endpoint::from_address("127.0.0.1:81".parse().unwrap())];
-        let response = filter.on_downstream_receive(DownstreamContext::new(
+        let response = filter.read(ReadContext::new(
             Endpoints::new(endpoints).unwrap().into(),
             "127.0.0.1:80".parse().unwrap(),
             "abc".to_string().into_bytes(),
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[test]
-    fn on_upstream_receive() {
+    fn write() {
         let config = Config {
             strategy: Strategy::Suffix,
             metadata_key: TOKEN_KEY.into(),
@@ -289,7 +289,7 @@ mod tests {
             remove: false,
         };
         let filter = capture_bytes(config);
-        assert_filter_on_upstream_receive_no_change(&filter);
+        assert_write_no_change(&filter);
     }
 
     #[test]
@@ -325,7 +325,7 @@ mod tests {
     {
         let endpoints = vec![Endpoint::from_address("127.0.0.1:81".parse().unwrap())];
         let response = filter
-            .on_downstream_receive(DownstreamContext::new(
+            .read(ReadContext::new(
                 Endpoints::new(endpoints).unwrap().into(),
                 "127.0.0.1:80".parse().unwrap(),
                 "helloabc".to_string().into_bytes(),

--- a/src/extensions/filters/compress/mod.rs
+++ b/src/extensions/filters/compress/mod.rs
@@ -23,8 +23,8 @@ use snap::write::FrameEncoder;
 
 use crate::extensions::filters::compress::metrics::Metrics;
 use crate::extensions::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error as RegistryError, Filter,
-    FilterFactory, UpstreamContext, UpstreamResponse,
+    CreateFilterArgs, Error as RegistryError, Filter, FilterFactory, ReadContext, ReadResponse,
+    WriteContext, WriteResponse,
 };
 
 mod metrics;
@@ -144,7 +144,7 @@ impl Compress {
 }
 
 impl Filter for Compress {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         let original_size = ctx.contents.len();
         match self.direction {
             Direction::Upstream => match self.compressor.encode(&mut ctx.contents) {
@@ -174,7 +174,7 @@ impl Filter for Compress {
         }
     }
 
-    fn on_upstream_receive(&self, mut ctx: UpstreamContext) -> Option<UpstreamResponse> {
+    fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
         let original_size = ctx.contents.len();
         match self.direction {
             Direction::Upstream => match self.compressor.decode(&mut ctx.contents) {
@@ -292,9 +292,9 @@ mod tests {
         );
         let expected = contents_fixture();
 
-        // on_downstream_receive compress
-        let downstream_response = compress
-            .on_downstream_receive(DownstreamContext::new(
+        // read compress
+        let read_response = compress
+            .read(ReadContext::new(
                 UpstreamEndpoints::from(
                     Endpoints::new(vec![Endpoint::from_address(
                         "127.0.0.1:80".parse().unwrap(),
@@ -306,39 +306,39 @@ mod tests {
             ))
             .expect("should compress");
 
-        assert_ne!(expected, downstream_response.contents);
+        assert_ne!(expected, read_response.contents);
         assert!(
-            expected.len() > downstream_response.contents.len(),
+            expected.len() > read_response.contents.len(),
             "Original: {}. Compressed: {}",
             expected.len(),
-            downstream_response.contents.len()
+            read_response.contents.len()
         );
         assert_eq!(
             expected.len() as i64,
             compress.metrics.decompressed_bytes_total.get()
         );
         assert_eq!(
-            downstream_response.contents.len() as i64,
+            read_response.contents.len() as i64,
             compress.metrics.compressed_bytes_total.get()
         );
 
-        // on_upstream_receive decompress
-        let upstream_response = compress
-            .on_upstream_receive(UpstreamContext::new(
+        // write decompress
+        let write_response = compress
+            .write(WriteContext::new(
                 &Endpoint::from_address("127.0.0.1:80".parse().unwrap()),
                 "127.0.0.1:8080".parse().unwrap(),
                 "127.0.0.1:8081".parse().unwrap(),
-                downstream_response.contents.clone(),
+                read_response.contents.clone(),
             ))
             .expect("should decompress");
 
-        assert_eq!(expected, upstream_response.contents);
+        assert_eq!(expected, write_response.contents);
 
         assert_eq!(0, compress.metrics.packets_dropped_decompress.get());
         assert_eq!(0, compress.metrics.packets_dropped_compress.get());
         // multiply by two, because data was sent both upstream and downstream
         assert_eq!(
-            (downstream_response.contents.len() * 2) as i64,
+            (read_response.contents.len() * 2) as i64,
             compress.metrics.compressed_bytes_total.get()
         );
         assert_eq!(
@@ -387,7 +387,7 @@ mod tests {
             Metrics::new(&Registry::default()).unwrap(),
         );
 
-        let upstream_response = compression.on_upstream_receive(UpstreamContext::new(
+        let upstream_response = compression.write(WriteContext::new(
             &Endpoint::from_address("127.0.0.1:80".parse().unwrap()),
             "127.0.0.1:8080".parse().unwrap(),
             "127.0.0.1:8081".parse().unwrap(),
@@ -407,7 +407,7 @@ mod tests {
             Metrics::new(&Registry::default()).unwrap(),
         );
 
-        let downstream_response = compression.on_downstream_receive(DownstreamContext::new(
+        let downstream_response = compression.read(ReadContext::new(
             UpstreamEndpoints::from(
                 Endpoints::new(vec![Endpoint::from_address(
                     "127.0.0.1:80".parse().unwrap(),
@@ -471,9 +471,9 @@ mod tests {
         F: Filter + ?Sized,
     {
         let expected = contents_fixture();
-        // on_upstream_receive compress
-        let upstream_response = filter
-            .on_upstream_receive(UpstreamContext::new(
+        // write compress
+        let write_response = filter
+            .write(WriteContext::new(
                 &Endpoint::from_address("127.0.0.1:80".parse().unwrap()),
                 "127.0.0.1:8080".parse().unwrap(),
                 "127.0.0.1:8081".parse().unwrap(),
@@ -481,17 +481,17 @@ mod tests {
             ))
             .expect("should compress");
 
-        assert_ne!(expected, upstream_response.contents);
+        assert_ne!(expected, write_response.contents);
         assert!(
-            expected.len() > upstream_response.contents.len(),
+            expected.len() > write_response.contents.len(),
             "Original: {}. Compressed: {}",
             expected.len(),
-            upstream_response.contents.len()
+            write_response.contents.len()
         );
 
-        // on_downstream_receive decompress
-        let downstream_response = filter
-            .on_downstream_receive(DownstreamContext::new(
+        // read decompress
+        let read_response = filter
+            .read(ReadContext::new(
                 UpstreamEndpoints::from(
                     Endpoints::new(vec![Endpoint::from_address(
                         "127.0.0.1:80".parse().unwrap(),
@@ -499,11 +499,11 @@ mod tests {
                     .unwrap(),
                 ),
                 "127.0.0.1:8080".parse().unwrap(),
-                upstream_response.contents.clone(),
+                write_response.contents.clone(),
             ))
             .expect("should decompress");
 
-        assert_eq!(expected, downstream_response.contents);
-        (expected, upstream_response.contents)
+        assert_eq!(expected, read_response.contents);
+        (expected, write_response.contents)
     }
 }

--- a/src/extensions/filters/debug.rs
+++ b/src/extensions/filters/debug.rs
@@ -18,8 +18,7 @@ use serde::{Deserialize, Serialize};
 use slog::{info, o, Logger};
 
 use crate::extensions::filter_registry::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, FilterFactory, UpstreamContext,
-    UpstreamResponse,
+    CreateFilterArgs, Error, FilterFactory, ReadContext, ReadResponse, WriteContext, WriteResponse,
 };
 use crate::extensions::Filter;
 
@@ -115,12 +114,12 @@ impl FilterFactory for DebugFactory {
 }
 
 impl Filter for Debug {
-    fn on_downstream_receive(&self, ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
         info!(self.log, "on local receive"; "from" => ctx.from, "contents" => packet_to_string(ctx.contents.clone()));
         Some(ctx.into())
     }
 
-    fn on_upstream_receive(&self, ctx: UpstreamContext) -> Option<UpstreamResponse> {
+    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
         info!(self.log, "received endpoint packet"; "endpoint" => ctx.endpoint.address,
         "from" => ctx.from,
         "to" => ctx.to,
@@ -143,23 +142,20 @@ mod tests {
     use serde_yaml::Mapping;
     use serde_yaml::Value;
 
-    use crate::test_utils::{
-        assert_filter_on_downstream_receive_no_change, assert_filter_on_upstream_receive_no_change,
-        logger,
-    };
+    use crate::test_utils::{assert_filter_read_no_change, assert_write_no_change, logger};
 
     use super::*;
 
     #[test]
-    fn on_downstream_receive() {
+    fn read() {
         let df = Debug::new(&logger(), None);
-        assert_filter_on_downstream_receive_no_change(&df);
+        assert_filter_read_no_change(&df);
     }
 
     #[test]
-    fn on_upstream_receive() {
+    fn write() {
         let df = Debug::new(&logger(), None);
-        assert_filter_on_upstream_receive_no_change(&df);
+        assert_write_no_change(&df);
     }
 
     #[test]

--- a/src/extensions/filters/load_balancer/mod.rs
+++ b/src/extensions/filters/load_balancer/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::UpstreamEndpoints;
 use crate::extensions::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
+    CreateFilterArgs, Error, Filter, FilterFactory, ReadContext, ReadResponse,
 };
 
 /// Policy represents how a [`LoadBalancerFilter`] distributes
@@ -126,7 +126,7 @@ impl FilterFactory for LoadBalancerFilterFactory {
 }
 
 impl Filter for LoadBalancerFilter {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         self.endpoint_chooser.choose_endpoints(&mut ctx.endpoints);
         Some(ctx.into())
     }
@@ -139,7 +139,7 @@ mod tests {
 
     use crate::cluster::Endpoint;
     use crate::config::Endpoints;
-    use crate::extensions::filter_registry::DownstreamContext;
+    use crate::extensions::filter_registry::ReadContext;
     use crate::extensions::filters::load_balancer::LoadBalancerFilterFactory;
     use crate::extensions::{CreateFilterArgs, Filter, FilterFactory};
 
@@ -157,7 +157,7 @@ mod tests {
         input_addresses: &[SocketAddr],
     ) -> Vec<SocketAddr> {
         filter
-            .on_downstream_receive(DownstreamContext::new(
+            .read(ReadContext::new(
                 Endpoints::new(
                     input_addresses
                         .iter()

--- a/src/extensions/filters/local_rate_limit/mod.rs
+++ b/src/extensions/filters/local_rate_limit/mod.rs
@@ -24,7 +24,7 @@ use tokio::time::{self, Instant};
 
 use metrics::Metrics;
 
-use crate::extensions::filter_registry::{CreateFilterArgs, DownstreamContext, DownstreamResponse};
+use crate::extensions::filter_registry::{CreateFilterArgs, ReadContext, ReadResponse};
 use crate::extensions::{Error, Filter, FilterFactory};
 
 mod metrics;
@@ -189,7 +189,7 @@ impl Drop for RateLimitFilter {
 }
 
 impl Filter for RateLimitFilter {
-    fn on_downstream_receive(&self, ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
         self.acquire_token().map(|()| ctx.into()).or_else(|| {
             self.metrics.packets_dropped_total.inc();
             None
@@ -206,11 +206,11 @@ mod tests {
 
     use crate::cluster::Endpoint;
     use crate::config::Endpoints;
-    use crate::extensions::filter_registry::DownstreamContext;
+    use crate::extensions::filter_registry::ReadContext;
     use crate::extensions::filters::local_rate_limit::metrics::Metrics;
     use crate::extensions::filters::local_rate_limit::{Config, RateLimitFilter};
     use crate::extensions::Filter;
-    use crate::test_utils::assert_filter_on_upstream_receive_no_change;
+    use crate::test_utils::assert_write_no_change;
 
     fn rate_limiter(config: Config) -> RateLimitFilter {
         RateLimitFilter::new(config, Metrics::new(&Registry::default()).unwrap())
@@ -292,11 +292,11 @@ mod tests {
         });
 
         // Check that other routes are not affected.
-        assert_filter_on_upstream_receive_no_change(&r);
+        assert_write_no_change(&r);
 
         // Check that we're rate limited.
         assert!(r
-            .on_downstream_receive(DownstreamContext::new(
+            .read(ReadContext::new(
                 Endpoints::new(vec![Endpoint::from_address(
                     "127.0.0.1:8080".parse().unwrap(),
                 )])
@@ -316,7 +316,7 @@ mod tests {
         });
 
         let result = r
-            .on_downstream_receive(DownstreamContext::new(
+            .read(ReadContext::new(
                 Endpoints::new(vec![Endpoint::from_address(
                     "127.0.0.1:8080".parse().unwrap(),
                 )])
@@ -331,6 +331,6 @@ mod tests {
         assert_eq!(None, r.acquire_token());
 
         // Check that other routes are not affected.
-        assert_filter_on_upstream_receive_no_change(&r);
+        assert_write_no_change(&r);
     }
 }

--- a/src/extensions/filters/token_router/mod.rs
+++ b/src/extensions/filters/token_router/mod.rs
@@ -20,8 +20,8 @@ use slog::{error, o, Logger};
 use crate::extensions::filters::token_router::metrics::Metrics;
 use crate::extensions::filters::CAPTURED_BYTES;
 use crate::extensions::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
-    UpstreamContext, UpstreamResponse,
+    CreateFilterArgs, Error, Filter, FilterFactory, ReadContext, ReadResponse, WriteContext,
+    WriteResponse,
 };
 
 mod metrics;
@@ -99,7 +99,7 @@ impl TokenRouter {
 }
 
 impl Filter for TokenRouter {
-    fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         match ctx.metadata.get(self.metadata_key.as_str()) {
             None => {
                 error!(self.log, "Filter configuration issue: token not found";
@@ -125,7 +125,7 @@ impl Filter for TokenRouter {
         }
     }
 
-    fn on_upstream_receive(&self, ctx: UpstreamContext) -> Option<UpstreamResponse> {
+    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
         Some(ctx.into())
     }
 }
@@ -138,7 +138,7 @@ mod tests {
     use serde_yaml::{Mapping, Value};
 
     use crate::config::Endpoints;
-    use crate::test_utils::{assert_filter_on_upstream_receive_no_change, logger};
+    use crate::test_utils::{assert_write_no_change, logger};
 
     use super::*;
     use crate::cluster::Endpoint;
@@ -168,7 +168,7 @@ mod tests {
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(TOKEN_KEY.into(), Box::new(b"123".to_vec()));
-        assert_on_downstream_receive(filter.deref(), ctx);
+        assert_read(filter.deref(), ctx);
     }
 
     #[test]
@@ -182,7 +182,7 @@ mod tests {
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Box::new(b"123".to_vec()));
-        assert_on_downstream_receive(filter.deref(), ctx);
+        assert_read(filter.deref(), ctx);
     }
 
     #[test]
@@ -195,7 +195,7 @@ mod tests {
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Box::new(b"123".to_vec()));
-        assert_on_downstream_receive(filter.deref(), ctx);
+        assert_read(filter.deref(), ctx);
     }
 
     #[test]
@@ -209,40 +209,40 @@ mod tests {
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Box::new(b"123".to_vec()));
-        assert_on_downstream_receive(&filter, ctx);
+        assert_read(&filter, ctx);
 
         // invalid key
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Box::new(b"567".to_vec()));
 
-        let option = filter.on_downstream_receive(ctx);
+        let option = filter.read(ctx);
         assert!(option.is_none());
         assert_eq!(1, filter.metrics.packets_dropped_no_endpoint_match.get());
 
         // no key
         let ctx = new_ctx();
-        assert!(filter.on_downstream_receive(ctx).is_none());
+        assert!(filter.read(ctx).is_none());
         assert_eq!(1, filter.metrics.packets_dropped_no_token_found.get());
 
         // wrong type key
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Box::new(String::from("wrong")));
-        assert!(filter.on_downstream_receive(ctx).is_none());
+        assert!(filter.read(ctx).is_none());
         assert_eq!(1, filter.metrics.packets_dropped_invalid_token.get());
     }
 
     #[test]
-    fn on_upstream_receive() {
+    fn write() {
         let config = Config {
             metadata_key: CAPTURED_BYTES.into(),
         };
         let filter = router(config);
-        assert_filter_on_upstream_receive_no_change(&filter);
+        assert_write_no_change(&filter);
     }
 
-    fn new_ctx() -> DownstreamContext {
+    fn new_ctx() -> ReadContext {
         let endpoint1 = Endpoint::new(
             "127.0.0.1:80".parse().unwrap(),
             vec!["123".into()].into_iter().collect(),
@@ -254,18 +254,18 @@ mod tests {
             None,
         );
 
-        DownstreamContext::new(
+        ReadContext::new(
             Endpoints::new(vec![endpoint1, endpoint2]).unwrap().into(),
             "127.0.0.1:100".parse().unwrap(),
             b"hello".to_vec(),
         )
     }
 
-    fn assert_on_downstream_receive<F>(filter: &F, ctx: DownstreamContext)
+    fn assert_read<F>(filter: &F, ctx: ReadContext)
     where
         F: Filter + ?Sized,
     {
-        let result = filter.on_downstream_receive(ctx).unwrap();
+        let result = filter.read(ctx).unwrap();
 
         assert_eq!(b"hello".to_vec(), result.contents);
         assert_eq!(1, result.endpoints.size());

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -19,8 +19,8 @@ use slog::Logger;
 pub(crate) use filter_chain::CreateFilterError;
 pub use filter_chain::FilterChain;
 pub use filter_registry::{
-    CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
-    FilterRegistry, UpstreamContext, UpstreamResponse,
+    CreateFilterArgs, Error, Filter, FilterFactory, FilterRegistry, ReadContext, ReadResponse,
+    WriteContext, WriteResponse,
 };
 
 pub(crate) mod filter_manager;

--- a/src/proxy/server/mod.rs
+++ b/src/proxy/server/mod.rs
@@ -30,7 +30,7 @@ use metrics::Metrics as ProxyMetrics;
 use crate::cluster::cluster_manager::SharedClusterManager;
 use crate::cluster::Endpoint;
 use crate::config::{Config, Source};
-use crate::extensions::{DownstreamContext, Filter, FilterChain, FilterRegistry};
+use crate::extensions::{Filter, FilterChain, FilterRegistry, ReadContext};
 use crate::proxy::server::error::Error;
 use crate::proxy::sessions::{
     Packet, Session, SESSION_EXPIRY_POLL_INTERVAL, SESSION_TIMEOUT_SECONDS,
@@ -351,11 +351,7 @@ impl Server {
             let filter_manager_guard = args.filter_manager.read();
             filter_manager_guard.get_filter_chain()
         };
-        let result = filter_chain.on_downstream_receive(DownstreamContext::new(
-            endpoints,
-            recv_addr,
-            packet.to_vec(),
-        ));
+        let result = filter_chain.read(ReadContext::new(endpoints, recv_addr, packet.to_vec()));
 
         if let Some(response) = result {
             for endpoint in response.endpoints.iter() {

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -189,8 +189,7 @@ mod tests {
     use super::ListenerManager;
     use crate::extensions::filter_manager::ListenerManagerArgs;
     use crate::extensions::{
-        CreateFilterArgs, DownstreamContext, DownstreamResponse, Error, Filter, FilterFactory,
-        FilterRegistry,
+        CreateFilterArgs, Error, Filter, FilterFactory, FilterRegistry, ReadContext, ReadResponse,
     };
     use crate::test_utils::logger;
     use crate::xds::envoy::config::listener::v3::{
@@ -220,7 +219,7 @@ mod tests {
     }
 
     impl Filter for Append {
-        fn on_downstream_receive(&self, mut ctx: DownstreamContext) -> Option<DownstreamResponse> {
+        fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
             ctx.contents = format!(
                 "{}{}",
                 String::from_utf8(ctx.contents).unwrap(),
@@ -349,7 +348,7 @@ mod tests {
 
         // Test the new filter chain's functionality. It should append to payloads.
         let response = filter_chain
-            .on_downstream_receive(DownstreamContext::new(
+            .read(ReadContext::new(
                 UpstreamEndpoints::from(
                     Endpoints::new(vec![Endpoint::from_address(
                         "127.0.0.1:8080".parse().unwrap(),
@@ -466,7 +465,7 @@ mod tests {
 
             // Test the new filter chain's functionality.
             let response = filter_chain
-                .on_downstream_receive(DownstreamContext::new(
+                .read(ReadContext::new(
                     UpstreamEndpoints::from(
                         Endpoints::new(vec![Endpoint::from_address(
                             "127.0.0.1:8080".parse().unwrap(),

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -91,13 +91,13 @@ mod tests {
         assert_eq!(
             2,
             result.matches("odr").count(),
-            "Should be 2 on_downstream_receive calls in {}",
+            "Should be 2 read calls in {}",
             result
         );
         assert_eq!(
             2,
             result.matches("our").count(),
-            "Should be 2 on_upstream_receive calls in {}",
+            "Should be 2 write calls in {}",
             result
         );
     }


### PR DESCRIPTION
Refactor `on_downstream_receive` to `read` and `on_upstream_receive` to `write`, to align with Envoy concepts, and remove confusion about `upstream` and `downstream`.

Also renamed corresponding `Contexts` and `Responses` to align with new `Read` and `Write` terminology as well.

Closes #192