### PR TITLE
WIP: Add wasmtime filter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+[workspace]
+members = [".", "wasm"]
+
 [package]
 name = "quilkin"
 version = "0.1.0-dev"
@@ -53,6 +56,7 @@ tonic = "0.4.0"
 uuid = {version = "0.8.1", default-features = false, features = ["v4"]}
 snap = "1.0.3"
 tokio-stream = "0.1.2"
+wasmtime = { version = "0.26.0", optional = false }
 
 [dev-dependencies]
 reqwest = "0.11.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.47.0"
+channel = "1.51.0"
 components = ["rustfmt", "clippy"]

--- a/src/extensions/filters/mod.rs
+++ b/src/extensions/filters/mod.rs
@@ -23,6 +23,8 @@ pub use debug::DebugFactory;
 pub use load_balancer::LoadBalancerFilterFactory;
 pub use local_rate_limit::RateLimitFilterFactory;
 pub use token_router::TokenRouterFactory;
+//#[cfg(feature = "wasmtime")]
+pub use self::wasmtime::WasmtimeFactory;
 
 mod capture_bytes;
 mod compress;
@@ -31,6 +33,8 @@ mod debug;
 mod load_balancer;
 mod local_rate_limit;
 mod token_router;
+//#[cfg(feature = "wasmtime")]
+mod wasmtime;
 
 pub const CAPTURED_BYTES: &str = "quilkin.dev/captured_bytes";
 

--- a/src/extensions/filters/wasmtime.rs
+++ b/src/extensions/filters/wasmtime.rs
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 Google LLC All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::extensions::filter_registry::{
+    CreateFilterArgs, Error, FilterFactory, ReadContext, ReadResponse, WriteContext, WriteResponse,
+};
+use crate::extensions::Filter;
+use wasmtime::*;
+
+const WASM: &[u8] = include_bytes!("./../../../target/wasm32-unknown-unknown/debug/quilkin_wasm.wasm");
+
+/// Factory for the Debug
+pub struct WasmtimeFactory {
+    engine: Engine,
+}
+
+impl WasmtimeFactory {
+    pub fn new() -> Self {
+        let mut config = Config::default();
+        config.wasm_reference_types(true);
+        let engine = Engine::new(&config).unwrap();
+
+        Self { engine }
+    }
+}
+
+impl FilterFactory for WasmtimeFactory {
+    fn name(&self) -> String {
+        "quilkin.extensions.filters.wasmtime.v1alpha1.Wasmtime".into()
+    }
+
+    fn create_filter(&self, _args: CreateFilterArgs) -> Result<Box<dyn Filter>, Error> {
+        Ok(Box::new(Wasmtime::new(self.engine.clone(), WASM)))
+    }
+}
+
+/// Debug logs all incoming and outgoing packets
+pub struct Wasmtime {
+    engine: Engine,
+    module: Module,
+}
+
+impl Wasmtime {
+    /// Constructor for the Debug. Pass in a "id" to append a string to your log messages from this
+    /// Filter.
+    fn new(engine: Engine, wat: &[u8]) -> Self {
+        let module = Module::from_binary(&engine, wat).unwrap();
+
+        Self {
+            engine,
+            module,
+        }
+    }
+
+    unsafe fn _get_memory(&self, instance: &Instance, ptr: *const u8, len: usize) -> Result<Vec<u8>, ()> {
+        let memory = instance.get_memory("memory").unwrap();
+        let raw = memory.data_ptr().offset(*ptr as isize);
+        Ok(Vec::from_raw_parts(raw, len, len))
+    }
+
+    /// Copy a byte array into an instance's linear memory
+    /// and return the offset relative to the module's memory.
+    fn copy_memory(&self, instance: &Instance, bytes: &Vec<u8>) -> Result<isize, ()> {
+        let memory = instance.get_memory("memory").unwrap();
+        // Get the guest's exported alloc function, and call it with the
+        // length of the byte array we are trying to copy.
+        // The result is an offset relative to the module's linear memory,
+        // which is used to copy the bytes into the module's memory.
+        // Then, return the offset.
+        let alloc = instance
+            .get_typed_func::<i32, i32>("alloc")
+            .expect("expected alloc function not found");
+        let guest_ptr_offset = alloc.call(bytes.len() as i32).unwrap() as isize;
+
+        unsafe {
+            let raw = memory.data_ptr().offset(guest_ptr_offset);
+            raw.copy_from(bytes.as_ptr(), bytes.len());
+        }
+
+        return Ok(guest_ptr_offset);
+    }
+}
+
+impl Filter for Wasmtime {
+    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
+        let store = Store::new(&self.engine);
+        let instance = Instance::new(&store, &self.module, &[]).unwrap();
+        let ptr = self.copy_memory(&instance, &ctx.contents).unwrap();
+        let func = instance.get_typed_func::<(i32, i32), i32>("read").unwrap();
+        let result = func.call((ptr as i32, ctx.contents.len() as i32)).unwrap();
+        (result != 0).then(|| ctx.into())
+    }
+
+    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
+        let store = Store::new(&self.engine);
+        let instance = Instance::new(&store, &self.module, &[]).unwrap();
+        let ptr = self.copy_memory(&instance, &ctx.contents).unwrap();
+        let func = instance.get_typed_func::<(i32, i32), i32>("write").unwrap();
+        let result = func.call((ptr as i32, ctx.contents.len() as i32)).unwrap();
+        (result != 0).then(|| ctx.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::{assert_filter_read_no_change, assert_write_no_change};
+
+    use super::*;
+
+    #[test]
+    fn read() {
+        let wasmtime = Wasmtime::new(Engine::default(), WASM);
+        assert_filter_read_no_change(&wasmtime);
+    }
+
+    #[test]
+    fn write() {
+        let wasmtime = Wasmtime::new(Engine::default(), WASM);
+        assert_write_no_change(&wasmtime);
+    }
+}

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "quilkin-wasm"
+version = "0.1.0"
+authors = ["Erin Power <erin.power@embark-studios.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,29 @@
+#[no_mangle]
+pub extern "C" fn alloc(len: usize) -> *mut u8 {
+    let mut buf = Vec::with_capacity(len);
+    let ptr = buf.as_mut_ptr();
+    std::mem::forget(buf);
+    return ptr;
+}
+
+#[no_mangle]
+#[doc(hidden)]
+pub unsafe extern "C" fn dealloc(ptr: *mut u8, size: usize) {
+    let align = std::mem::align_of::<usize>();
+    let layout = std::alloc::Layout::from_size_align_unchecked(size, align);
+    std::alloc::dealloc(ptr, layout);
+}
+
+#[no_mangle]
+pub extern "C" fn read(ptr: *mut u8, size: usize) -> bool {
+    let contents = unsafe { std::str::from_utf8(std::slice::from_raw_parts(ptr, size)).unwrap() };
+
+    contents == "hello"
+}
+
+#[no_mangle]
+pub extern "C" fn write(ptr: *mut u8, size: usize) -> bool {
+    let contents = unsafe { std::str::from_utf8(std::slice::from_raw_parts(ptr, size)).unwrap() };
+
+    contents == "hello"
+}


### PR DESCRIPTION
Inspired by #13, I was wondering how hard it might be to support WebAssembly, as then we can support multiple languages, have a very secure sandbox, has async support for #12 if we wanted the scripts running async, and wasmtime has interesting options for controlling it's machinery such as [`fuel`](https://docs.rs/wasmtime/0.26.0/wasmtime/struct.Config.html#method.consume_fuel) that would allow control over how long scriptable filters can run.
 
This PR doesn't implement any of that currently, it's just a proof of concept of a filter that passes the contents of a packet to a WebAssembly module containing a `read` and `write` function, executes the relevant function, and if it returns `true`, the filter continues, else it returns `None`. Since WebAssembly Interface Types aren't available yet, you need to use pointers or a serialisation step for passing complex data between the host and the module so I held off on doing that.

If you want to test this locally you have to first build the included WebAssembly crate with the following command. I wrote it in Rust for obvious reasons, but this could be anything really.

```
rustup target add wasm32-unknown-unknown
cargo build -p quilkin-wasm --target=wasm32-unknown-unknown
```