### PR TITLE
Remove need for nightly in CI and developer guide

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -55,9 +55,7 @@ test: ensure-build-image
 	docker run --rm $(common_rust_args) \
  		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
 	docker run --rm $(common_rust_args) \
-     		--entrypoint=cargo $(BUILD_IMAGE_TAG) test --tests
-	docker run --rm $(common_rust_args) \
-     		--entrypoint=cargo $(BUILD_IMAGE_TAG) +nightly test --doc
+     		--entrypoint=cargo $(BUILD_IMAGE_TAG) test
 
 # Build all binaries, images and related artifacts
 build: binary-archive build-image

--- a/build/README.md
+++ b/build/README.md
@@ -39,16 +39,9 @@ To build a production release, run:
 
 #### Testing
 
-We use some nightly features to automatically test our external documentation, so you will need to be explicit about
-which tests you wish to run.
+To run the unit, integration and docs tests:
 
-To run the unit and integration tests:
-
-`cargo test --tests`
-
-To run our external documentation tests:
-
-`cargo +nightly test --doc`
+`cargo test`
 
 To run our benchmarks:
 

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -30,7 +30,6 @@ RUN set -eux && \
     rm rustup-init && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rustup component add rustfmt clippy && \
-    rustup toolchain install nightly && \
     cargo install cross && \
     cargo install cargo-about && \
     cargo install --locked cargo-deny && \


### PR DESCRIPTION
Now that we've upgraded to rust 1.54.0, we no longer need to use `+nightly` to run our document tests!