### PR TITLE
Security: Updated tokio + prost-types dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ hyper = "0.14.2"
 num_cpus = "1.13.0"
 parking_lot = "0.11.0"
 prometheus = { version = "0.12", default-features = false }
-prost = "0.7.0"
-prost-types = "0.7.0"
+prost = "0.8.0"
+prost-types = "0.8.0"
 rand = "0.8"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.60"
@@ -58,9 +58,9 @@ slog-async = "2.6.0"
 slog-json = "2.3.0"
 slog-term = "2.5.0"
 snap = "1.0.3"
-tokio = { version = "1.1.0", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
+tokio = { version = "1.8.2", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
 tokio-stream = "0.1.2"
-tonic = "0.4.0"
+tonic = "0.5.0"
 uuid = {version = "0.8.1", default-features = false, features = ["v4"]}
 thiserror = "1.0.25"
 
@@ -69,5 +69,5 @@ reqwest = "0.11.0"
 regex = "1.3.9"
 
 [build-dependencies]
-tonic-build = { version = "0.4.0", default_features = false, features = ["transport", "prost"] }
-prost-build = "0.7.0"
+tonic-build = { version = "0.5.1", default_features = false, features = ["transport", "prost"] }
+prost-build = "0.8.0"

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -92,12 +92,14 @@ mod envoy {
     pub mod service {
         pub mod discovery {
             pub mod v3 {
+                #![allow(clippy::unit_arg)]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.service.discovery.v3");
             }
         }
         pub mod cluster {
             pub mod v3 {
+                #![allow(clippy::unit_arg)]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.service.cluster.v3");
             }

--- a/src/xds/ads_client.rs
+++ b/src/xds/ads_client.rs
@@ -191,8 +191,10 @@ impl AdsClient {
                             backoff = bk_off;
 
                             // Do not retry if this is an invalid URL error that we cannot recover from.
-                            if err.to_string().to_lowercase().contains("invalid url") {
-                                return Err(ExecutionError::Message(format!("{:?}", err)));
+                            // Need to use {:?} as the Display output only returns 'transport error'
+                            let err_description = format!("{:?}", err);
+                            if err_description.to_lowercase().contains("invalid url") {
+                                return Err(ExecutionError::Message(err_description));
                             }
                             error!(log, "Unable to connect to the XDS server"; "address" => server_addr, "error" => %err);
                             Self::backoff(

--- a/tests/xds.rs
+++ b/tests/xds.rs
@@ -92,12 +92,14 @@ mod envoy {
     pub mod service {
         pub mod discovery {
             pub mod v3 {
+                #![allow(clippy::unit_arg)]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.service.discovery.v3");
             }
         }
         pub mod cluster {
             pub mod v3 {
+                #![allow(clippy::unit_arg)]
                 #![doc(hidden)]
                 tonic::include_proto!("envoy.service.cluster.v3");
             }


### PR DESCRIPTION
When running `cargo deny` locally I found security advisories for both tokio and prost-types, so bumped them both up to the latest versions in Cargo.toml, and fixed the issues I found along the way.

Work on #327