### PR TITLE
Make `Filter` an `async trait`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ tokio-stream = "0.1.2"
 tonic = "0.5.0"
 uuid = {version = "0.8.1", default-features = false, features = ["v4"]}
 thiserror = "1.0.25"
+async-trait = "0.1.50"
 
 [dev-dependencies]
 reqwest = "0.11.0"

--- a/docs/extensions/filters/writing_custom_filters.md
+++ b/docs/extensions/filters/writing_custom_filters.md
@@ -73,12 +73,13 @@ To extend Quilkin's code with our own custom filter, we need to do the following
    // to `"greet.v1"`.
    struct Greet;
 
+   #[async_trait::async_trait]
    impl Filter for Greet {
-       fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+       async fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
            ctx.contents.splice(0..0, String::from("Hello ").into_bytes());
            Some(ctx.into())
        }
-       fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+       async fn write(&self, mut ctx: WriteContext<'async_trait>) -> Option<WriteResponse> {
            ctx.contents.splice(0..0, String::from("Goodbye ").into_bytes());
            Some(ctx.into())
        }
@@ -210,13 +211,14 @@ The [Serde] crate is used to describe static YAML configuration in code while [P
 
    struct Greet(String);
 
+   #[async_trait::async_trait]
    impl Filter for Greet {
-       fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+       async fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
            ctx.contents
                .splice(0..0, format!("{} ",self.0).into_bytes());
            Some(ctx.into())
        }
-       fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+       async fn write(&self, mut ctx: WriteContext<'async_trait>) -> Option<WriteResponse> {
            ctx.contents
                .splice(0..0, format!("{} ",self.0).into_bytes());
            Some(ctx.into())

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -37,13 +37,14 @@ pub fn factory() -> DynFilterFactory {
 
 struct Greet(String);
 
+#[async_trait::async_trait]
 impl Filter for Greet {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+    async fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         ctx.contents
             .splice(0..0, format!("{} ", self.0).into_bytes());
         Some(ctx.into())
     }
-    fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+    async fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
         ctx.contents
             .splice(0..0, format!("{} ", self.0).into_bytes());
         Some(ctx.into())

--- a/src/extensions/filter_registry.rs
+++ b/src/extensions/filter_registry.rs
@@ -192,7 +192,7 @@ pub trait Filter: Send + Sync {
     /// sent (which may be manipulated) as well.
     /// If the packet should be rejected, return None.
     /// By default, passes the context through unchanged
-    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
+    async fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
         Some(ctx.into())
     }
 
@@ -202,7 +202,7 @@ pub trait Filter: Send + Sync {
     /// be sent (which may be manipulated).
     /// If the packet should be rejected, return None.
     /// By default, passes the context through unchanged
-    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
+    async fn write(&self, ctx: WriteContext<'async_trait>) -> Option<WriteResponse> {
         Some(ctx.into())
     }
 }
@@ -385,12 +385,12 @@ mod tests {
 
     struct TestFilter {}
 
-    impl Filter for TestFilter {
-        fn read(&self, _: ReadContext) -> Option<ReadResponse> {
+    #[async_trait::async_trait] impl Filter for TestFilter {
+        async fn read(&self, _: ReadContext) -> Option<ReadResponse> {
             None
         }
 
-        fn write(&self, _: WriteContext) -> Option<WriteResponse> {
+        async fn write(&self, _: WriteContext) -> Option<WriteResponse> {
             None
         }
     }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -77,6 +77,7 @@ pub(crate) use self::chain::FilterChain;
 ///   `write` implementation to execute.
 ///   * Labels
 ///     * `filter` The name of the filter being executed.
+#[async_trait::async_trait]
 pub trait Filter: Send + Sync {
     /// [`Filter::read`] is invoked when the proxy receives data from a
     /// downstream connection on the listening port.
@@ -86,7 +87,7 @@ pub trait Filter: Send + Sync {
     /// be sent (which may be manipulated) as well. If the packet should be
     /// rejected, return [`None`].  By default, the context passes
     /// through unchanged.
-    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
+    async fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
         Some(ctx.into())
     }
 
@@ -97,7 +98,7 @@ pub trait Filter: Send + Sync {
     /// This function should return an [`WriteResponse`] containing the packet to
     /// be sent (which may be manipulated). If the packet should be rejected,
     /// return [`None`]. By default, the context passes through unchanged.
-    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
+    async fn write(&self, ctx: WriteContext<'async_trait>) -> Option<WriteResponse> {
         Some(ctx.into())
     }
 }

--- a/src/filters/concatenate_bytes.rs
+++ b/src/filters/concatenate_bytes.rs
@@ -48,8 +48,9 @@ impl ConcatenateBytes {
     }
 }
 
+#[async_trait::async_trait]
 impl Filter for ConcatenateBytes {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+    async fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         match self.on_read {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());
@@ -63,7 +64,7 @@ impl Filter for ConcatenateBytes {
         Some(ctx.into())
     }
 
-    fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+    async fn write(&self, mut ctx: WriteContext<'async_trait>) -> Option<WriteResponse> {
         match self.on_write {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());

--- a/src/filters/extensions/concatenate_bytes.rs
+++ b/src/filters/extensions/concatenate_bytes.rs
@@ -139,8 +139,9 @@ impl ConcatenateBytes {
     }
 }
 
+#[async_trait::async_trait]
 impl Filter for ConcatenateBytes {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+    async fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         match self.on_read {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());
@@ -154,7 +155,7 @@ impl Filter for ConcatenateBytes {
         Some(ctx.into())
     }
 
-    fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+    async fn write(&self, mut ctx: WriteContext<'async_trait>) -> Option<WriteResponse> {
         match self.on_write {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());

--- a/src/filters/extensions/load_balancer.rs
+++ b/src/filters/extensions/load_balancer.rs
@@ -143,8 +143,9 @@ impl FilterFactory for LoadBalancerFilterFactory {
     }
 }
 
+#[async_trait::async_trait]
 impl Filter for LoadBalancerFilter {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+    async fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
         self.endpoint_chooser.choose_endpoints(&mut ctx.endpoints);
         Some(ctx.into())
     }

--- a/src/filters/manager.rs
+++ b/src/filters/manager.rs
@@ -171,17 +171,20 @@ mod tests {
             "127.0.0.1:8080".parse().unwrap(),
         )])
         .unwrap();
-        let response = filter_chain.read(ReadContext::new(
-            UpstreamEndpoints::from(test_endpoints.clone()),
-            "127.0.0.1:8081".parse().unwrap(),
-            vec![],
-        ));
+        let response = filter_chain
+            .read(ReadContext::new(
+                UpstreamEndpoints::from(test_endpoints.clone()),
+                "127.0.0.1:8081".parse().unwrap(),
+                vec![],
+            ))
+            .await;
         assert!(response.is_some());
 
         // A simple test filter that drops all packets flowing upstream.
         struct Drop;
+        #[async_trait::async_trait]
         impl Filter for Drop {
-            fn read(&self, _: ReadContext) -> Option<ReadResponse> {
+            async fn read(&self, _: ReadContext) -> Option<ReadResponse> {
                 None
             }
         }
@@ -203,6 +206,7 @@ mod tests {
                     "127.0.0.1:8081".parse().unwrap(),
                     vec![],
                 ))
+                .await
                 .is_none()
             {
                 break;

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -67,18 +67,19 @@ mod tests {
 
     struct TestFilter {}
 
+    #[async_trait::async_trait]
     impl Filter for TestFilter {
-        fn read(&self, _: ReadContext) -> Option<ReadResponse> {
+        async fn read(&self, _: ReadContext) -> Option<ReadResponse> {
             None
         }
 
-        fn write(&self, _: WriteContext) -> Option<WriteResponse> {
+        async fn write(&self, _: WriteContext<'async_trait>) -> Option<WriteResponse> {
             None
         }
     }
 
-    #[test]
-    fn insert_and_get() {
+    #[tokio::test]
+    async fn insert_and_get() {
         let reg = new_registry(&logger());
 
         match reg.get(
@@ -116,9 +117,11 @@ mod tests {
                 addr,
                 vec![]
             ))
+            .await
             .is_some());
         assert!(filter
             .write(WriteContext::new(&endpoint, addr, addr, vec![],))
+            .await
             .is_some());
     }
 }

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -335,7 +335,7 @@ impl Server {
         };
         let result = filter_chain.read(ReadContext::new(endpoints, recv_addr, packet));
 
-        if let Some(response) = result {
+        if let Some(response) = result.await {
             for endpoint in response.endpoints.iter() {
                 Self::session_send_packet(
                     &response.contents.as_slice(),

--- a/src/proxy/sessions/session.rs
+++ b/src/proxy/sessions/session.rs
@@ -212,8 +212,9 @@ impl Session {
             let filter_manager_guard = filter_manager.read();
             filter_manager_guard.get_filter_chain()
         };
-        if let Some(response) =
-            filter_chain.write(WriteContext::new(endpoint, from, to, packet.to_vec()))
+        if let Some(response) = filter_chain
+            .write(WriteContext::new(endpoint, from, to, packet.to_vec()))
+            .await
         {
             if let Err(err) = sender.send(Packet::new(to, response.contents)).await {
                 metrics.rx_errors_total.inc();

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -235,8 +235,9 @@ mod tests {
         }
     }
 
+    #[async_trait::async_trait]
     impl Filter for Append {
-        fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+        async fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
             ctx.contents = format!(
                 "{}{}",
                 String::from_utf8(ctx.contents).unwrap(),
@@ -377,6 +378,7 @@ mod tests {
                 "127.0.0.1:8081".parse().unwrap(),
                 "hello-".into(),
             ))
+            .await
             .unwrap();
 
         assert_eq!(
@@ -489,6 +491,7 @@ mod tests {
                     "127.0.0.1:8081".parse().unwrap(),
                     "hello-".into(),
                 ))
+                .await
                 .unwrap();
 
             assert_eq!(


### PR DESCRIPTION
This PR makes the `Filter` trait asynchronous, allowing implementors to insert yield points. It's worth noting that you could always spawn background tasks even before this change it just wouldn't have been useful. This PR doesn't change any behaviour other adding async, but this will also allow us to try things like cancellable, concurrent, and parallel filters.

This is currently built off #293 to reduce merge conflicts, the important work is in  https://github.com/googleforgames/quilkin/commit/7c0d5fd42afae63018debed77f58f1acec4cd204

closes #12 