### PR TITLE
Documentation snapshot/release README.md section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,18 @@ Project is currently in *alpha* status, and is being actively developed. Expect 
 
 Not to be used in production systems.
 
-## Usage
+## Documentation
+
+### Releases
+
+* v0.1.0 ([guides](https://github.com/googleforgames/quilkin/blob/v0.1.0/README.md#usage), 
+  [api](https://docs.rs/quilkin/0.1.0/quilkin/), [macros](https://docs.rs/quilkin-macros/0.1.0/quilkin_macros/)).
+
+### Usage
+
+> Below is documentation for the development version of Quilkin. To view the documentation for a specific release, 
+> switch to the release tag in the dropdown at the top of the page, or click on the appropriate release documentation 
+> link above.
 
 * Start with our [Project Overview](./docs/README.md).
 * See how to [use Quilkin](./docs/using.md).

--- a/build/templates/release-issue.md
+++ b/build/templates/release-issue.md
@@ -26,6 +26,8 @@
     - [ ] Reset checklist back to "run `make` to submit the cloud build", and start from there again.
 - [ ] Run `cd macros && cargo publish --dry-run --allow-dirty` and ensure there are no issues.
 - [ ] Run `cargo publish --dry-run --allow-dirty` and ensure there are no issues.  
+- [ ] Add a release item to README.md "Documentation" > "Releases" list with related links in reverse chronological 
+  order.
 - [ ] Submit these changes as a PR, and merge with approval.
 - [ ] Create a [Github release](https://github.com/googleforgames/quilkin/releases/new) using the 
   [Github release template](./github-release.md).


### PR DESCRIPTION
Break out a section on the README.md linking to tagged snapshots of documentation, so that as API changes occur it's still easy to see previous API documentation and accompanying guides. It also stops new users from getting confused by in-flight API changes.

I believe this will aso unblock #293 and also remove the requirement to get a 0.1.0 snapshot for #319, which could block other PRs as well.