### PR TITLE
Remove `name` from all examples and configurations

### DIFF
--- a/build/release/quilkin.yaml
+++ b/build/release/quilkin.yaml
@@ -17,5 +17,4 @@
 version: v1alpha1
 static:
   endpoints:
-    - name: noop
-      address: 127.0.0.1:0
+    - address: 127.0.0.1:0

--- a/examples/agones-xonotic/client-compress.yaml
+++ b/examples/agones-xonotic/client-compress.yaml
@@ -23,5 +23,4 @@ static:
         on_write: DECOMPRESS
         mode: SNAPPY
   endpoints:
-    - name: xonotic
-      address: ${GAMESERVER_IP}:${GAMESERVER_PORT}
+    - address: ${GAMESERVER_IP}:${GAMESERVER_PORT}

--- a/examples/agones-xonotic/sidecar-compress.yaml
+++ b/examples/agones-xonotic/sidecar-compress.yaml
@@ -31,8 +31,7 @@ data:
               on_write: COMPRESS
               mode: SNAPPY
       endpoints:
-        - name: xonotic
-          address: 127.0.0.1:26000
+        - address: 127.0.0.1:26000
 ---
 apiVersion: "agones.dev/v1"
 kind: Fleet

--- a/examples/agones-xonotic/sidecar.yaml
+++ b/examples/agones-xonotic/sidecar.yaml
@@ -25,8 +25,7 @@ data:
       port: 26001
     static:
       endpoints:
-        - name: xonotic
-          address: 127.0.0.1:26000
+        - address: 127.0.0.1:26000
 ---
 apiVersion: "agones.dev/v1"
 kind: Fleet

--- a/examples/iperf3/proxy.yaml
+++ b/examples/iperf3/proxy.yaml
@@ -24,5 +24,4 @@ proxy:
   port: 8000
 static:
   endpoints:
-    - name: iperf3 client
-      address: 127.0.0.1:8001
+    - address: 127.0.0.1:8001

--- a/examples/proxy.yaml
+++ b/examples/proxy.yaml
@@ -24,15 +24,13 @@ proxy:
   port: 7001 # the port to receive traffic to locally
 static: # Provide static configuration of endpoints
   endpoints: # array of potential endpoints to send on traffic to
-    - name: Game Server No. 1
-      address: 127.0.0.1:26000
+    - address: 127.0.0.1:26000
       metadata: # Metadata associated with the endpoint
         quilkin.dev:
           tokens:
             - MXg3aWp5Ng== # the connection byte array to route to, encoded as base64 (string value: 1x7ijy6)
             - OGdqM3YyaQ== # (string value: 8gj3v2i)
-    - name: Game Server No. 2
-      address: 127.0.0.1:26001
+    - address: 127.0.0.1:26001
       metadata: # Metadata associated with the endpoint
         quilkin.dev:
           tokens:


### PR DESCRIPTION
Since we removed `name` from Endpoint configs, this broke all our examples, and the default configuration for the Docker image.

This fixes these issues 😊