### PR TITLE
Usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ Not to be used in production systems.
 
 ## Usage
 
-`quilkin --filename="configuration.yaml"`
-
 * Start with our [Project Overview](./docs/README.md).
+* See how to [use Quilkin](./docs/using.md).
 * View [example integration architectures](./docs/integrations.md).
 * Quickstart: [Quilkin with netcat](docs/quickstart-netcat.md).
 * See the [examples](./examples) folder for configuration and usage examples.
@@ -47,21 +46,6 @@ Participation in this project comes under the [Contributor Covenant Code of Cond
 Please read the [contributing](CONTRIBUTING.md) guide for directions on writing code and submitting Pull Requests.
 
 Quilkin is in active development - we would love your help in shaping its future!
-
-## Building
-
-To build a binary of Quilkin on your operating system of choice, first clone the repository.
-
-```shell script
-git clone https://github.com/googleforgames/quilkin.git
-cd quilkin
-git submodule update --init --recursive
-```
-We use several submodules, so make sure you have them downloaded and updated.
-
-To build a production release version of the binary:
-
-`cargo build --release`
 
 ## Community
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,6 @@ Quilkin incorporates these abilities:
 
 ## What Next?
 
+* Read the [usage guide](./using.md)
 * Have a look at the [example configurations](../examples) for basic configuration examples.
 * Check out the [example integration patterns](./integrations.md).
-* Review the [set of filters](./extensions/filters/filters.md) that are available.

--- a/docs/using.md
+++ b/docs/using.md
@@ -1,0 +1,48 @@
+# Using Quilkin
+
+There are two choices for running Quilkin:
+
+* Binary
+* Container image
+
+For each version there is both a release version, which is optimised for production usage, and a debug version that 
+has debug level logging enabled.
+
+## Binary
+
+The release binary can be downloaded from the 
+[Github releases page](https://github.com/googleforgames/quilkin/releases).
+
+Quilkin needs to be run with an accompanying [configuration file](./proxy-configuration.md), like so:
+
+`quilkin --filename="configuration.yaml"`
+
+If you require debug output, you can run the same command can be run with the `quilkin-debug` binary.
+
+You can also use the shorthand of `-f` instead of `--filename` if you so desire.
+
+## Container Image
+
+For each release, there are both a release and debug container image built and hosted on Google Cloud 
+[Artifact Registry](https://cloud.google.com/artifact-registry) listed for 
+each [release](https://github.com/googleforgames/quilkin/releases).
+
+The production release can be found under the tag: 
+
+`us-docker.pkg.dev/quilkin/release/quilkin:{version}`
+
+Whereas, if you need debugging logging, use the following tag:
+
+`us-docker.pkg.dev/quilkin/release/quilkin:{version}-debug`
+
+Mount your [configuration file](./proxy-configuration.md) at `/etc/quilkin/quilkin.yaml` to configure the Quilkin 
+instance inside the container.
+
+A [default configuration](https://github.com/googleforgames/quilkin/blob/examples/agones-sidecar/build/release/quilkin.yaml)
+is provided, such the container will start without a new configuration file, but it is configured to point to 
+`127.0.0.1:0` as a no-op configuration.
+
+What's next:
+
+* Run through the [netcat with Quilkin quickstart](./quickstart-netcat.md)
+* Review our [example integration architectures](./integrations.md)


### PR DESCRIPTION
Includes documentation for execution of the release binaries and docker images.

This also includes removing this from the README.md page, as well as the build information (which is still in CONTRIBUTING.md), as the target for the documentation is based around the release binaries for the upcoming alpha release.