### PR TITLE
Add execution measurement metrics to `FilterChain`

### DIFF
--- a/docs/extensions/filters/filters.md
+++ b/docs/extensions/filters/filters.md
@@ -30,6 +30,18 @@ There are a few things we note here:
 
 * Exactly one filter chain is specified and used to process all packets that flow through Quilkin.
 
+**Metrics**
+
+* `filter_read_duration_seconds` The duration it took for a `filter`'s
+  `read` implementation to execute.
+  * Labels
+    * `filter` The name of the filter being executed.
+
+* `filter_write_duration_seconds` The duration it took for a `filter`'s
+  `write` implementation to execute.
+  * Labels
+    * `filter` The name of the filter being executed.
+
 ### Configuration Examples ###
 
 ```rust

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -16,7 +16,7 @@
 
 use slog::Logger;
 
-pub(crate) use filter_chain::CreateFilterError;
+pub(crate) use filter_chain::Error as FilterChainError;
 pub use filter_chain::FilterChain;
 pub use filter_registry::{
     ConfigType, CreateFilterArgs, Error, Filter, FilterFactory, FilterRegistry, ReadContext,

--- a/src/extensions/filter_manager.rs
+++ b/src/extensions/filter_manager.rs
@@ -149,7 +149,9 @@ mod tests {
 
     #[tokio::test]
     async fn dynamic_filter_manager_update_filter_chain() {
-        let filter_manager = FilterManager::fixed(Arc::new(FilterChain::new(vec![])));
+        let registry = prometheus::Registry::default();
+        let filter_manager =
+            FilterManager::fixed(Arc::new(FilterChain::new(vec![], &registry).unwrap()));
         let (filter_chain_updates_tx, filter_chain_updates_rx) = mpsc::channel(10);
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
 
@@ -183,7 +185,8 @@ mod tests {
                 None
             }
         }
-        let filter_chain = Arc::new(FilterChain::new(vec![Box::new(Drop)]));
+        let filter_chain =
+            Arc::new(FilterChain::new(vec![("Drop".into(), Box::new(Drop))], &registry).unwrap());
         assert!(filter_chain_updates_tx.send(filter_chain).await.is_ok());
 
         let mut num_iterations = 0;
@@ -218,7 +221,9 @@ mod tests {
     async fn dynamic_filter_manager_shutdown_task_on_shutdown_signal() {
         // Test that we shut down the background task if we receive a shutdown signal.
 
-        let filter_manager = FilterManager::fixed(Arc::new(FilterChain::new(vec![])));
+        let registry = prometheus::Registry::default();
+        let filter_manager =
+            FilterManager::fixed(Arc::new(FilterChain::new(vec![], &registry).unwrap()));
         let (filter_chain_updates_tx, filter_chain_updates_rx) = mpsc::channel(10);
         let (shutdown_tx, shutdown_rx) = watch::channel(());
 
@@ -237,7 +242,7 @@ mod tests {
 
         // Send a filter chain update on the channel. This should fail
         // since the listening task should have shut down.
-        let filter_chain = Arc::new(FilterChain::new(vec![]));
+        let filter_chain = Arc::new(FilterChain::new(vec![], &registry).unwrap());
         assert!(filter_chain_updates_tx.send(filter_chain).await.is_err());
     }
 }

--- a/src/extensions/filters.rs
+++ b/src/extensions/filters.rs
@@ -59,8 +59,11 @@ impl fmt::Display for ConvertProtoConfigError {
 }
 
 impl ConvertProtoConfigError {
-    pub fn new(reason: String, field: Option<String>) -> Self {
-        Self { reason, field }
+    pub fn new(reason: impl Into<String>, field: Option<String>) -> Self {
+        Self {
+            reason: reason.into(),
+            field,
+        }
     }
 }
 

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -31,7 +31,7 @@ use crate::config::{
     parse_endpoint_metadata_from_yaml, Config, Endpoints, ManagementServer, Proxy, Source,
     ValidationError, ValueInvalidArgs,
 };
-use crate::extensions::{default_registry, CreateFilterError, FilterChain, FilterRegistry};
+use crate::extensions::{default_registry, FilterChain, FilterChainError, FilterRegistry};
 use crate::proxy::server::metrics::Metrics as ProxyMetrics;
 use crate::proxy::sessions::metrics::Metrics as SessionMetrics;
 use crate::proxy::{Admin as ProxyAdmin, Health, Metrics, Server};
@@ -57,7 +57,7 @@ pub(super) struct ValidatedConfig {
 #[derive(Debug)]
 pub enum Error {
     InvalidConfig(ValidationError),
-    CreateFilterChain(CreateFilterError),
+    CreateFilterChain(FilterChainError),
 }
 
 impl std::error::Error for Error {}
@@ -68,8 +68,8 @@ impl From<ValidationError> for Error {
     }
 }
 
-impl From<CreateFilterError> for Error {
-    fn from(err: CreateFilterError) -> Self {
+impl From<FilterChainError> for Error {
+    fn from(err: FilterChainError) -> Self {
         Error::CreateFilterChain(err)
     }
 }

--- a/src/proxy/sessions/session_manager.rs
+++ b/src/proxy/sessions/session_manager.rs
@@ -128,7 +128,6 @@ mod tests {
     use crate::proxy::sessions::metrics::Metrics;
     use crate::proxy::sessions::session_manager::Sessions;
     use crate::proxy::sessions::{Packet, Session};
-    use crate::proxy::Metrics as ProxyMetrics;
     use crate::test_utils::TestHelper;
 
     use super::SessionManager;
@@ -160,13 +159,14 @@ mod tests {
 
         // Insert key.
         {
+            let registry = Registry::default();
             let mut sessions = sessions.write().await;
             sessions.insert(
                 key,
                 Session::new(
                     &t.log,
-                    Metrics::new(&ProxyMetrics::new(&t.log, Registry::default()).registry).unwrap(),
-                    FilterManager::fixed(Arc::new(FilterChain::new(vec![]))),
+                    Metrics::new(&registry).unwrap(),
+                    FilterManager::fixed(Arc::new(FilterChain::new(vec![], &registry).unwrap())),
                     from,
                     endpoint.clone(),
                     send,
@@ -220,13 +220,14 @@ mod tests {
         let ttl = Duration::from_secs(1);
 
         {
+            let registry = Registry::default();
             let mut sessions = sessions.write().await;
             sessions.insert(
                 key,
                 Session::new(
                     &t.log,
-                    Metrics::new(&ProxyMetrics::new(&t.log, Registry::default()).registry).unwrap(),
-                    FilterManager::fixed(Arc::new(FilterChain::new(vec![]))),
+                    Metrics::new(&registry).unwrap(),
+                    FilterManager::fixed(Arc::new(FilterChain::new(vec![], &registry).unwrap())),
                     from,
                     endpoint.clone(),
                     send,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -27,8 +27,8 @@ use tokio::sync::{mpsc, oneshot, watch};
 use crate::cluster::Endpoint;
 use crate::config::{Builder as ConfigBuilder, Config, EndPoint, Endpoints};
 use crate::extensions::{
-    CreateFilterArgs, Error, Filter, FilterFactory, ReadContext, ReadResponse, WriteContext,
-    WriteResponse,
+    CreateFilterArgs, Error, Filter, FilterChain, FilterFactory, ReadContext, ReadResponse,
+    WriteContext, WriteResponse,
 };
 use crate::proxy::{Builder, PendingValidation};
 
@@ -313,6 +313,16 @@ pub fn config_with_dummy_endpoint() -> ConfigBuilder {
 /// Creates a dummy endpoint with `id` as a suffix.
 pub fn ep(id: u8) -> EndPoint {
     EndPoint::new(format!("127.0.0.{:?}:8080", id).parse().unwrap())
+}
+
+pub fn new_test_chain(registry: &prometheus::Registry) -> Arc<FilterChain> {
+    Arc::new(
+        FilterChain::new(
+            vec![("TestFilter".into(), Box::new(TestFilter {}))],
+            registry,
+        )
+        .unwrap(),
+    )
 }
 
 #[cfg(test)]

--- a/src/xds/error.rs
+++ b/src/xds/error.rs
@@ -24,3 +24,19 @@ impl Error {
         Error { message }
     }
 }
+
+impl From<prometheus::Error> for Error {
+    fn from(error: prometheus::Error) -> Self {
+        Self {
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<crate::extensions::FilterChainError> for Error {
+    fn from(error: crate::extensions::FilterChainError) -> Self {
+        Self {
+            message: error.to_string(),
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a measure filter that accepts any filter and measure each of its operations. Since this is the first nested filter there were a couple of other changes needed.

- ConcatBytes's filter and config are now public. This is in order to construct the filter statically in the tests.  I think we should probably have these public for all filters so that they can be easily construct-able statically when using `quilkin` as a library.
- `FilterRegistry` is now `Arc<RwLock<HashMap<K, RwLock<V>>` to make it concurrent safe and cheaply clone-able.
- `quilkin::run` now accepts a closure that passes in a `FilterRegistry`, this is to allow you to construct filters like `MeasureFactory` which requires access to the `FilterRegistry`.

resolves #167 