### PR TITLE
Tweaks to release checklist.

### DIFF
--- a/build/templates/release-issue.md
+++ b/build/templates/release-issue.md
@@ -24,21 +24,19 @@
     [archive_dependencies.sh](https://github.com/googleforgames/quilkin/blob/main/build/release/archive_dependencies.sh) 
     so that the source is archived in the container image.
     - [ ] Reset checklist back to "run `make` to submit the cloud build", and start from there again.
+- [ ] Run `cd macros && cargo publish --dry-run` and ensure there are no issues.
+- [ ] Run `cargo publish --dry-run` and ensure there are no issues.  
 - [ ] Submit these changes as a PR, and merge with approval.
 - [ ] Create a [Github release](https://github.com/googleforgames/quilkin/releases/new) using the 
   [Github release template](./github-release.md).
-    - [ ] Populate the tag with `v{version}`.
+    - [ ] Populate the tag with `v{version}`, description, and relevant changelog sections.
     - [ ] Attach all the remaining cloud build artifacts to the release.
-- [ ] Submit the release.
 - [ ] Run `git remote update && git checkout main && git reset --hard upstream/main` to ensure your code is in line
       with upstream.
 - [ ] Run `git checkout -b release-{version} && git push upstream` to create a release branch.
-- [ ] Publish to [crates.io/crates/quilkin-macros](https://crates.io/crates/quilkin-macros)
-  - [ ] Run `cd macros && cargo publish --dry-run` to ensure there are no issues.
-  - [ ] If there are no issues, run `cd macros && cargo publish` to publish to crates.io!
-- [ ] Publish to [crates.io/crates/quilkin](https://crates.io/crates/quilkin)
-    - [ ] Run `cargo publish --dry-run` to ensure there are no issues.
-    - [ ] If there are no issues, run `cargo publish` to publish to crates.io!
+- [ ] Publish to [crates.io/crates/quilkin-macros](https://crates.io/crates/quilkin-macros): run `cd macros && cargo publish`
+- [ ] Publish to [crates.io/crates/quilkin](https://crates.io/crates/quilkin): run `cargo publish`
+- [ ] Submit the release.
 - [ ] Post an announcement to the [mailing list](https://groups.google.com/g/quilkin-discuss).
 - [ ] Post to the [Twitter account](https://twitter.com/quilkindev).
 - [ ] Update Cargo version for development


### PR DESCRIPTION
I realised that the checks for issues with `cargo publish` should occur before the PR's to update version numbers, so that it can be fixed in that pull request.

Also realised that publishing to crates.io should happen before submitting the release on github, just in case something goes wrong, the release is not stuck in a half-released state.

I figure the ordering for our first release may get tweaked as needed (see #313), but I think this should work for general releases.