### PR TITLE
Add a type for session keys

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -19,6 +19,7 @@ pub use builder::{logger, Builder, PendingValidation, Validated};
 pub(crate) use health::Health;
 pub(crate) use metrics::Metrics;
 pub use server::Server;
+pub use sessions::SessionKey;
 
 mod admin;
 mod builder;

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-pub use session::{Packet, Session};
+pub use session::{Packet, Session, SessionKey};
 pub use session_manager::SESSION_TIMEOUT_SECONDS;
 
 pub(crate) mod error;

--- a/src/proxy/sessions/session.rs
+++ b/src/proxy/sessions/session.rs
@@ -51,6 +51,22 @@ pub struct Session {
     shutdown_tx: watch::Sender<()>,
 }
 
+// A (source, destination) address pair that uniquely identifies a session.
+#[derive(Clone, Eq, Hash, PartialEq, Debug, PartialOrd, Ord)]
+pub struct SessionKey {
+    pub source: SocketAddr,
+    pub destination: SocketAddr,
+}
+
+impl From<(SocketAddr, SocketAddr)> for SessionKey {
+    fn from(pair: (SocketAddr, SocketAddr)) -> Self {
+        SessionKey {
+            source: pair.0,
+            destination: pair.1,
+        }
+    }
+}
+
 /// ReceivedPacketContext contains state needed to process a received packet.
 struct ReceivedPacketContext<'a> {
     packet: &'a [u8],
@@ -179,8 +195,11 @@ impl Session {
     }
 
     /// key returns the key to be used for this session in a SessionMap
-    pub fn key(&self) -> (SocketAddr, SocketAddr) {
-        (self.from, self.dest.address)
+    pub fn key(&self) -> SessionKey {
+        SessionKey {
+            source: self.from,
+            destination: self.dest.address,
+        }
     }
 
     /// process_recv_packet processes a packet that is received by this session.


### PR DESCRIPTION
Currently looking at adding some sort of session based state in a filter
and figured to make this a type rather than using a plain tuple of adresses so that
its easier to identify across the repo