### PR TITLE
Fix for Apache Licence header

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/about.toml
+++ b/about.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build/ci/buildstep/Dockerfile
+++ b/build/ci/buildstep/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/ci/buildstep/Makefile
+++ b/build/ci/buildstep/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/ci/buildstep/cloudbuild.yaml
+++ b/build/ci/buildstep/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/ci/github-bot/Makefile
+++ b/build/ci/github-bot/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/ci/github-bot/cloudbuild.yaml
+++ b/build/ci/github-bot/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/ci/github-bot/go.mod
+++ b/build/ci/github-bot/go.mod
@@ -1,4 +1,4 @@
-// Copyright 2021 Google LLC All Rights Reserved.
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build/ci/github-bot/main.go
+++ b/build/ci/github-bot/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build/release/Dockerfile.builder
+++ b/build/release/Dockerfile.builder
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/release/Dockerfile.release
+++ b/build/release/Dockerfile.release
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/release/Makefile
+++ b/build/release/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/release/archive_dependencies.sh
+++ b/build/release/archive_dependencies.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/release/cloudbuild.yaml
+++ b/build/release/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/release/quilkin.yaml
+++ b/build/release/quilkin.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/agones-xonotic/client-compress.yaml
+++ b/examples/agones-xonotic/client-compress.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/agones-xonotic/sidecar-compress.yaml
+++ b/examples/agones-xonotic/sidecar-compress.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/agones-xonotic/sidecar.yaml
+++ b/examples/agones-xonotic/sidecar.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/control-plane.yaml
+++ b/examples/control-plane.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/iperf3/.gitignore
+++ b/examples/iperf3/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/iperf3/clean.sh
+++ b/examples/iperf3/clean.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/iperf3/proxy.yaml
+++ b/examples/iperf3/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/iperf3/run.sh
+++ b/examples/iperf3/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/proxy.yaml
+++ b/examples/proxy.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 Google LLC All Rights Reserved.
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quilkin-filter-example/.gitignore
+++ b/examples/quilkin-filter-example/.gitignore
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quilkin-filter-example/Cargo.toml
+++ b/examples/quilkin-filter-example/Cargo.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quilkin-filter-example/build.rs
+++ b/examples/quilkin-filter-example/build.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/quilkin-filter-example/config.yaml
+++ b/examples/quilkin-filter-example/config.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/quilkin-filter-example/src/greet.proto
+++ b/examples/quilkin-filter-example/src/greet.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/license.csv.hbs
+++ b/license.csv.hbs
@@ -1,5 +1,5 @@
 {{!
-Copyright 2021 Google LLC All Rights Reserved.
+Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/license.html.hbs
+++ b/license.html.hbs
@@ -1,5 +1,5 @@
 <!--
-Copyright 2021 Google LLC All Rights Reserved.
+Copyright 2021 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/macros/src/filter.rs
+++ b/macros/src/filter.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/macros/src/include.rs
+++ b/macros/src/include.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/quilkin/extensions/filters/capture_bytes/v1alpha1/capture_bytes.proto
+++ b/proto/quilkin/extensions/filters/capture_bytes/v1alpha1/capture_bytes.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/quilkin/extensions/filters/compress/v1alpha1/compress.proto
+++ b/proto/quilkin/extensions/filters/compress/v1alpha1/compress.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/quilkin/extensions/filters/concatenate_bytes/v1alpha1/concatenate_bytes.proto
+++ b/proto/quilkin/extensions/filters/concatenate_bytes/v1alpha1/concatenate_bytes.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/quilkin/extensions/filters/debug/v1alpha1/debug.proto
+++ b/proto/quilkin/extensions/filters/debug/v1alpha1/debug.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/quilkin/extensions/filters/load_balancer/v1alpha1/load_balancer.proto
+++ b/proto/quilkin/extensions/filters/load_balancer/v1alpha1/load_balancer.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/quilkin/extensions/filters/local_rate_limit/v1alpha1/local_rate_limit.proto
+++ b/proto/quilkin/extensions/filters/local_rate_limit/v1alpha1/local_rate_limit.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/quilkin/extensions/filters/token_router/v1alpha1/token_router.proto
+++ b/proto/quilkin/extensions/filters/token_router/v1alpha1/token_router.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC All Rights Reserved.
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/cluster/cluster_manager.rs
+++ b/src/cluster/cluster_manager.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/cluster/metrics.rs
+++ b/src/cluster/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/config/endpoints.rs
+++ b/src/config/endpoints.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/config/metadata.rs
+++ b/src/config/metadata.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/extensions/filter_registry.rs
+++ b/src/extensions/filter_registry.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/config.rs
+++ b/src/filters/config.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/error.rs
+++ b/src/filters/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions.rs
+++ b/src/filters/extensions.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/capture_bytes.rs
+++ b/src/filters/extensions/capture_bytes.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/capture_bytes/metrics.rs
+++ b/src/filters/extensions/capture_bytes/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/capture_bytes/proto.rs
+++ b/src/filters/extensions/capture_bytes/proto.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/compress.rs
+++ b/src/filters/extensions/compress.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/compress/metrics.rs
+++ b/src/filters/extensions/compress/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/compress/proto.rs
+++ b/src/filters/extensions/compress/proto.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/concatenate_bytes.rs
+++ b/src/filters/extensions/concatenate_bytes.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/debug.rs
+++ b/src/filters/extensions/debug.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/load_balancer.rs
+++ b/src/filters/extensions/load_balancer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/load_balancer/proto.rs
+++ b/src/filters/extensions/load_balancer/proto.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/local_rate_limit.rs
+++ b/src/filters/extensions/local_rate_limit.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/local_rate_limit/metrics.rs
+++ b/src/filters/extensions/local_rate_limit/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/local_rate_limit/proto.rs
+++ b/src/filters/extensions/local_rate_limit/proto.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/token_router.rs
+++ b/src/filters/extensions/token_router.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/token_router/metrics.rs
+++ b/src/filters/extensions/token_router/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/extensions/token_router/proto.rs
+++ b/src/filters/extensions/token_router/proto.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/factory.rs
+++ b/src/filters/factory.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/manager.rs
+++ b/src/filters/manager.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/read.rs
+++ b/src/filters/read.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/set.rs
+++ b/src/filters/set.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/filters/write.rs
+++ b/src/filters/write.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/admin.rs
+++ b/src/proxy/admin.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/health.rs
+++ b/src/proxy/health.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/metrics.rs
+++ b/src/proxy/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/server/error.rs
+++ b/src/proxy/server/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/server/metrics.rs
+++ b/src/proxy/server/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/server/resource_manager.rs
+++ b/src/proxy/server/resource_manager.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/sessions/error.rs
+++ b/src/proxy/sessions/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/sessions/metrics.rs
+++ b/src/proxy/sessions/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/sessions/session.rs
+++ b/src/proxy/sessions/session.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/proxy/sessions/session_manager.rs
+++ b/src/proxy/sessions/session_manager.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/utils/debug.rs
+++ b/src/utils/debug.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/xds/ads_client.rs
+++ b/src/xds/ads_client.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/xds/cluster.rs
+++ b/src/xds/cluster.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/xds/error.rs
+++ b/src/xds/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/xds/metadata.rs
+++ b/src/xds/metadata.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/xds/metrics.rs
+++ b/src/xds/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Google LLC All Rights Reserved.
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/xds.rs
+++ b/tests/xds.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC All Rights Reserved.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Apparently I applied the Apache header licence wrong to everything, so this is a fix for that so that now everything has the correct details.