### PR TITLE
Remove initial xds update delay

### DIFF
--- a/docs/using.md
+++ b/docs/using.md
@@ -15,11 +15,11 @@ The release binary can be downloaded from the
 
 Quilkin needs to be run with an accompanying [configuration file](./proxy-configuration.md), like so:
 
-`quilkin --filename="configuration.yaml"`
+`quilkin --config="configuration.yaml"`
 
 If you require debug output, you can run the same command can be run with the `quilkin-debug` binary.
 
-You can also use the shorthand of `-f` instead of `--filename` if you so desire.
+You can also use the shorthand of `-c` instead of `--config` if you so desire.
 
 ## Container Image
 

--- a/src/proxy/server/resource_manager.rs
+++ b/src/proxy/server/resource_manager.rs
@@ -24,9 +24,8 @@ use crate::xds::ads_client::{
     AdsClient, ClusterUpdate, ExecutionResult, UPDATES_CHANNEL_BUFFER_SIZE,
 };
 use prometheus::Registry;
-use slog::{debug, o, warn, Logger};
+use slog::{o, warn, Logger};
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::{mpsc, oneshot, watch};
 
 /// Contains resource managers for fixed cluster/filter etc resources.
@@ -75,12 +74,12 @@ impl DynamicResourceManagers {
         metrics_registry: Registry,
         filter_registry: FilterRegistry,
         management_servers: Vec<ManagementServer>,
-        mut shutdown_rx: watch::Receiver<()>,
+        shutdown_rx: watch::Receiver<()>,
     ) -> Result<DynamicResourceManagers, InitializeError> {
         let log = base_logger.new(o!("source" => "server::DynamicResourceManager"));
 
-        let (cluster_updates_tx, mut cluster_updates_rx) = Self::cluster_updates_channel();
-        let (filter_chain_updates_tx, mut filter_chain_updates_rx) =
+        let (cluster_updates_tx, cluster_updates_rx) = Self::cluster_updates_channel();
+        let (filter_chain_updates_tx, filter_chain_updates_rx) =
             Self::filter_chain_updates_channel();
 
         let listener_manager_args = ListenerManagerArgs::new(
@@ -101,30 +100,9 @@ impl DynamicResourceManagers {
             shutdown_rx: shutdown_rx.clone(),
         })?;
 
-        // Initial cluster warming - wait to receive the initial LDS and CDS resources
-        // from the XDS server before we start receiving any traffic.
-        debug!(log, "Waiting to receive initial cluster update.");
-        let (cluster_update, execution_result_rx) = Self::receive_update(
-            &mut cluster_updates_rx,
-            execution_result_rx,
-            &mut shutdown_rx,
-        )
-        .await?;
-        debug!(log, "Received initial cluster update.");
-
-        debug!(log, "Waiting to receive initial filter chain update.");
-        let (filter_chain_update, execution_result_rx) = Self::receive_update(
-            &mut filter_chain_updates_rx,
-            execution_result_rx,
-            &mut shutdown_rx,
-        )
-        .await?;
-        debug!(log, "Received initial filter chain update.");
-
         let cluster_manager = ClusterManager::dynamic(
             base_logger.new(o!("source" => "ClusterManager")),
             &metrics_registry,
-            cluster_update,
             cluster_updates_rx,
             shutdown_rx.clone(),
         )
@@ -132,10 +110,11 @@ impl DynamicResourceManagers {
 
         let filter_manager = FilterManager::dynamic(
             base_logger.new(o!("source" => "FilterManager")),
-            filter_chain_update,
+            &metrics_registry,
             filter_chain_updates_rx,
-            shutdown_rx.clone(),
-        );
+            shutdown_rx,
+        )
+        .map_err(|err| InitializeError::Message(format!("{:?}", err)))?;
 
         Ok(Self {
             cluster_manager,
@@ -181,39 +160,6 @@ impl DynamicResourceManagers {
         Ok(())
     }
 
-    // Waits until it receives a cluster update from the given channel.
-    // This also takes in the execution result receiver - while we're waiting for
-    // an update, if the client exits prematurely, we return its execution error.
-    async fn receive_update<T>(
-        updates_rx: &mut mpsc::Receiver<T>,
-        execution_result_rx: oneshot::Receiver<ExecutionResult>,
-        shutdown_rx: &mut watch::Receiver<()>,
-    ) -> Result<(T, oneshot::Receiver<ExecutionResult>), InitializeError> {
-        tokio::select! {
-            update = updates_rx.recv() => {
-                match update {
-                    Some(update) => {
-                        Ok((update, execution_result_rx))
-                    }
-                    None => {
-                        // Sender has dropped (the client exited prematurely) - so we can't
-                        // initialize properly.
-                        // Check the client's execution result if exiting was due to some root cause
-                        // error and return that error if so. Otherwise return a generic error.
-                        if let Ok(Ok(Err(execution_error))) = tokio::time::timeout(Duration::from_millis(1000), execution_result_rx).await {
-                            Err(InitializeError::Message(format!("failed to receive initial update: {:?}", execution_error)))
-                        } else {
-                            Err(InitializeError::Message("failed to receive initial update: sender dropped the channel".into()))
-                        }
-                    }
-                }
-            }
-            _ = shutdown_rx.changed() => {
-                Err(InitializeError::Message("failed to receive initial update: received shutdown signal".into()))
-            },
-        }
-    }
-
     fn cluster_updates_channel() -> (mpsc::Sender<ClusterUpdate>, mpsc::Receiver<ClusterUpdate>) {
         mpsc::channel(UPDATES_CHANNEL_BUFFER_SIZE)
     }
@@ -229,11 +175,9 @@ impl DynamicResourceManagers {
 mod tests {
 
     use super::DynamicResourceManagers;
-    use crate::cluster::cluster_manager::InitializeError;
     use crate::config::ManagementServer;
     use crate::filters::{manager::ListenerManagerArgs, FilterRegistry};
     use crate::test_utils::logger;
-    use crate::xds::ads_client::ExecutionError;
 
     use std::time::Duration;
 
@@ -243,97 +187,6 @@ mod tests {
     use tokio::sync::oneshot;
     use tokio::sync::watch;
     use tokio::time;
-
-    #[tokio::test]
-    async fn dynamic_resource_manager_receive_update() {
-        let (updates_tx, mut updates_rx) = mpsc::channel(10);
-        let (_shutdown_tx, mut shutdown_rx) = watch::channel(());
-        let (_execution_tx, execution_result_rx) = oneshot::channel();
-
-        updates_tx.send(42).await.unwrap();
-
-        let (result, _) = DynamicResourceManagers::receive_update(
-            &mut updates_rx,
-            execution_result_rx,
-            &mut shutdown_rx,
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(42, result);
-    }
-
-    #[tokio::test]
-    async fn dynamic_resource_manager_shutdown_task_on_system_shutdown() {
-        // If a shutdown is triggered, shutdown the task.
-        let (_updates_tx, mut updates_rx) = mpsc::channel::<usize>(10);
-        let (shutdown_tx, mut shutdown_rx) = watch::channel(());
-        let (_execution_tx, execution_result_rx) = oneshot::channel();
-
-        // Send a shutdown signal.
-        shutdown_tx.send(()).unwrap();
-
-        // We should exit with an error.
-        let result = DynamicResourceManagers::receive_update(
-            &mut updates_rx,
-            execution_result_rx,
-            &mut shutdown_rx,
-        )
-        .await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn dynamic_resource_manager_shutdown_task_on_sender_half_closed() {
-        // If the sender half of the updates channel is dropped, shutdown the task
-        // since we can never receive an update after that.
-        let (updates_tx, mut updates_rx) = mpsc::channel::<usize>(10);
-        let (_shutdown_tx, mut shutdown_rx) = watch::channel(());
-        let (_execution_tx, execution_result_rx) = oneshot::channel();
-
-        // Drop the sender half.
-        drop(updates_tx);
-
-        // We should exit with an error since we now can never receive an update.
-        let result = DynamicResourceManagers::receive_update(
-            &mut updates_rx,
-            execution_result_rx,
-            &mut shutdown_rx,
-        )
-        .await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn dynamic_resource_manager_return_execution_error_on_sender_half_closed() {
-        // If the sender half of the updates channel is dropped, check the ExecutionResult
-        // channel for any error that might hint at why it was dropped and if one exists,
-        // return it.
-        let (updates_tx, mut updates_rx) = mpsc::channel::<usize>(10);
-        let (_shutdown_tx, mut shutdown_rx) = watch::channel(());
-        let (execution_result_tx, execution_result_rx) = oneshot::channel();
-
-        // Leave an error ExecutionResult before dropping the updates channel.
-        execution_result_tx
-            .send(Err(ExecutionError::Message("Boo!".into())))
-            .unwrap();
-
-        // Drop the sender half of the updates channel.
-        drop(updates_tx);
-
-        // When exiting due to the sending channel being dropped, we first check
-        // for an execution result error and return that instead.
-        match DynamicResourceManagers::receive_update(
-            &mut updates_rx,
-            execution_result_rx,
-            &mut shutdown_rx,
-        )
-        .await
-        {
-            Err(InitializeError::Message(msg)) if msg.contains("Boo!") => {}
-            unexpected => unreachable!(format!("{:?}", unexpected)),
-        }
-    }
 
     #[tokio::test]
     async fn dynamic_resource_manager_return_execution_error() {


### PR DESCRIPTION
We don't need to explicitly wait for an update from the xds server during startup since we will eventually get one.
So instead, allow the proxy to startup immediately.