### PR TITLE
Better language on using.md

### DIFF
--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -17,7 +17,7 @@ Quilkin needs to be run with an accompanying [configuration file](./proxy-config
 
 `quilkin --config="configuration.yaml"`
 
-If you require debug output, you can run the same command can be run with the `quilkin-debug` binary.
+To view debug output, run the same command with the `quilkin-debug` binary.
 
 You can also use the shorthand of `-c` instead of `--config` if you so desire.
 


### PR DESCRIPTION
"If you require debug output, you can run the same command can be run with the quilkin-debug binary." was a strange sentence.