### PR TITLE
Fix for change: --filename to --config

### DIFF
--- a/docs/src/filters/writing_custom_filters.md
+++ b/docs/src/filters/writing_custom_filters.md
@@ -159,7 +159,7 @@ static:
 ```
 - Start the proxy
   ```bash
-  cargo run -- -f config.yaml
+  cargo run -- -c config.yaml
   ```
 
 - Start a UDP listening server on the configured port

--- a/docs/src/proxy-configuration.md
+++ b/docs/src/proxy-configuration.md
@@ -1,8 +1,11 @@
 Proxy Configuration
 
-The following is the schema and reference for a Quilkin proxy configuration file. See the [examples] folder for example configuration files.
+The following is the schema and reference for a Quilkin proxy configuration file. See the [examples] folder for 
+example configuration files.
 
-By default Quilkin will look for a configuration file named `quilkin.yaml` in its current running directory first, then if not present, in `/etc/quilkin/quilkin.yaml` on UNIX systems. This can be overridden with the `-f/--filename` command-line argument, or the `QUILKIN_FILENAME` environment variable.
+By default Quilkin will look for a configuration file named `quilkin.yaml` in its current running directory first, 
+then if not present, in `/etc/quilkin/quilkin.yaml` on UNIX systems. This can be overridden with the 
+`-c/--config` command-line argument, or the `QUILKIN_FILENAME` environment variable.
 
 ```yaml
 type: object

--- a/docs/src/quickstart-agones-xonotic.md
+++ b/docs/src/quickstart-agones-xonotic.md
@@ -112,7 +112,7 @@ replace the `${GAMESERVER_IP}` and `${GAMESERVER_PORT}` values in your copy of `
 Run this configuration locally as:
 
 ```shell
-quilkin -f ./client-compress.yaml`
+quilkin -c ./client-compress.yaml`
 ```
 
 Now we can connect to the local client proxy on "127.0.0.1:7000" via the "Multiplayer > Address" field in the

--- a/docs/src/quickstart-netcat.md
+++ b/docs/src/quickstart-netcat.md
@@ -38,13 +38,13 @@ a single endpoint of 127.0.0.1, port 8000.
 Let's start Quilkin with the above configuration:
 
 ```shell
-./quilkin --filename proxy.yaml
+./quilkin --config proxy.yaml
 ```
 
 You should see an output like the following:
 
 ```shell
-$ ./quilkin --filename proxy.yaml
+$ ./quilkin --config proxy.yaml
 {"msg":"Starting Quilkin","level":"INFO","ts":"2021-04-25T19:27:22.535174615-07:00","source":"run","version":"0.1.0-dev"}
 {"msg":"Starting","level":"INFO","ts":"2021-04-25T19:27:22.535315827-07:00","source":"server::Server","port":7000}
 {"msg":"Starting admin endpoint","level":"INFO","ts":"2021-04-25T19:27:22.535550572-07:00","source":"proxy::Admin","address":"[::]:9091"}

--- a/examples/agones-xonotic/README.md
+++ b/examples/agones-xonotic/README.md
@@ -25,7 +25,7 @@ Instead of connecting Xonotic directly, take the IP and port from the Agones hos
 `${GAMESERVER_IP}` and `${GAMESERVER_PORT}` values in a local copy of `client-compress.yaml`. Run this configuration 
 locally as:
 
-`quilkin -f ./client-compress.yaml`
+`quilkin -c ./client-compress.yaml`
 
 From there connect to the local client proxy on "127.0.0.1:7000" via the "Multiplayer > Address" field in the 
 Xonotic client, and Quilkin will take care of compressing the data for you without having to change either the 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -28,4 +28,4 @@ COPY ./target/x86_64-unknown-linux-gnu/debug/quilkin .
 
 FROM $PROFILE
 USER nonroot:nonroot
-ENTRYPOINT ["/quilkin", "--filename", "/etc/quilkin/quilkin.yaml"]
+ENTRYPOINT ["/quilkin", "--config", "/etc/quilkin/quilkin.yaml"]


### PR DESCRIPTION
I missed the change to the file config parameters in PR #350, which broke our development docs as well as our container image builds.

This fixes all that.