### PR TITLE
Point COC contact to a Google Group.

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -40,7 +40,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders
-responsible for enforcement at [markmandel@google.com](mailto:markmandel@google.com). All complaints will be
+responsible for enforcement at [quilkin-coc@googlegroups.com](mailto:quilkin-coc@googlegroups.com). All complaints will be
 reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.


### PR DESCRIPTION
Realised the CoC was still pointing to my email address. Moving it to a Google Group.