### PR TITLE
Add Prometheus scraping to Xonotic example

### DIFF
--- a/examples/agones-xonotic/README.md
+++ b/examples/agones-xonotic/README.md
@@ -30,3 +30,9 @@ locally as:
 From there connect to the local client proxy on "127.0.0.1:7000" via the "Multiplayer > Address" field in the 
 Xonotic client, and Quilkin will take care of compressing the data for you without having to change either the 
 client or the dedicated game server.
+
+## Metrics
+
+The Quilkin sidecars are also annotated with the 
+[appropriate Prometheus annotations](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus#scraping-pod-metrics-via-annotations)
+to inform Prometheus on how to scrape the Quilkin proxies for metrics.

--- a/examples/agones-xonotic/sidecar-compress.yaml
+++ b/examples/agones-xonotic/sidecar-compress.yaml
@@ -50,6 +50,11 @@ spec:
         initialDelaySeconds: 30
         periodSeconds: 60
       template:
+        metadata:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9091"
         spec:
           containers:
             - name: xonotic

--- a/examples/agones-xonotic/sidecar.yaml
+++ b/examples/agones-xonotic/sidecar.yaml
@@ -44,6 +44,11 @@ spec:
         initialDelaySeconds: 30
         periodSeconds: 60
       template:
+        metadata:
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/path: /metrics
+            prometheus.io/port: "9091"
         spec:
           containers:
             - name: xonotic


### PR DESCRIPTION
Adds the appropriate annotations to the Xonotic example to show how one can scrape Quilkin for metrics.

Work on #234