### PR TITLE
Expose binary version as debug/release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "quilkin"
-version = "0.1.0"
+version = "0.1.0-dev"
 authors = ["Mark Mandel <markmandel@google.com>", "Ifeanyi Ubah <ifeanyi.ubah@embark-studios.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,24 @@ use tokio::sync::watch;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+#[cfg(debug_assertions)]
+fn version() -> String {
+    format!("{}+debug", VERSION)
+}
+
+#[cfg(not(debug_assertions))]
+fn version() -> String {
+    VERSION.into()
+}
+
 #[tokio::main]
 async fn main() {
+    let version = version();
     let base_logger = logger();
     let log = base_logger.new(o!("source" => "main"));
 
     let matches = App::new("Quilkin Proxy")
-        .version("0.1.0")
+        .version(version.as_str())
         .about("Quilkin is a non-transparent UDP proxy specifically designed for use with large scale multiplayer dedicated game servers")
         .arg(clap::Arg::with_name("filename")
             .short("f")
@@ -47,7 +58,7 @@ async fn main() {
         .get_matches();
 
     let filename = matches.value_of("filename").unwrap();
-    info!(log, "Starting Quilkin"; "version" => VERSION);
+    info!(log, "Starting Quilkin"; "version" => version);
 
     let config = Arc::new(Config::from_reader(File::open(filename).unwrap()).unwrap());
     let server = Builder::from(config)


### PR DESCRIPTION
This does several things around managing the binary version and it's exposure when executed:

1. Consolidates the single source of truth for the version number be stored in the Cargo.toml.
1. Added a "-dev" prefix to the current version. Part of the release process will be to file a PR to remove this. This ensures it's always clear which builds are dev and which are releases.
1. Adds the +debug version [build metadata](https://semver.org/#spec-item-10) to the debug build version of Quilkin.