### PR TITLE
Add /live health endpoint to admin server

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -14,6 +14,13 @@ admin:
 
 The admin interface provides the following endpoints:
 
+## /live
+
+This provides a liveness probe endpoint, most commonly used in 
+[Kubernetes based systems](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command).
+
+Will return an HTTP status of 200 when all health checks pass.
+
 ## /metrics
 
 Outputs [Prometheus](https://prometheus.io/) formatted metrics for this proxy.

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -33,7 +33,7 @@ use crate::config::{
 };
 use crate::extensions::{default_registry, CreateFilterError, FilterChain, FilterRegistry};
 use crate::proxy::server::metrics::Metrics as ProxyMetrics;
-use crate::proxy::{Admin as ProxyAdmin, Metrics, Server};
+use crate::proxy::{Admin as ProxyAdmin, Health, Metrics, Server};
 
 pub(super) enum ValidatedSource {
     Static {
@@ -120,7 +120,8 @@ impl From<Arc<Config>> for Builder<PendingValidation> {
     fn from(config: Arc<Config>) -> Self {
         let log = logger();
         let metrics = Arc::new(Metrics::new(&log, Registry::default()));
-        let admin = ProxyAdmin::new(&log, config.admin.address, metrics.clone());
+        let health = Health::new(&log);
+        let admin = ProxyAdmin::new(&log, config.admin.address, metrics.clone(), health);
         Builder {
             config,
             filter_registry: default_registry(&log),

--- a/src/proxy/health.rs
+++ b/src/proxy/health.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+use std::sync::atomic::AtomicBool;
+
+use hyper::{Body, Response, StatusCode};
+use slog::{error, o, Logger};
+use std::panic;
+use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+
+pub struct Health {
+    log: Logger,
+    healthy: Arc<AtomicBool>,
+}
+
+impl Health {
+    pub fn new(base: &Logger) -> Self {
+        let health = Self {
+            log: base.new(o!("source" => "proxy::Health")),
+            healthy: Arc::new(AtomicBool::new(true)),
+        };
+
+        let log = health.log.clone();
+        let healthy = health.healthy.clone();
+        let default_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |panic_info| {
+            error!(log, "Panic has occurred. Moving to Unhealthy");
+            healthy.swap(false, Relaxed);
+            default_hook(panic_info);
+        }));
+
+        health
+    }
+
+    /// returns a HTTP 200 response if the proxy is healthy.
+    pub fn check_healthy(&self) -> Response<Body> {
+        if self.healthy.load(Relaxed) {
+            return Response::new("ok".into());
+        };
+
+        let mut response = Response::new(Body::empty());
+        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::proxy::health::Health;
+    use crate::test_utils::logger;
+    use hyper::StatusCode;
+    use std::panic;
+
+    #[test]
+    fn panic_hook() {
+        let log = logger();
+        let health = Health::new(&log);
+
+        let response = health.check_healthy();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let _ = panic::catch_unwind(|| {
+            panic!("oh no!");
+        });
+
+        let response = health.check_healthy();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -16,11 +16,13 @@
 
 pub(crate) use admin::Admin;
 pub use builder::{logger, Builder, PendingValidation, Validated};
+pub(crate) use health::Health;
 pub(crate) use metrics::Metrics;
 pub use server::Server;
 
 mod admin;
 mod builder;
+mod health;
 mod metrics;
 mod server;
 mod sessions;

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2021 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[cfg(test)]
+mod tests {
+    use quilkin::config::{Admin, Builder, EndPoint};
+    use quilkin::proxy::Builder as ProxyBuilder;
+    use quilkin::test_utils::TestHelper;
+    use std::panic;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn health_server() {
+        let mut t = TestHelper::default();
+
+        // create server configuration
+        let server_port = 12349;
+        let server_config = Builder::empty()
+            .with_port(server_port)
+            .with_static(vec![], vec![EndPoint::new("127.0.0.1:0".parse().unwrap())])
+            .with_admin(Admin {
+                address: "[::]:9093".parse().unwrap(),
+            })
+            .build();
+        t.run_server_with_builder(ProxyBuilder::from(Arc::new(server_config)));
+
+        let resp = reqwest::get("http://localhost:9093/live")
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        assert_eq!("ok", resp);
+
+        let _ = panic::catch_unwind(|| {
+            panic!("oh no!");
+        });
+
+        let resp = reqwest::get("http://localhost:9093/live").await.unwrap();
+        assert!(resp.status().is_server_error(), "Should be unhealthy");
+    }
+}


### PR DESCRIPTION
Create a `Health` module which tracks if a panic occurs anywhere in the code base (which may or may not be on the main thread),
and moves the system to unhealthy.

In the future we could add extra checks to this module as we discover more things that impact proxy health.

Closes #73