### PR TITLE
Cleanup other parts of the public API.

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -31,7 +31,7 @@ static SERVER_INIT: Lazy<()> = Lazy::new(|| {
                 )],
             )
             .build();
-        let server = quilkin::proxy::Builder::from(std::sync::Arc::new(config))
+        let server = quilkin::Builder::from(std::sync::Arc::new(config))
             .validate()
             .unwrap()
             .build();

--- a/docs/extensions/filters/capture_bytes.md
+++ b/docs/extensions/filters/capture_bytes.md
@@ -30,7 +30,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 
 `[[TODO: update/link to routing examples once they are complete]]`

--- a/docs/extensions/filters/compress.md
+++ b/docs/extensions/filters/compress.md
@@ -24,7 +24,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 
 The above example shows a proxy that could be used with a typical game client, where the original client data is 

--- a/docs/extensions/filters/concatenate_bytes.md
+++ b/docs/extensions/filters/concatenate_bytes.md
@@ -24,7 +24,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 
 ### Configuration Options

--- a/docs/extensions/filters/debug.md
+++ b/docs/extensions/filters/debug.md
@@ -23,7 +23,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 
 ### Configuration Options

--- a/docs/extensions/filters/filters.md
+++ b/docs/extensions/filters/filters.md
@@ -65,7 +65,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 2);
-# quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 }
 ```
 

--- a/docs/extensions/filters/load_balancer.md
+++ b/docs/extensions/filters/load_balancer.md
@@ -23,7 +23,7 @@ static:
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-#   quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+#   quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 # }
 ```
 

--- a/docs/extensions/filters/local_rate_limit.md
+++ b/docs/extensions/filters/local_rate_limit.md
@@ -26,7 +26,7 @@ static:
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-#   quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+#   quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 # }
 ```
 To configure a rate limiter, we specify the maximum rate at which the proxy is allowed to forward packets. In the example above, we configured the proxy to forward a maximum of 1000 packets per 500ms (2000 packets/second).

--- a/docs/extensions/filters/token_router.md
+++ b/docs/extensions/filters/token_router.md
@@ -35,7 +35,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 
 View the [CaptureBytes](./capture_bytes.md) filter documentation for more details.
@@ -102,7 +102,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 2);
-# quilkin::proxy::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 
 On the game client side the [ConcatenateBytes](./concatenate_bytes.md) filter could also be used to add authentication

--- a/docs/extensions/filters/writing_custom_filters.md
+++ b/docs/extensions/filters/writing_custom_filters.md
@@ -109,7 +109,7 @@ To extend Quilkin's code with our own custom filter, we need to do the following
 
 1. **Start the proxy**
 
-   We can run the proxy in the exact manner as the default Quilkin binary using the [runner] module, passing in our custom [FilterFactory].
+   We can run the proxy in the exact manner as the default Quilkin binary using the [run] function, passing in our custom [FilterFactory].
    Lets add a main function that does that. Quilkin relies on the [Tokio] async runtime so we need to import that crate and wrap our main function with it.
 
    Add Tokio as a dependency in `Cargo.toml`.
@@ -133,7 +133,7 @@ To extend Quilkin's code with our own custom filter, we need to do the following
    #         unimplemented!()
    #     }
    # }
-   use quilkin::{filters::DynFilterFactory, runner::run};
+   use quilkin::{filters::DynFilterFactory, run};
 
    #[tokio::main]
    async fn main() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Quilkin configuration.
+
 use std::net::SocketAddr;
 
 use base64_serde::base64_serde_type;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,11 +18,22 @@ mod cluster;
 pub mod config;
 pub mod filters;
 pub(crate) mod metrics;
-pub mod proxy;
-pub mod runner;
-pub mod test_utils;
+mod proxy;
+mod runner;
 pub(crate) mod utils;
 pub(crate) mod xds;
+
+#[doc(hidden)]
+pub mod test_utils;
+
+pub type Result<T, E = runner::Error> = std::result::Result<T, E>;
+
+#[doc(inline)]
+pub use self::{
+    config::Config,
+    proxy::{logger, Builder, PendingValidation, Server, Validated},
+    runner::{run, run_with_config},
+};
 
 pub use quilkin_macros::include_proto;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,11 @@
 
 use std::sync::Arc;
 
-use quilkin::runner;
-
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[tokio::main]
-async fn main() -> Result<(), quilkin::runner::Error> {
-    let log = quilkin::proxy::logger();
+async fn main() -> quilkin::Result<()> {
+    let log = quilkin::logger();
     let version: std::borrow::Cow<'static, str> = if cfg!(debug_assertions) {
         format!("{}+debug", VERSION).into()
     } else {
@@ -46,5 +44,5 @@ async fn main() -> Result<(), quilkin::runner::Error> {
 
     let config = quilkin::config::Config::find(&log, matches.value_of("config")).map(Arc::new)?;
 
-    runner::run_with_config(log, config, vec![]).await
+    quilkin::run_with_config(log, config, vec![]).await
 }

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -277,6 +277,8 @@ impl Builder<Validated> {
     }
 }
 
+/// Create a new `slog::Logger` instance using the default
+/// quilkin configuration.
 pub fn logger() -> Logger {
     let drain = slog_json::Json::new(std::io::stdout())
         .set_pretty(false)

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -18,16 +18,20 @@ extern crate quilkin;
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::Arc,
+    };
 
     use serde_yaml::{Mapping, Value};
     use slog::info;
 
-    use quilkin::config::{Builder as ConfigBuilder, EndPoint, Filter};
-    use quilkin::filters::debug;
-    use quilkin::proxy::Builder as ProxyBuilder;
-    use quilkin::test_utils::{new_registry, TestHelper};
-    use std::sync::Arc;
+    use quilkin::{
+        config::{Builder as ConfigBuilder, EndPoint, Filter},
+        filters::debug,
+        test_utils::{new_registry, TestHelper},
+        Builder as ProxyBuilder,
+    };
 
     #[tokio::test]
     async fn test_filter() {

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -17,8 +17,8 @@
 #[cfg(test)]
 mod tests {
     use quilkin::config::{Admin, Builder, EndPoint};
-    use quilkin::proxy::Builder as ProxyBuilder;
     use quilkin::test_utils::TestHelper;
+    use quilkin::Builder as ProxyBuilder;
     use std::panic;
     use std::sync::Arc;
 

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -23,8 +23,8 @@ mod tests {
     use slog::info;
 
     use quilkin::config::{Admin, Builder as ConfigBuilder, EndPoint};
-    use quilkin::proxy::Builder;
     use quilkin::test_utils::TestHelper;
+    use quilkin::Builder;
     use std::sync::Arc;
 
     #[tokio::test]

--- a/tests/xds.rs
+++ b/tests/xds.rs
@@ -15,14 +15,9 @@
  */
 
 #[allow(warnings)]
-mod xds {
-    pub mod core {
-        pub mod v3 {
-            #![doc(hidden)]
-            tonic::include_proto!("xds.core.v3");
-        }
-    }
-}
+quilkin::include_proto!("xds.core.v3");
+#[allow(warnings)]
+quilkin::include_proto!("google.rpc");
 
 #[allow(warnings)]
 mod envoy {
@@ -109,14 +104,6 @@ mod envoy {
 }
 
 #[allow(warnings)]
-mod google {
-    pub mod rpc {
-        #![doc(hidden)]
-        tonic::include_proto!("google.rpc");
-    }
-}
-
-#[allow(warnings)]
 mod quilkin_proto {
     pub mod extensions {
         pub mod filters {
@@ -129,8 +116,6 @@ mod quilkin_proto {
         }
     }
 }
-
-extern crate quilkin;
 
 #[cfg(test)]
 mod tests {
@@ -158,8 +143,8 @@ mod tests {
     };
 
     use quilkin::config::Config;
-    use quilkin::proxy::Builder;
     use quilkin::test_utils::{logger, TestHelper};
+    use quilkin::Builder;
 
     use prost::Message;
     use slog::{info, o, Logger};


### PR DESCRIPTION
This now makes the `proxy` and `runner` private modules as they don't really provide much for users of the library as the `proxy` and the `runner` could both be considered Quilkin. So their types are now exported at the top-level. So instead of `quilkin::runner::run(…)` it's `quilkin::run(…)` for "running Quilkin", and it's `quilkin::Builder` instead of `quilkin::proxy::Builder`, as you're building a Quilkin server. This is how the top-level docs looks like with these changes.


<img width="1010" alt="Screenshot 2021-06-30 at 09 37 01" src="https://user-images.githubusercontent.com/4464295/123946611-b256ea00-d99f-11eb-9902-8d2db254ba2e.png">
