### PR TITLE
GH Action: Sizing labels on PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,36 @@
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: labeler
+on:
+  - pull_request_target
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    name: Label the PR size
+    steps:
+      - uses: codelytv/pr-size-labeler@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          xs_max_size: '10'
+          s_max_size: '100'
+          m_max_size: '500'
+          l_max_size: '1000'
+          fail_if_xl: 'false'
+          message_if_xl: >
+            'This PR exceeds the recommended size of 1000 lines.
+            Please make sure you are NOT addressing multiple issues with one PR.
+            Note this PR might be rejected due to its size.’

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !.gitignore
 !.gcloudignore
 !.dockerignore
+!.github
 
 *.iml
 


### PR DESCRIPTION
I miss this from other projects I work on. I find it makes things easier as a reviewer, as you can quickly identify smaller PRs that require less review and get them reviewed fast, and make sure you block out time for the larger submissions.

I do like the touch with this one that it will ping you a reminder that you might want to split up your PR if you are over 1000 lines 🙂