### PR TITLE
Exclude items from crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ readme = "README.md"
 keywords = ["proxy", "game-server", "game-development", "networking", "multiplayer"]
 categories = ["game-development", "network-programming"]
 edition = "2018"
+exclude = ["docs", "build", "examples", "image"]
 
 [dependencies]
 # Local


### PR DESCRIPTION
Since we have several directories that (a) aren't needed for the crate and (b) have some images and other larger items in them, let's exclude them from the crate.

Work on #232