### PR TITLE
Use `thiserror` for Error definitions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tokio = { version = "1.1.0", features = ["rt-multi-thread", "signal", "test-util
 tokio-stream = "0.1.2"
 tonic = "0.4.0"
 uuid = {version = "0.8.1", default-features = false, features = ["v4"]}
+thiserror = "1.0.25"
 
 [dev-dependencies]
 reqwest = "0.11.0"

--- a/src/cluster/cluster_manager.rs
+++ b/src/cluster/cluster_manager.rs
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 // We use a parking_lot since it's significantly faster under low contention
 // and we will need to acquire a read lock with every packet that is processed
 // to be able to capture the current endpoint state and pass it to Filters.
 use parking_lot::RwLock;
 use slog::{debug, o, warn, Logger};
-use std::{fmt, sync::Arc};
 
 use prometheus::{Registry, Result as MetricsResult};
 use tokio::sync::{mpsc, watch};
@@ -40,18 +41,11 @@ pub(crate) struct ClusterManager {
 
 /// InitializeError is returned with an error message if the
 /// [`ClusterManager`] fails to initialize properly.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum InitializeError {
+    #[error("{:?}", .0)]
     Message(String),
 }
-
-impl fmt::Display for InitializeError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", format!("{:?}", self))
-    }
-}
-
-impl std::error::Error for InitializeError {}
 
 impl ClusterManager {
     fn new(metrics_registry: &Registry, endpoints: Option<Endpoints>) -> MetricsResult<Self> {

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-use std::fmt::{self, Formatter};
-
 use prometheus::{Error as PrometheusError, Histogram, HistogramOpts, Registry};
 
 use crate::config::{Filter as FilterConfig, ValidationError};
@@ -36,24 +34,15 @@ pub struct FilterChain {
     filter_write_duration_seconds: Vec<Histogram>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("{}", .0)]
     Prometheus(PrometheusError),
+    #[error("failed to create filter {}: {}", filter_name, error)]
     Filter {
         filter_name: String,
         error: ValidationError,
     },
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Prometheus(error) => f.write_str(&error.to_string()),
-            Self::Filter { filter_name, error } => {
-                write!(f, "failed to create filter {}: {}", filter_name, error,)
-            }
-        }
-    }
 }
 
 impl From<PrometheusError> for Error {

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -14,13 +14,7 @@
  *  limitations under the License.
  */
 
-use std::collections::HashSet;
-use std::convert::TryInto;
-use std::marker::PhantomData;
-use std::{
-    fmt::{self, Formatter},
-    sync::Arc,
-};
+use std::{collections::HashSet, convert::TryInto, marker::PhantomData, sync::Arc};
 
 use prometheus::Registry;
 use slog::{o, Drain, Logger};
@@ -54,13 +48,13 @@ pub(super) struct ValidatedConfig {
 }
 
 /// Represents an error that occurred while validating and building a server.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("invalid config: {}", .0)]
     InvalidConfig(ValidationError),
+    #[error("failed to create filter chain: {}", .0)]
     CreateFilterChain(FilterChainError),
 }
-
-impl std::error::Error for Error {}
 
 impl From<ValidationError> for Error {
     fn from(err: ValidationError) -> Self {
@@ -71,19 +65,6 @@ impl From<ValidationError> for Error {
 impl From<FilterChainError> for Error {
     fn from(err: FilterChainError) -> Self {
         Error::CreateFilterChain(err)
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::InvalidConfig(source) => write!(f, "invalid config: {}", format!("{}", source)),
-            Error::CreateFilterChain(source) => write!(
-                f,
-                "failed to create filter chain: {}",
-                format!("{}", source)
-            ),
-        }
     }
 }
 

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -545,7 +545,7 @@ mod tests {
                         value: vec![],
                     })),
                 }])],
-                "filter MissingFilter is not found",
+                "filter `MissingFilter` not found",
             ),
             (
                 // Multiple filter chains.


### PR DESCRIPTION
I know in #269 I advocated for `snafu`, but now I am of the mind that we only need `thiserror` to generate the `Display` and `Error` impls. Its proc-macro is more powerful than `snafu`'s and this would allow us to add `eyre` later for better backtraces and such.

closes #269 