### PR TITLE
Move deny warnings to CI

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
   # that it skips checking some files that were built previously. As a result
   # we run it before other cargo sub-commands to ensure that it checks all files.
   - name: gcr.io/$PROJECT_ID/ci
-    args: ["clippy", "--tests"]
+    args: ["clippy", "--tests", "--", "-D", "warnings"]
     id: clippy
   - name: gcr.io/$PROJECT_ID/ci
     args: ["fmt", "--", "--check"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// Fail the build if clippy finds any warnings.
-#![deny(warnings)]
 // Running external documentation tests depends on the
 // `external_doc` unstable feature only available on a
 // nightly compiler. So we enable the feature only when needed.


### PR DESCRIPTION
What is nice about this is that we deny warnings for the stable version of Rust that we support, and we ignore warnings for the nightly version, which has more changes more often.

Closes #189