### PR TITLE
Add `cargo-deny` to CI by adding to `make test`

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -49,6 +49,8 @@ version:
 # Run all tests
 test: ensure-build-image
 	docker run --rm $(common_rust_args) \
+     		--entrypoint=cargo $(BUILD_IMAGE_TAG) deny check
+	docker run --rm $(common_rust_args) \
  		--entrypoint=cargo $(BUILD_IMAGE_TAG) clippy --tests -- -D warnings
 	docker run --rm $(common_rust_args) \
  		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check

--- a/build/README.md
+++ b/build/README.md
@@ -50,6 +50,10 @@ To run our external documentation tests:
 
 `cargo +nightly test --doc`
 
+To test dependency licences and security advisories:
+
+`cargo deny check`
+
 ### Developing with Make + Docker 
 
 There are a few reasons you may want to use the [Make](https://www.gnu.org/software/make/)

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -33,6 +33,7 @@ RUN set -eux && \
     rustup toolchain install nightly && \
     cargo install cross && \
     cargo install cargo-about && \
+    cargo install --locked cargo-deny && \
     rustup --version && \
     cargo --version && \
     rustc --version && \


### PR DESCRIPTION
This adds `cargo-deny` to `make test`, which also makes sure it is run in Cloud Build for continuous integration.

This found a couple of dependencies that need to be updated because of security advisories. These will be updated in a separate PR.

Closes #327