### PR TITLE
Remove redundant cfg(test)

### DIFF
--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -14,75 +14,72 @@
  *  limitations under the License.
  */
 
-#[cfg(test)]
-mod tests {
-    use std::net::SocketAddr;
+use std::net::SocketAddr;
 
-    use slog::info;
-    use tokio::time::{timeout, Duration};
+use slog::info;
+use tokio::time::{timeout, Duration};
 
-    use quilkin::config::{Builder, EndPoint, Filter};
-    use quilkin::filters::compress;
-    use quilkin::test_utils::{logger, TestHelper};
+use quilkin::config::{Builder, EndPoint, Filter};
+use quilkin::filters::compress;
+use quilkin::test_utils::{logger, TestHelper};
 
-    #[tokio::test]
-    async fn client_and_server() {
-        let log = logger();
-        let mut t = TestHelper::default();
-        let echo = t.run_echo_server().await;
+#[tokio::test]
+async fn client_and_server() {
+    let log = logger();
+    let mut t = TestHelper::default();
+    let echo = t.run_echo_server().await;
 
-        // create server configuration as
-        let server_port = 12356;
-        let yaml = "
+    // create server configuration as
+    let server_port = 12356;
+    let yaml = "
 on_read: DECOMPRESS
 on_write: COMPRESS
 ";
-        let server_config = Builder::empty()
-            .with_port(server_port)
-            .with_static(
-                vec![Filter {
-                    name: compress::factory(&log).name().into(),
-                    config: serde_yaml::from_str(yaml).unwrap(),
-                }],
-                vec![EndPoint::new(echo)],
-            )
-            .build();
-        // Run server proxy.
-        t.run_server_with_config(server_config);
+    let server_config = Builder::empty()
+        .with_port(server_port)
+        .with_static(
+            vec![Filter {
+                name: compress::factory(&log).name().into(),
+                config: serde_yaml::from_str(yaml).unwrap(),
+            }],
+            vec![EndPoint::new(echo)],
+        )
+        .build();
+    // Run server proxy.
+    t.run_server_with_config(server_config);
 
-        // create a local client
-        let client_port = 12357;
-        let yaml = "
+    // create a local client
+    let client_port = 12357;
+    let yaml = "
 on_read: COMPRESS
 on_write: DECOMPRESS
 ";
-        let client_config = Builder::empty()
-            .with_port(client_port)
-            .with_static(
-                vec![Filter {
-                    name: compress::factory(&log).name().into(),
-                    config: serde_yaml::from_str(yaml).unwrap(),
-                }],
-                vec![EndPoint::new(
-                    format!("127.0.0.1:{}", server_port).parse().unwrap(),
-                )],
-            )
-            .build();
-        // Run client proxy.
-        t.run_server_with_config(client_config);
+    let client_config = Builder::empty()
+        .with_port(client_port)
+        .with_static(
+            vec![Filter {
+                name: compress::factory(&log).name().into(),
+                config: serde_yaml::from_str(yaml).unwrap(),
+            }],
+            vec![EndPoint::new(
+                format!("127.0.0.1:{}", server_port).parse().unwrap(),
+            )],
+        )
+        .build();
+    // Run client proxy.
+    t.run_server_with_config(client_config);
 
-        // let's send the packet
-        let (mut rx, tx) = t.open_socket_and_recv_multiple_packets().await;
+    // let's send the packet
+    let (mut rx, tx) = t.open_socket_and_recv_multiple_packets().await;
 
-        // game_client
-        let local_addr: SocketAddr = format!("127.0.0.1:{}", client_port).parse().unwrap();
-        info!(t.log, "Sending hello"; "address" => local_addr);
-        tx.send_to(b"hello", &local_addr).await.unwrap();
+    // game_client
+    let local_addr: SocketAddr = format!("127.0.0.1:{}", client_port).parse().unwrap();
+    info!(t.log, "Sending hello"; "address" => local_addr);
+    tx.send_to(b"hello", &local_addr).await.unwrap();
 
-        let expected = timeout(Duration::from_secs(5), rx.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap();
-        assert_eq!("hello", expected);
-    }
+    let expected = timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("hello", expected);
 }

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -14,50 +14,47 @@
  * limitations under the License.
  */
 
-#[cfg(test)]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-    use tokio::time::{timeout, Duration};
+use tokio::time::{timeout, Duration};
 
-    use quilkin::config::{Builder, EndPoint, Filter};
-    use quilkin::filters::concatenate_bytes;
-    use quilkin::test_utils::TestHelper;
+use quilkin::config::{Builder, EndPoint, Filter};
+use quilkin::filters::concatenate_bytes;
+use quilkin::test_utils::TestHelper;
 
-    #[tokio::test]
-    async fn concatenate_bytes() {
-        let mut t = TestHelper::default();
-        let yaml = "
+#[tokio::test]
+async fn concatenate_bytes() {
+    let mut t = TestHelper::default();
+    let yaml = "
 on_read: APPEND
 bytes: YWJj #abc
 ";
-        let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server().await;
 
-        let server_port = 12346;
-        let server_config = Builder::empty()
-            .with_port(server_port)
-            .with_static(
-                vec![Filter {
-                    name: concatenate_bytes::factory().name().into(),
-                    config: serde_yaml::from_str(yaml).unwrap(),
-                }],
-                vec![EndPoint::new(echo)],
-            )
-            .build();
-        t.run_server_with_config(server_config);
+    let server_port = 12346;
+    let server_config = Builder::empty()
+        .with_port(server_port)
+        .with_static(
+            vec![Filter {
+                name: concatenate_bytes::factory().name().into(),
+                config: serde_yaml::from_str(yaml).unwrap(),
+            }],
+            vec![EndPoint::new(echo)],
+        )
+        .build();
+    t.run_server_with_config(server_config);
 
-        // let's send the packet
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    // let's send the packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
-        socket.send_to(b"hello", &local_addr).await.unwrap();
+    let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
+    socket.send_to(b"hello", &local_addr).await.unwrap();
 
-        assert_eq!(
-            "helloabc",
-            timeout(Duration::from_secs(5), recv_chan.recv())
-                .await
-                .expect("should have received a packet")
-                .unwrap()
-        );
-    }
+    assert_eq!(
+        "helloabc",
+        timeout(Duration::from_secs(5), recv_chan.recv())
+            .await
+            .expect("should have received a packet")
+            .unwrap()
+    );
 }

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -15,82 +15,78 @@
  */
 
 ///! Complex integration tests that incorporate multiple elements
+use std::net::SocketAddr;
+use std::str::from_utf8;
 
-#[cfg(test)]
-mod tests {
-    use std::net::SocketAddr;
-    use std::str::from_utf8;
+use tokio::time::{timeout, Duration};
 
-    use tokio::time::{timeout, Duration};
+use quilkin::config::{Builder, EndPoint, Filter};
+use quilkin::filters::{compress, concatenate_bytes};
+use quilkin::test_utils::TestHelper;
 
-    use quilkin::config::{Builder, EndPoint, Filter};
-    use quilkin::filters::{compress, concatenate_bytes};
-    use quilkin::test_utils::TestHelper;
+#[tokio::test]
+async fn filter_order() {
+    let mut t = TestHelper::default();
 
-    #[tokio::test]
-    async fn filter_order() {
-        let mut t = TestHelper::default();
-
-        let yaml_concat_read = "
+    let yaml_concat_read = "
 on_read: APPEND
 bytes: eHl6 #xyz
 ";
 
-        let yaml_concat_write = "
+    let yaml_concat_write = "
 on_write: APPEND
 bytes: YWJj #abc
 ";
 
-        let yaml_compress = "
+    let yaml_compress = "
 on_read: COMPRESS
 on_write: DECOMPRESS
 ";
 
-        let echo = t
-            .run_echo_server_with_tap(move |_, bytes, _| {
-                assert!(
-                    from_utf8(bytes).is_err(),
-                    "Should be compressed, and therefore unable to be turned into a string"
-                );
-            })
-            .await;
+    let echo = t
+        .run_echo_server_with_tap(move |_, bytes, _| {
+            assert!(
+                from_utf8(bytes).is_err(),
+                "Should be compressed, and therefore unable to be turned into a string"
+            );
+        })
+        .await;
 
-        let server_port = 12346;
-        let server_config = Builder::empty()
-            .with_port(server_port)
-            .with_static(
-                vec![
-                    Filter {
-                        name: concatenate_bytes::factory().name().into(),
-                        config: serde_yaml::from_str(yaml_concat_read).unwrap(),
-                    },
-                    Filter {
-                        name: concatenate_bytes::factory().name().into(),
-                        config: serde_yaml::from_str(yaml_concat_write).unwrap(),
-                    },
-                    Filter {
-                        name: compress::factory(&t.log).name().into(),
-                        config: serde_yaml::from_str(yaml_compress).unwrap(),
-                    },
-                ],
-                vec![EndPoint::new(echo)],
-            )
-            .build();
+    let server_port = 12346;
+    let server_config = Builder::empty()
+        .with_port(server_port)
+        .with_static(
+            vec![
+                Filter {
+                    name: concatenate_bytes::factory().name().into(),
+                    config: serde_yaml::from_str(yaml_concat_read).unwrap(),
+                },
+                Filter {
+                    name: concatenate_bytes::factory().name().into(),
+                    config: serde_yaml::from_str(yaml_concat_write).unwrap(),
+                },
+                Filter {
+                    name: compress::factory(&t.log).name().into(),
+                    config: serde_yaml::from_str(yaml_compress).unwrap(),
+                },
+            ],
+            vec![EndPoint::new(echo)],
+        )
+        .build();
 
-        t.run_server_with_config(server_config);
+    t.run_server_with_config(server_config);
 
-        // let's send the packet
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    // let's send the packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        let local_addr: SocketAddr = format!("127.0.0.1:{}", server_port).parse().unwrap();
-        socket.send_to(b"hello", &local_addr).await.unwrap();
+    let local_addr: SocketAddr = format!("127.0.0.1:{}", server_port).parse().unwrap();
+    socket.send_to(b"hello", &local_addr).await.unwrap();
 
-        assert_eq!(
-            "helloxyzabc",
-            timeout(Duration::from_secs(5), recv_chan.recv())
-                .await
-                .expect("should have received a packet")
-                .unwrap()
-        );
-    }
+    assert_eq!(
+        "helloxyzabc",
+        timeout(Duration::from_secs(5), recv_chan.recv())
+            .await
+            .expect("should have received a packet")
+            .unwrap()
+    );
 }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -14,158 +14,153 @@
  * limitations under the License.
  */
 
-extern crate quilkin;
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
-#[cfg(test)]
-mod tests {
-    use std::{
-        net::{IpAddr, Ipv4Addr, SocketAddr},
-        sync::Arc,
-    };
+use serde_yaml::{Mapping, Value};
+use slog::info;
 
-    use serde_yaml::{Mapping, Value};
-    use slog::info;
+use quilkin::{
+    config::{Builder as ConfigBuilder, EndPoint, Filter},
+    filters::debug,
+    test_utils::{new_registry, TestHelper},
+    Builder as ProxyBuilder,
+};
 
-    use quilkin::{
-        config::{Builder as ConfigBuilder, EndPoint, Filter},
-        filters::debug,
-        test_utils::{new_registry, TestHelper},
-        Builder as ProxyBuilder,
-    };
+#[tokio::test]
+async fn test_filter() {
+    let mut t = TestHelper::default();
 
-    #[tokio::test]
-    async fn test_filter() {
-        let mut t = TestHelper::default();
+    // create an echo server as an endpoint.
+    let echo = t.run_echo_server().await;
 
-        // create an echo server as an endpoint.
-        let echo = t.run_echo_server().await;
+    // create server configuration
+    let server_port = 12346;
+    let server_config = ConfigBuilder::empty()
+        .with_port(server_port)
+        .with_static(
+            vec![Filter {
+                name: "TestFilter".to_string(),
+                config: None,
+            }],
+            vec![EndPoint::new(echo)],
+        )
+        .build();
 
-        // create server configuration
-        let server_port = 12346;
-        let server_config = ConfigBuilder::empty()
-            .with_port(server_port)
-            .with_static(
-                vec![Filter {
-                    name: "TestFilter".to_string(),
-                    config: None,
-                }],
-                vec![EndPoint::new(echo)],
-            )
-            .build();
+    // Run server proxy.
+    let registry = new_registry(&t.log);
+    t.run_server_with_builder(
+        ProxyBuilder::from(Arc::new(server_config))
+            .with_filter_registry(registry)
+            .disable_admin(),
+    );
 
-        // Run server proxy.
-        let registry = new_registry(&t.log);
-        t.run_server_with_builder(
-            ProxyBuilder::from(Arc::new(server_config))
-                .with_filter_registry(registry)
-                .disable_admin(),
-        );
+    // create a local client
+    let client_port = 12347;
+    let client_config = ConfigBuilder::empty()
+        .with_port(client_port)
+        .with_static(
+            vec![Filter {
+                name: "TestFilter".to_string(),
+                config: None,
+            }],
+            vec![EndPoint::new(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                server_port,
+            ))],
+        )
+        .build();
 
-        // create a local client
-        let client_port = 12347;
-        let client_config = ConfigBuilder::empty()
-            .with_port(client_port)
-            .with_static(
-                vec![Filter {
-                    name: "TestFilter".to_string(),
-                    config: None,
-                }],
-                vec![EndPoint::new(SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                    server_port,
-                ))],
-            )
-            .build();
+    // Run client proxy.
+    let registry = new_registry(&t.log);
+    t.run_server_with_builder(
+        ProxyBuilder::from(Arc::new(client_config))
+            .with_filter_registry(registry)
+            .disable_admin(),
+    );
 
-        // Run client proxy.
-        let registry = new_registry(&t.log);
-        t.run_server_with_builder(
-            ProxyBuilder::from(Arc::new(client_config))
-                .with_filter_registry(registry)
-                .disable_admin(),
-        );
+    // let's send the packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        // let's send the packet
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    // game_client
+    let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
+    info!(t.log, "Sending hello"; "address" => local_addr);
+    socket.send_to(b"hello", &local_addr).await.unwrap();
 
-        // game_client
-        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
-        info!(t.log, "Sending hello"; "address" => local_addr);
-        socket.send_to(b"hello", &local_addr).await.unwrap();
+    let result = recv_chan.recv().await.unwrap();
+    // since we don't know the ephemeral ip addresses in use, we'll search for
+    // substrings for the results we expect that the TestFilter will inject in
+    // the round-tripped packets.
+    assert_eq!(
+        2,
+        result.matches("odr").count(),
+        "Should be 2 read calls in {}",
+        result
+    );
+    assert_eq!(
+        2,
+        result.matches("our").count(),
+        "Should be 2 write calls in {}",
+        result
+    );
+}
 
-        let result = recv_chan.recv().await.unwrap();
-        // since we don't know the ephemeral ip addresses in use, we'll search for
-        // substrings for the results we expect that the TestFilter will inject in
-        // the round-tripped packets.
-        assert_eq!(
-            2,
-            result.matches("odr").count(),
-            "Should be 2 read calls in {}",
-            result
-        );
-        assert_eq!(
-            2,
-            result.matches("our").count(),
-            "Should be 2 write calls in {}",
-            result
-        );
-    }
+#[tokio::test]
+async fn debug_filter() {
+    let mut t = TestHelper::default();
 
-    #[tokio::test]
-    async fn debug_filter() {
-        let mut t = TestHelper::default();
+    // handy for grabbing the configuration name
+    let factory = debug::factory(&t.log);
 
-        // handy for grabbing the configuration name
-        let factory = debug::factory(&t.log);
+    // create an echo server as an endpoint.
+    let echo = t.run_echo_server().await;
 
-        // create an echo server as an endpoint.
-        let echo = t.run_echo_server().await;
+    // filter config
+    let mut map = Mapping::new();
+    map.insert(Value::from("id"), Value::from("server"));
+    // create server configuration
+    let server_port = 12247;
+    let server_config = ConfigBuilder::empty()
+        .with_port(server_port)
+        .with_static(
+            vec![Filter {
+                name: factory.name().into(),
+                config: Some(serde_yaml::Value::Mapping(map)),
+            }],
+            vec![EndPoint::new(echo)],
+        )
+        .build();
+    t.run_server_with_config(server_config);
 
-        // filter config
-        let mut map = Mapping::new();
-        map.insert(Value::from("id"), Value::from("server"));
-        // create server configuration
-        let server_port = 12247;
-        let server_config = ConfigBuilder::empty()
-            .with_port(server_port)
-            .with_static(
-                vec![Filter {
-                    name: factory.name().into(),
-                    config: Some(serde_yaml::Value::Mapping(map)),
-                }],
-                vec![EndPoint::new(echo)],
-            )
-            .build();
-        t.run_server_with_config(server_config);
+    let mut map = Mapping::new();
+    map.insert(Value::from("id"), Value::from("client"));
+    // create a local client
+    let client_port = 12248;
+    let client_config = ConfigBuilder::empty()
+        .with_port(client_port)
+        .with_static(
+            vec![Filter {
+                name: factory.name().into(),
+                config: Some(serde_yaml::Value::Mapping(map)),
+            }],
+            vec![EndPoint::new(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                server_port,
+            ))],
+        )
+        .build();
+    t.run_server_with_config(client_config);
 
-        let mut map = Mapping::new();
-        map.insert(Value::from("id"), Value::from("client"));
-        // create a local client
-        let client_port = 12248;
-        let client_config = ConfigBuilder::empty()
-            .with_port(client_port)
-            .with_static(
-                vec![Filter {
-                    name: factory.name().into(),
-                    config: Some(serde_yaml::Value::Mapping(map)),
-                }],
-                vec![EndPoint::new(SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                    server_port,
-                ))],
-            )
-            .build();
-        t.run_server_with_config(client_config);
+    // let's send the packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        // let's send the packet
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    // game client
+    let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
+    info!(t.log, "Sending hello"; "address" => local_addr);
+    socket.send_to(b"hello", &local_addr).await.unwrap();
 
-        // game client
-        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
-        info!(t.log, "Sending hello"; "address" => local_addr);
-        socket.send_to(b"hello", &local_addr).await.unwrap();
-
-        // since the debug filter doesn't change the data, it should be exactly the same
-        assert_eq!("hello", recv_chan.recv().await.unwrap());
-    }
+    // since the debug filter doesn't change the data, it should be exactly the same
+    assert_eq!("hello", recv_chan.recv().await.unwrap());
 }

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -14,43 +14,40 @@
  * limitations under the License.
  */
 
-#[cfg(test)]
-mod tests {
-    use quilkin::config::{Admin, Builder, EndPoint};
-    use quilkin::test_utils::TestHelper;
-    use quilkin::Builder as ProxyBuilder;
-    use std::panic;
-    use std::sync::Arc;
+use quilkin::config::{Admin, Builder, EndPoint};
+use quilkin::test_utils::TestHelper;
+use quilkin::Builder as ProxyBuilder;
+use std::panic;
+use std::sync::Arc;
 
-    #[tokio::test]
-    async fn health_server() {
-        let mut t = TestHelper::default();
+#[tokio::test]
+async fn health_server() {
+    let mut t = TestHelper::default();
 
-        // create server configuration
-        let server_port = 12349;
-        let server_config = Builder::empty()
-            .with_port(server_port)
-            .with_static(vec![], vec![EndPoint::new("127.0.0.1:0".parse().unwrap())])
-            .with_admin(Admin {
-                address: "[::]:9093".parse().unwrap(),
-            })
-            .build();
-        t.run_server_with_builder(ProxyBuilder::from(Arc::new(server_config)));
+    // create server configuration
+    let server_port = 12349;
+    let server_config = Builder::empty()
+        .with_port(server_port)
+        .with_static(vec![], vec![EndPoint::new("127.0.0.1:0".parse().unwrap())])
+        .with_admin(Admin {
+            address: "[::]:9093".parse().unwrap(),
+        })
+        .build();
+    t.run_server_with_builder(ProxyBuilder::from(Arc::new(server_config)));
 
-        let resp = reqwest::get("http://localhost:9093/live")
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
+    let resp = reqwest::get("http://localhost:9093/live")
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
 
-        assert_eq!("ok", resp);
+    assert_eq!("ok", resp);
 
-        let _ = panic::catch_unwind(|| {
-            panic!("oh no!");
-        });
+    let _ = panic::catch_unwind(|| {
+        panic!("oh no!");
+    });
 
-        let resp = reqwest::get("http://localhost:9093/live").await.unwrap();
-        assert!(resp.status().is_server_error(), "Should be unhealthy");
-    }
+    let resp = reqwest::get("http://localhost:9093/live").await.unwrap();
+    assert!(resp.status().is_server_error(), "Should be unhealthy");
 }

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -14,58 +14,53 @@
  * limitations under the License.
  */
 
-extern crate quilkin;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-#[cfg(test)]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use tokio::time::{timeout, Duration};
 
-    use tokio::time::{timeout, Duration};
+use quilkin::config::{Builder as ConfigBuilder, EndPoint, Filter};
+use quilkin::filters::local_rate_limit;
+use quilkin::test_utils::TestHelper;
 
-    use quilkin::config::{Builder as ConfigBuilder, EndPoint, Filter};
-    use quilkin::filters::local_rate_limit;
-    use quilkin::test_utils::TestHelper;
+#[tokio::test]
+async fn local_rate_limit_filter() {
+    let mut t = TestHelper::default();
 
-    #[tokio::test]
-    async fn local_rate_limit_filter() {
-        let mut t = TestHelper::default();
-
-        let yaml = "
+    let yaml = "
 max_packets: 2
 period: 1s
 ";
-        let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server().await;
 
-        let server_port = 12346;
-        let server_config = ConfigBuilder::empty()
-            .with_port(server_port)
-            .with_static(
-                vec![Filter {
-                    name: local_rate_limit::factory().name().into(),
-                    config: serde_yaml::from_str(yaml).unwrap(),
-                }],
-                vec![EndPoint::new(echo)],
-            )
-            .build();
-        t.run_server_with_config(server_config);
+    let server_port = 12346;
+    let server_config = ConfigBuilder::empty()
+        .with_port(server_port)
+        .with_static(
+            vec![Filter {
+                name: local_rate_limit::factory().name().into(),
+                config: serde_yaml::from_str(yaml).unwrap(),
+            }],
+            vec![EndPoint::new(echo)],
+        )
+        .build();
+    t.run_server_with_config(server_config);
 
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
+    let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
 
-        for _ in 0..3 {
-            socket.send_to(b"hello", &server_addr).await.unwrap();
-        }
-
-        for _ in 0..2 {
-            assert_eq!(recv_chan.recv().await.unwrap(), "hello");
-        }
-
-        // Allow enough time to have received any response.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        // Check that we do not get any response.
-        assert!(timeout(Duration::from_secs(1), recv_chan.recv())
-            .await
-            .is_err());
+    for _ in 0..3 {
+        socket.send_to(b"hello", &server_addr).await.unwrap();
     }
+
+    for _ in 0..2 {
+        assert_eq!(recv_chan.recv().await.unwrap(), "hello");
+    }
+
+    // Allow enough time to have received any response.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // Check that we do not get any response.
+    assert!(timeout(Duration::from_secs(1), recv_chan.recv())
+        .await
+        .is_err());
 }

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -14,68 +14,63 @@
  * limitations under the License.
  */
 
-extern crate quilkin;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-#[cfg(test)]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use slog::info;
 
-    use slog::info;
+use quilkin::config::{Admin, Builder as ConfigBuilder, EndPoint};
+use quilkin::test_utils::TestHelper;
+use quilkin::Builder;
+use std::sync::Arc;
 
-    use quilkin::config::{Admin, Builder as ConfigBuilder, EndPoint};
-    use quilkin::test_utils::TestHelper;
-    use quilkin::Builder;
-    use std::sync::Arc;
+#[tokio::test]
+async fn metrics_server() {
+    let mut t = TestHelper::default();
 
-    #[tokio::test]
-    async fn metrics_server() {
-        let mut t = TestHelper::default();
+    // create an echo server as an endpoint.
+    let echo = t.run_echo_server().await;
 
-        // create an echo server as an endpoint.
-        let echo = t.run_echo_server().await;
+    // create server configuration
+    let server_port = 12346;
+    let server_config = ConfigBuilder::empty()
+        .with_port(server_port)
+        .with_static(vec![], vec![EndPoint::new(echo)])
+        .with_admin(Admin {
+            address: "[::]:9092".parse().unwrap(),
+        })
+        .build();
+    t.run_server_with_builder(Builder::from(Arc::new(server_config)));
 
-        // create server configuration
-        let server_port = 12346;
-        let server_config = ConfigBuilder::empty()
-            .with_port(server_port)
-            .with_static(vec![], vec![EndPoint::new(echo)])
-            .with_admin(Admin {
-                address: "[::]:9092".parse().unwrap(),
-            })
-            .build();
-        t.run_server_with_builder(Builder::from(Arc::new(server_config)));
+    // create a local client
+    let client_port = 12347;
+    let client_config = ConfigBuilder::empty()
+        .with_port(client_port)
+        .with_static(
+            vec![],
+            vec![EndPoint::new(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                server_port,
+            ))],
+        )
+        .build();
+    t.run_server_with_builder(Builder::from(Arc::new(client_config)));
 
-        // create a local client
-        let client_port = 12347;
-        let client_config = ConfigBuilder::empty()
-            .with_port(client_port)
-            .with_static(
-                vec![],
-                vec![EndPoint::new(SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                    server_port,
-                ))],
-            )
-            .build();
-        t.run_server_with_builder(Builder::from(Arc::new(client_config)));
+    // let's send the packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        // let's send the packet
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    // game_client
+    let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
+    info!(t.log, "Sending hello"; "address" => local_addr);
+    socket.send_to(b"hello", &local_addr).await.unwrap();
 
-        // game_client
-        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
-        info!(t.log, "Sending hello"; "address" => local_addr);
-        socket.send_to(b"hello", &local_addr).await.unwrap();
+    let _ = recv_chan.recv().await.unwrap();
 
-        let _ = recv_chan.recv().await.unwrap();
+    let resp = reqwest::get("http://localhost:9092/metrics")
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
 
-        let resp = reqwest::get("http://localhost:9092/metrics")
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-
-        assert!(resp.contains("quilkin_session_tx_packets_total 1"));
-    }
+    assert!(resp.contains("quilkin_session_tx_packets_total 1"));
 }

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -14,65 +14,60 @@
  * limitations under the License.
  */
 
-extern crate quilkin;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-#[cfg(test)]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use tokio::select;
+use tokio::time::{sleep, Duration};
 
-    use tokio::select;
-    use tokio::time::{sleep, Duration};
+use quilkin::config::{Builder as ConfigBuilder, EndPoint};
+use quilkin::test_utils::TestHelper;
 
-    use quilkin::config::{Builder as ConfigBuilder, EndPoint};
-    use quilkin::test_utils::TestHelper;
+#[tokio::test]
+async fn echo() {
+    let mut t = TestHelper::default();
 
-    #[tokio::test]
-    async fn echo() {
-        let mut t = TestHelper::default();
+    // create two echo servers as endpoints
+    let server1 = t.run_echo_server().await;
+    let server2 = t.run_echo_server().await;
 
-        // create two echo servers as endpoints
-        let server1 = t.run_echo_server().await;
-        let server2 = t.run_echo_server().await;
+    // create server configuration
+    let server_port = 12345;
+    let server_config = ConfigBuilder::empty()
+        .with_port(server_port)
+        .with_static(vec![], vec![EndPoint::new(server1), EndPoint::new(server2)])
+        .build();
 
-        // create server configuration
-        let server_port = 12345;
-        let server_config = ConfigBuilder::empty()
-            .with_port(server_port)
-            .with_static(vec![], vec![EndPoint::new(server1), EndPoint::new(server2)])
-            .build();
+    t.run_server_with_config(server_config);
 
-        t.run_server_with_config(server_config);
+    // create a local client
+    let client_port = 12344;
+    let client_config = ConfigBuilder::empty()
+        .with_port(client_port)
+        .with_static(
+            vec![],
+            vec![EndPoint::new(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                server_port,
+            ))],
+        )
+        .build();
+    t.run_server_with_config(client_config);
 
-        // create a local client
-        let client_port = 12344;
-        let client_config = ConfigBuilder::empty()
-            .with_port(client_port)
-            .with_static(
-                vec![],
-                vec![EndPoint::new(SocketAddr::new(
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                    server_port,
-                ))],
-            )
-            .build();
-        t.run_server_with_config(client_config);
+    // let's send the packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        // let's send the packet
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    // game_client
+    let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
+    socket.send_to(b"hello", &local_addr).await.unwrap();
 
-        // game_client
-        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
-        socket.send_to(b"hello", &local_addr).await.unwrap();
+    assert_eq!("hello", recv_chan.recv().await.unwrap());
+    assert_eq!("hello", recv_chan.recv().await.unwrap());
 
-        assert_eq!("hello", recv_chan.recv().await.unwrap());
-        assert_eq!("hello", recv_chan.recv().await.unwrap());
-
-        // should only be two returned items
-        select! {
-            res = recv_chan.recv() => {
-                unreachable!("Should not receive a third packet: {}", res.unwrap());
-            }
-            _ = sleep(Duration::from_secs(2)) => {}
-        };
-    }
+    // should only be two returned items
+    select! {
+        res = recv_chan.recv() => {
+            unreachable!("Should not receive a third packet: {}", res.unwrap());
+        }
+        _ = sleep(Duration::from_secs(2)) => {}
+    };
 }

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -14,75 +14,72 @@
  *  limitations under the License.
  */
 
-#[cfg(test)]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-    use tokio::time::{timeout, Duration};
+use tokio::time::{timeout, Duration};
 
-    use quilkin::config::{Builder, EndPoint, Filter};
-    use quilkin::filters::{capture_bytes, token_router};
-    use quilkin::test_utils::{logger, TestHelper};
+use quilkin::config::{Builder, EndPoint, Filter};
+use quilkin::filters::{capture_bytes, token_router};
+use quilkin::test_utils::{logger, TestHelper};
 
-    /// This test covers both token_router and capture_bytes filters,
-    /// since they work in concert together.
-    #[tokio::test]
-    async fn token_router() {
-        let log = logger();
-        let mut t = TestHelper::default();
-        let echo = t.run_echo_server().await;
+/// This test covers both token_router and capture_bytes filters,
+/// since they work in concert together.
+#[tokio::test]
+async fn token_router() {
+    let log = logger();
+    let mut t = TestHelper::default();
+    let echo = t.run_echo_server().await;
 
-        let capture_yaml = "
+    let capture_yaml = "
 size: 3
 remove: true
 ";
-        let endpoint_metadata = "
+    let endpoint_metadata = "
 quilkin.dev:
     tokens:
         - YWJj # abc
-";
-        let server_port = 12348;
-        let server_config = Builder::empty()
-            .with_port(server_port)
-            .with_static(
-                vec![
-                    Filter {
-                        name: capture_bytes::factory(&log).name().into(),
-                        config: serde_yaml::from_str(capture_yaml).unwrap(),
-                    },
-                    Filter {
-                        name: token_router::factory(&log).name().into(),
-                        config: None,
-                    },
-                ],
-                vec![EndPoint::with_metadata(
-                    echo,
-                    Some(serde_yaml::from_str(endpoint_metadata).unwrap()),
-                )],
-            )
-            .build();
-        t.run_server_with_config(server_config);
+        ";
+    let server_port = 12348;
+    let server_config = Builder::empty()
+        .with_port(server_port)
+        .with_static(
+            vec![
+                Filter {
+                    name: capture_bytes::factory(&log).name().into(),
+                    config: serde_yaml::from_str(capture_yaml).unwrap(),
+                },
+                Filter {
+                    name: token_router::factory(&log).name().into(),
+                    config: None,
+                },
+            ],
+            vec![EndPoint::with_metadata(
+                echo,
+                Some(serde_yaml::from_str(endpoint_metadata).unwrap()),
+            )],
+        )
+        .build();
+    t.run_server_with_config(server_config);
 
-        // valid packet
-        let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+    // valid packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
-        let msg = b"helloabc";
-        socket.send_to(msg, &local_addr).await.unwrap();
+    let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
+    let msg = b"helloabc";
+    socket.send_to(msg, &local_addr).await.unwrap();
 
-        assert_eq!(
-            "hello",
-            timeout(Duration::from_secs(5), recv_chan.recv())
-                .await
-                .expect("should have received a packet")
-                .unwrap()
-        );
+    assert_eq!(
+        "hello",
+        timeout(Duration::from_secs(5), recv_chan.recv())
+            .await
+            .expect("should have received a packet")
+            .unwrap()
+    );
 
-        // send an invalid packet
-        let msg = b"helloxyz";
-        socket.send_to(msg, &local_addr).await.unwrap();
+    // send an invalid packet
+    let msg = b"helloxyz";
+    socket.send_to(msg, &local_addr).await.unwrap();
 
-        let result = timeout(Duration::from_secs(3), recv_chan.recv()).await;
-        assert!(result.is_err(), "should not have received a packet");
-    }
+    let result = timeout(Duration::from_secs(3), recv_chan.recv()).await;
+    assert!(result.is_err(), "should not have received a packet");
 }

--- a/tests/xds.rs
+++ b/tests/xds.rs
@@ -117,118 +117,112 @@ mod quilkin_proto {
     }
 }
 
-#[cfg(test)]
-mod tests {
+use envoy::config::cluster::v3::{cluster::ClusterDiscoveryType, Cluster};
+use envoy::config::core::v3::{address, socket_address::PortSpecifier, Address, SocketAddress};
+use envoy::config::endpoint::v3::{
+    lb_endpoint::HostIdentifier, ClusterLoadAssignment, Endpoint, LbEndpoint, LocalityLbEndpoints,
+};
+use envoy::config::listener::v3::{
+    filter::ConfigType, Filter as LdsFilter, FilterChain as LdsFilterChain, Listener,
+};
+use envoy::service::discovery::v3::aggregated_discovery_service_server::{
+    AggregatedDiscoveryService as ADS, AggregatedDiscoveryServiceServer as ADSServer,
+};
+use envoy::service::discovery::v3::{
+    DeltaDiscoveryRequest, DeltaDiscoveryResponse, DiscoveryRequest, DiscoveryResponse,
+};
+use quilkin_proto::extensions::filters::concatenate_bytes::v1alpha1::concatenate_bytes::{
+    Strategy, StrategyValue,
+};
+use quilkin_proto::extensions::filters::concatenate_bytes::v1alpha1::ConcatenateBytes;
 
-    use super::envoy::config::cluster::v3::{cluster::ClusterDiscoveryType, Cluster};
-    use super::envoy::config::core::v3::{
-        address, socket_address::PortSpecifier, Address, SocketAddress,
-    };
-    use super::envoy::config::endpoint::v3::{
-        lb_endpoint::HostIdentifier, ClusterLoadAssignment, Endpoint, LbEndpoint,
-        LocalityLbEndpoints,
-    };
-    use super::envoy::config::listener::v3::{
-        filter::ConfigType, Filter as LdsFilter, FilterChain as LdsFilterChain, Listener,
-    };
-    use super::envoy::service::discovery::v3::aggregated_discovery_service_server::{
-        AggregatedDiscoveryService as ADS, AggregatedDiscoveryServiceServer as ADSServer,
-    };
-    use super::envoy::service::discovery::v3::{
-        DeltaDiscoveryRequest, DeltaDiscoveryResponse, DiscoveryRequest, DiscoveryResponse,
-    };
-    use super::quilkin_proto::extensions::filters::concatenate_bytes::v1alpha1::ConcatenateBytes;
-    use super::quilkin_proto::extensions::filters::concatenate_bytes::v1alpha1::concatenate_bytes::{
-        Strategy, StrategyValue,
-    };
+use quilkin::config::Config;
+use quilkin::test_utils::{logger, TestHelper};
+use quilkin::Builder;
 
-    use quilkin::config::Config;
-    use quilkin::test_utils::{logger, TestHelper};
-    use quilkin::Builder;
+use prost::Message;
+use slog::{info, o, Logger};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::time;
+use tonic::transport::Server;
 
-    use prost::Message;
-    use slog::{info, o, Logger};
-    use std::collections::HashMap;
-    use std::net::SocketAddr;
-    use std::sync::Arc;
-    use std::time::Duration;
-    use tokio::sync::mpsc;
-    use tokio::sync::watch;
-    use tokio::time;
-    use tonic::transport::Server;
+const CLUSTER_TYPE: &str = "type.googleapis.com/envoy.config.cluster.v3.Cluster";
+const LISTENER_TYPE: &str = "type.googleapis.com/envoy.config.listener.v3.Listener";
 
-    const CLUSTER_TYPE: &str = "type.googleapis.com/envoy.config.cluster.v3.Cluster";
-    const LISTENER_TYPE: &str = "type.googleapis.com/envoy.config.listener.v3.Listener";
+// A test xDS server implementation that waits for a client to connect and
+// forwards DiscoveryResponse(s) to the client. A rx chan is passed in upon creation
+// and can be used by the test to drive the DiscoveryResponses sent by the server to the client.
+struct ControlPlane {
+    log: Logger,
+    source_discovery_response_rx:
+        tokio::sync::Mutex<Option<mpsc::Receiver<Result<DiscoveryResponse, tonic::Status>>>>,
+    shutdown_rx: watch::Receiver<()>,
+}
 
-    // A test xDS server implementation that waits for a client to connect and
-    // forwards DiscoveryResponse(s) to the client. A rx chan is passed in upon creation
-    // and can be used by the test to drive the DiscoveryResponses sent by the server to the client.
-    struct ControlPlane {
-        log: Logger,
-        source_discovery_response_rx:
-            tokio::sync::Mutex<Option<mpsc::Receiver<Result<DiscoveryResponse, tonic::Status>>>>,
-        shutdown_rx: watch::Receiver<()>,
-    }
+#[tonic::async_trait]
+impl ADS for ControlPlane {
+    type StreamAggregatedResourcesStream =
+        tokio_stream::wrappers::ReceiverStream<Result<DiscoveryResponse, tonic::Status>>;
+    type DeltaAggregatedResourcesStream =
+        tokio_stream::wrappers::ReceiverStream<Result<DeltaDiscoveryResponse, tonic::Status>>;
 
-    #[tonic::async_trait]
-    impl ADS for ControlPlane {
-        type StreamAggregatedResourcesStream =
-            tokio_stream::wrappers::ReceiverStream<Result<DiscoveryResponse, tonic::Status>>;
-        type DeltaAggregatedResourcesStream =
-            tokio_stream::wrappers::ReceiverStream<Result<DeltaDiscoveryResponse, tonic::Status>>;
+    async fn stream_aggregated_resources(
+        &self,
+        _request: tonic::Request<tonic::Streaming<DiscoveryRequest>>,
+    ) -> Result<tonic::Response<Self::StreamAggregatedResourcesStream>, tonic::Status> {
+        let mut source_discovery_response_rx = self
+            .source_discovery_response_rx
+            .lock()
+            .await
+            .take()
+            .unwrap();
 
-        async fn stream_aggregated_resources(
-            &self,
-            _request: tonic::Request<tonic::Streaming<DiscoveryRequest>>,
-        ) -> Result<tonic::Response<Self::StreamAggregatedResourcesStream>, tonic::Status> {
-            let mut source_discovery_response_rx = self
-                .source_discovery_response_rx
-                .lock()
-                .await
-                .take()
-                .unwrap();
-
-            let log = self.log.clone();
-            let mut shutdown_rx = self.shutdown_rx.clone();
-            let (discovery_response_tx, discovery_response_rx) = mpsc::channel(1);
-            tokio::spawn(async move {
-                loop {
-                    tokio::select! {
-                        _ = shutdown_rx.changed() => {
-                            return;
-                        }
-                        source_response = source_discovery_response_rx.recv() => {
-                            match source_response {
-                                None => {
-                                    info!(log, "Stopping updates to client: source was dropped");
-                                    return;
-                                },
-                                Some(result) => {
-                                    let _ = discovery_response_tx.send(result).await.unwrap();
-                                }
+        let log = self.log.clone();
+        let mut shutdown_rx = self.shutdown_rx.clone();
+        let (discovery_response_tx, discovery_response_rx) = mpsc::channel(1);
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => {
+                        return;
+                    }
+                    source_response = source_discovery_response_rx.recv() => {
+                        match source_response {
+                            None => {
+                                info!(log, "Stopping updates to client: source was dropped");
+                                return;
+                            },
+                            Some(result) => {
+                                let _ = discovery_response_tx.send(result).await.unwrap();
                             }
                         }
                     }
                 }
-            });
-            Ok(tonic::Response::new(
-                tokio_stream::wrappers::ReceiverStream::new(discovery_response_rx),
-            ))
-        }
-
-        async fn delta_aggregated_resources(
-            &self,
-            _request: tonic::Request<tonic::Streaming<DeltaDiscoveryRequest>>,
-        ) -> Result<tonic::Response<Self::DeltaAggregatedResourcesStream>, tonic::Status> {
-            unimplemented!()
-        }
+            }
+        });
+        Ok(tonic::Response::new(
+            tokio_stream::wrappers::ReceiverStream::new(discovery_response_rx),
+        ))
     }
 
-    #[tokio::test]
-    async fn send_cds_and_lds_updates() {
-        let mut t = TestHelper::default();
+    async fn delta_aggregated_resources(
+        &self,
+        _request: tonic::Request<tonic::Streaming<DeltaDiscoveryRequest>>,
+    ) -> Result<tonic::Response<Self::DeltaAggregatedResourcesStream>, tonic::Status> {
+        unimplemented!()
+    }
+}
 
-        let config = "
+#[tokio::test]
+async fn send_cds_and_lds_updates() {
+    let mut t = TestHelper::default();
+
+    let config = "
 version: v1alpha1
 proxy:
   id: test-proxy
@@ -236,302 +230,299 @@ proxy:
 dynamic:
   management_servers:
     - address: http://127.0.0.1:23456
-";
+    ";
 
-        let config: Arc<Config> = Arc::new(serde_yaml::from_str(config).unwrap());
-        let server = Builder::from(config)
-            .with_log(logger())
-            .validate()
-            .unwrap()
-            .build();
+    let config: Arc<Config> = Arc::new(serde_yaml::from_str(config).unwrap());
+    let server = Builder::from(config)
+        .with_log(logger())
+        .validate()
+        .unwrap()
+        .build();
 
-        let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
-        let (discovery_response_tx, discovery_response_rx) = mpsc::channel(1);
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let (discovery_response_tx, discovery_response_rx) = mpsc::channel(1);
 
-        let mut control_plane_shutdown_rx = shutdown_rx.clone();
-        let log = t.log.new(o!("source" => "control-plane"));
-        tokio::spawn(async move {
-            let server = ADSServer::new(ControlPlane {
-                source_discovery_response_rx: tokio::sync::Mutex::new(Some(discovery_response_rx)),
-                log,
-                shutdown_rx: control_plane_shutdown_rx.clone(),
-            });
-            let server = Server::builder().add_service(server);
-            server
-                .serve_with_shutdown("0.0.0.0:23456".parse().unwrap(), async move {
-                    let _: Result<(), _> = control_plane_shutdown_rx.changed().await;
-                })
+    let mut control_plane_shutdown_rx = shutdown_rx.clone();
+    let log = t.log.new(o!("source" => "control-plane"));
+    tokio::spawn(async move {
+        let server = ADSServer::new(ControlPlane {
+            source_discovery_response_rx: tokio::sync::Mutex::new(Some(discovery_response_rx)),
+            log,
+            shutdown_rx: control_plane_shutdown_rx.clone(),
+        });
+        let server = Server::builder().add_service(server);
+        server
+            .serve_with_shutdown("0.0.0.0:23456".parse().unwrap(), async move {
+                let _: Result<(), _> = control_plane_shutdown_rx.changed().await;
+            })
+            .await
+            .unwrap();
+    });
+
+    // Run the server.
+    tokio::spawn(async move {
+        server.run(shutdown_rx).await.unwrap();
+    });
+
+    let timeout = time::sleep(Duration::from_secs(10));
+    tokio::pin!(timeout);
+
+    // Each time, we create a new upstream endpoint and send a cluster update for it.
+    let concat_bytes = vec![("b", "c,"), ("d", "e")];
+    for (i, (b1, b2)) in concat_bytes.into_iter().enumerate() {
+        let upstream_address = t.run_echo_server().await;
+
+        // Send a cluster update.
+        let cluster_update = cluster_discovery_response(
+            "cluster-1".into(),
+            i.to_string().as_str(),
+            i.to_string().as_str(),
+            upstream_address,
+        );
+        discovery_response_tx
+            .send(Ok(cluster_update))
+            .await
+            .unwrap();
+
+        // Send a filter update.
+        let filter_update = concat_listener_discovery_response(
+            i.to_string().as_str(),
+            i.to_string().as_str(),
+            vec![b1.into(), b2.into()],
+        );
+        discovery_response_tx.send(Ok(filter_update)).await.unwrap();
+
+        // Open a socket we can use to talk to the proxy and receive response back on.
+        let (mut response_rx, socket) = t.open_socket_and_recv_multiple_packets().await;
+
+        let expected_response = format!("a{}{}", b1, b2);
+        let mut interval = time::interval(Duration::from_millis(10));
+        loop {
+            // Send a packet, it should be suffixed with the new filter configs.
+            // Then wait to receive a response. Try until the update is applied
+            // and we receive the expected response.
+            socket
+                .send_to(b"a", &"127.0.0.1:34567".parse::<SocketAddr>().unwrap())
                 .await
                 .unwrap();
-        });
 
-        // Run the server.
-        tokio::spawn(async move {
-            server.run(shutdown_rx).await.unwrap();
-        });
-
-        let timeout = time::sleep(Duration::from_secs(10));
-        tokio::pin!(timeout);
-
-        // Each time, we create a new upstream endpoint and send a cluster update for it.
-        let concat_bytes = vec![("b", "c,"), ("d", "e")];
-        for (i, (b1, b2)) in concat_bytes.into_iter().enumerate() {
-            let upstream_address = t.run_echo_server().await;
-
-            // Send a cluster update.
-            let cluster_update = cluster_discovery_response(
-                "cluster-1".into(),
-                i.to_string().as_str(),
-                i.to_string().as_str(),
-                upstream_address,
-            );
-            discovery_response_tx
-                .send(Ok(cluster_update))
-                .await
-                .unwrap();
-
-            // Send a filter update.
-            let filter_update = concat_listener_discovery_response(
-                i.to_string().as_str(),
-                i.to_string().as_str(),
-                vec![b1.into(), b2.into()],
-            );
-            discovery_response_tx.send(Ok(filter_update)).await.unwrap();
-
-            // Open a socket we can use to talk to the proxy and receive response back on.
-            let (mut response_rx, socket) = t.open_socket_and_recv_multiple_packets().await;
-
-            let expected_response = format!("a{}{}", b1, b2);
-            let mut interval = time::interval(Duration::from_millis(10));
-            loop {
-                // Send a packet, it should be suffixed with the new filter configs.
-                // Then wait to receive a response. Try until the update is applied
-                // and we receive the expected response.
-                socket
-                    .send_to(b"a", &"127.0.0.1:34567".parse::<SocketAddr>().unwrap())
-                    .await
-                    .unwrap();
-
-                tokio::select! {
-                    _ = &mut timeout => {
-                        unreachable!("timed-out waiting for xDS update to be applied")
-                    },
-                    _ = interval.tick() => {
-                        // If we time out, it could mean that we haven't applied any cluster update yet so we
-                        // are dropping packets. In which case we can simply retry later.
-                        // If its for any other reason, our assertion will fail later or we will time out.
-                        if let Ok(response) = time::timeout(Duration::from_millis(500), response_rx.recv()).await {
-                            let response = response.unwrap();
-                            if expected_response == response {
-                                break;
-                            }
+            tokio::select! {
+                _ = &mut timeout => {
+                    unreachable!("timed-out waiting for xDS update to be applied")
+                },
+                _ = interval.tick() => {
+                    // If we time out, it could mean that we haven't applied any cluster update yet so we
+                    // are dropping packets. In which case we can simply retry later.
+                    // If its for any other reason, our assertion will fail later or we will time out.
+                    if let Ok(response) = time::timeout(Duration::from_millis(500), response_rx.recv()).await {
+                        let response = response.unwrap();
+                        if expected_response == response {
+                            break;
                         }
                     }
                 }
             }
         }
     }
+}
 
-    fn concat_listener_discovery_response(
-        version_info: &str,
-        nonce: &str,
-        bytes: Vec<Vec<u8>>,
-    ) -> DiscoveryResponse {
-        let filter_name = "quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes";
-        let filters = bytes
-            .into_iter()
-            .map(|value| LdsFilter {
-                name: filter_name.into(),
-                config_type: Some(ConfigType::TypedConfig({
-                    let mut buf = vec![];
-                    ConcatenateBytes {
-                        on_write: None,
-                        on_read: Some(StrategyValue {
-                            value: Strategy::Append as i32,
-                        }),
-                        bytes: value,
-                    }
-                    .encode(&mut buf)
-                    .unwrap();
-                    prost_types::Any {
-                        type_url: filter_name.into(),
-                        value: buf,
-                    }
-                })),
-            })
-            .collect();
+fn concat_listener_discovery_response(
+    version_info: &str,
+    nonce: &str,
+    bytes: Vec<Vec<u8>>,
+) -> DiscoveryResponse {
+    let filter_name = "quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes";
+    let filters = bytes
+        .into_iter()
+        .map(|value| LdsFilter {
+            name: filter_name.into(),
+            config_type: Some(ConfigType::TypedConfig({
+                let mut buf = vec![];
+                ConcatenateBytes {
+                    on_write: None,
+                    on_read: Some(StrategyValue {
+                        value: Strategy::Append as i32,
+                    }),
+                    bytes: value,
+                }
+                .encode(&mut buf)
+                .unwrap();
+                prost_types::Any {
+                    type_url: filter_name.into(),
+                    value: buf,
+                }
+            })),
+        })
+        .collect();
 
-        let filter_chain = create_lds_filter_chain(filters);
+    let filter_chain = create_lds_filter_chain(filters);
 
-        let listener_name = "listener-1";
-        let listener = create_lds_listener(listener_name.into(), vec![filter_chain]);
-        let mut buf = vec![];
-        listener.encode(&mut buf).unwrap();
-        let lds_resource = prost_types::Any {
-            type_url: LISTENER_TYPE.into(),
-            value: buf,
-        };
+    let listener_name = "listener-1";
+    let listener = create_lds_listener(listener_name.into(), vec![filter_chain]);
+    let mut buf = vec![];
+    listener.encode(&mut buf).unwrap();
+    let lds_resource = prost_types::Any {
+        type_url: LISTENER_TYPE.into(),
+        value: buf,
+    };
 
-        DiscoveryResponse {
-            version_info: version_info.into(),
-            resources: vec![lds_resource],
-            canary: false,
-            type_url: LISTENER_TYPE.into(),
-            nonce: nonce.into(),
-            control_plane: None,
-        }
+    DiscoveryResponse {
+        version_info: version_info.into(),
+        resources: vec![lds_resource],
+        canary: false,
+        type_url: LISTENER_TYPE.into(),
+        nonce: nonce.into(),
+        control_plane: None,
     }
+}
 
-    fn cluster_discovery_response(
-        name: String,
-        version_info: &str,
-        nonce: &str,
-        endpoint_addr: SocketAddr,
-    ) -> DiscoveryResponse {
-        let cluster = create_cluster_resource(&name, endpoint_addr);
-        let mut value = vec![];
-        cluster.encode(&mut value).unwrap();
-        let resource = prost_types::Any {
-            type_url: CLUSTER_TYPE.into(),
-            value,
-        };
+fn cluster_discovery_response(
+    name: String,
+    version_info: &str,
+    nonce: &str,
+    endpoint_addr: SocketAddr,
+) -> DiscoveryResponse {
+    let cluster = create_cluster_resource(&name, endpoint_addr);
+    let mut value = vec![];
+    cluster.encode(&mut value).unwrap();
+    let resource = prost_types::Any {
+        type_url: CLUSTER_TYPE.into(),
+        value,
+    };
 
-        DiscoveryResponse {
-            type_url: CLUSTER_TYPE.into(),
-            version_info: version_info.into(),
-            nonce: nonce.into(),
-            resources: vec![resource],
-            canary: false,
-            control_plane: None,
-        }
+    DiscoveryResponse {
+        type_url: CLUSTER_TYPE.into(),
+        version_info: version_info.into(),
+        nonce: nonce.into(),
+        resources: vec![resource],
+        canary: false,
+        control_plane: None,
     }
+}
 
-    #[allow(deprecated)]
-    fn create_cluster_resource(name: &str, endpoint_addr: SocketAddr) -> Cluster {
-        Cluster {
-            name: name.into(),
-            transport_socket_matches: vec![],
-            alt_stat_name: "".into(),
-            eds_cluster_config: None,
-            connect_timeout: None,
-            per_connection_buffer_limit_bytes: None,
-            lb_policy: 0,
-            load_balancing_policy: None,
-            load_assignment: Some(create_endpoint_resource(name, endpoint_addr)),
-            health_checks: vec![],
-            max_requests_per_connection: None,
-            circuit_breakers: None,
-            upstream_http_protocol_options: None,
-            common_http_protocol_options: None,
-            http_protocol_options: None,
-            http2_protocol_options: None,
-            typed_extension_protocol_options: HashMap::new(),
-            dns_refresh_rate: None,
-            dns_failure_refresh_rate: None,
-            respect_dns_ttl: false,
-            dns_lookup_family: 0,
-            dns_resolvers: vec![],
-            use_tcp_for_dns_lookups: false,
-            outlier_detection: None,
-            cleanup_interval: None,
-            upstream_bind_config: None,
-            lb_subset_config: None,
-            common_lb_config: None,
-            transport_socket: None,
-            metadata: None,
-            protocol_selection: 0,
-            upstream_connection_options: None,
-            close_connections_on_host_health_failure: false,
-            ignore_health_on_host_removal: false,
-            filters: vec![],
-            lrs_server: None,
-            track_timeout_budgets: false,
-            upstream_config: None,
-            track_cluster_stats: None,
-            preconnect_policy: None,
-            connection_pool_per_downstream_connection: false,
-            cluster_discovery_type: Some(ClusterDiscoveryType::Type(0)),
-            lb_config: None,
-        }
+#[allow(deprecated)]
+fn create_cluster_resource(name: &str, endpoint_addr: SocketAddr) -> Cluster {
+    Cluster {
+        name: name.into(),
+        transport_socket_matches: vec![],
+        alt_stat_name: "".into(),
+        eds_cluster_config: None,
+        connect_timeout: None,
+        per_connection_buffer_limit_bytes: None,
+        lb_policy: 0,
+        load_balancing_policy: None,
+        load_assignment: Some(create_endpoint_resource(name, endpoint_addr)),
+        health_checks: vec![],
+        max_requests_per_connection: None,
+        circuit_breakers: None,
+        upstream_http_protocol_options: None,
+        common_http_protocol_options: None,
+        http_protocol_options: None,
+        http2_protocol_options: None,
+        typed_extension_protocol_options: HashMap::new(),
+        dns_refresh_rate: None,
+        dns_failure_refresh_rate: None,
+        respect_dns_ttl: false,
+        dns_lookup_family: 0,
+        dns_resolvers: vec![],
+        use_tcp_for_dns_lookups: false,
+        outlier_detection: None,
+        cleanup_interval: None,
+        upstream_bind_config: None,
+        lb_subset_config: None,
+        common_lb_config: None,
+        transport_socket: None,
+        metadata: None,
+        protocol_selection: 0,
+        upstream_connection_options: None,
+        close_connections_on_host_health_failure: false,
+        ignore_health_on_host_removal: false,
+        filters: vec![],
+        lrs_server: None,
+        track_timeout_budgets: false,
+        upstream_config: None,
+        track_cluster_stats: None,
+        preconnect_policy: None,
+        connection_pool_per_downstream_connection: false,
+        cluster_discovery_type: Some(ClusterDiscoveryType::Type(0)),
+        lb_config: None,
     }
+}
 
-    fn create_endpoint_resource(cluster_name: &str, address: SocketAddr) -> ClusterLoadAssignment {
-        ClusterLoadAssignment {
-            cluster_name: cluster_name.into(),
-            endpoints: vec![LocalityLbEndpoints {
-                locality: None,
-                lb_endpoints: vec![LbEndpoint {
-                    health_status: 0,
-                    metadata: None,
-                    load_balancing_weight: None,
-                    host_identifier: Some(HostIdentifier::Endpoint(Endpoint {
-                        address: Some(Address {
-                            address: Some(address::Address::SocketAddress(SocketAddress {
-                                protocol: 1,
-                                address: address.ip().to_string(),
-                                resolver_name: "".into(),
-                                ipv4_compat: true,
-                                port_specifier: Some(PortSpecifier::PortValue(
-                                    address.port() as u32
-                                )),
-                            })),
-                        }),
-                        health_check_config: None,
-                        hostname: "".into(),
-                    })),
-                }],
+fn create_endpoint_resource(cluster_name: &str, address: SocketAddr) -> ClusterLoadAssignment {
+    ClusterLoadAssignment {
+        cluster_name: cluster_name.into(),
+        endpoints: vec![LocalityLbEndpoints {
+            locality: None,
+            lb_endpoints: vec![LbEndpoint {
+                health_status: 0,
+                metadata: None,
                 load_balancing_weight: None,
-                priority: 0,
-                proximity: None,
+                host_identifier: Some(HostIdentifier::Endpoint(Endpoint {
+                    address: Some(Address {
+                        address: Some(address::Address::SocketAddress(SocketAddress {
+                            protocol: 1,
+                            address: address.ip().to_string(),
+                            resolver_name: "".into(),
+                            ipv4_compat: true,
+                            port_specifier: Some(PortSpecifier::PortValue(address.port() as u32)),
+                        })),
+                    }),
+                    health_check_config: None,
+                    hostname: "".into(),
+                })),
             }],
-            named_endpoints: HashMap::new(),
-            policy: None,
-        }
+            load_balancing_weight: None,
+            priority: 0,
+            proximity: None,
+        }],
+        named_endpoints: HashMap::new(),
+        policy: None,
     }
+}
 
-    #[allow(deprecated)]
-    fn create_lds_filter_chain(filters: Vec<LdsFilter>) -> LdsFilterChain {
-        LdsFilterChain {
-            filter_chain_match: None,
-            filters,
-            use_proxy_proto: None,
-            metadata: None,
-            transport_socket: None,
-            transport_socket_connect_timeout: None,
-            name: "test-lds-filter-chain".into(),
-            on_demand_configuration: None,
-        }
+#[allow(deprecated)]
+fn create_lds_filter_chain(filters: Vec<LdsFilter>) -> LdsFilterChain {
+    LdsFilterChain {
+        filter_chain_match: None,
+        filters,
+        use_proxy_proto: None,
+        metadata: None,
+        transport_socket: None,
+        transport_socket_connect_timeout: None,
+        name: "test-lds-filter-chain".into(),
+        on_demand_configuration: None,
     }
+}
 
-    #[allow(deprecated)]
-    fn create_lds_listener(name: String, filter_chains: Vec<LdsFilterChain>) -> Listener {
-        Listener {
-            name,
-            address: None,
-            filter_chains,
-            default_filter_chain: None,
-            use_original_dst: None,
-            per_connection_buffer_limit_bytes: None,
-            metadata: None,
-            deprecated_v1: None,
-            drain_type: 0,
-            listener_filters: vec![],
-            listener_filters_timeout: None,
-            continue_on_listener_filters_timeout: false,
-            transparent: None,
-            freebind: None,
-            socket_options: vec![],
-            tcp_fast_open_queue_length: None,
-            traffic_direction: 0,
-            udp_listener_config: None,
-            api_listener: None,
-            connection_balance_config: None,
-            reuse_port: false,
-            access_log: vec![],
-            udp_writer_config: None,
-            tcp_backlog_size: None,
-            bind_to_port: None,
-            listener_specifier: None,
-        }
+#[allow(deprecated)]
+fn create_lds_listener(name: String, filter_chains: Vec<LdsFilterChain>) -> Listener {
+    Listener {
+        name,
+        address: None,
+        filter_chains,
+        default_filter_chain: None,
+        use_original_dst: None,
+        per_connection_buffer_limit_bytes: None,
+        metadata: None,
+        deprecated_v1: None,
+        drain_type: 0,
+        listener_filters: vec![],
+        listener_filters_timeout: None,
+        continue_on_listener_filters_timeout: false,
+        transparent: None,
+        freebind: None,
+        socket_options: vec![],
+        tcp_fast_open_queue_length: None,
+        traffic_direction: 0,
+        udp_listener_config: None,
+        api_listener: None,
+        connection_balance_config: None,
+        reuse_port: false,
+        access_log: vec![],
+        udp_writer_config: None,
+        tcp_backlog_size: None,
+        bind_to_port: None,
+        listener_specifier: None,
     }
 }


### PR DESCRIPTION
This removes the `#[cfg(test)] mod tests {}` around the tests in the `tests/` folder, as these tests are only compiled when `cfg(test)` is true. The rest of the diff is reformatting.