### PR TITLE
CI: Add cross compile and basic image test

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -87,7 +87,7 @@ build-macos-binary:
 	docker run --rm -v $(project_path):/workspace -w /workspace \
 		-v $(CARGO_HOME)/registry:/root/.cargo/registry \
         joseluisq/rust-linux-darwin-builder:$(rust_toolchain) \
-        	sh -c "cargo build --target x86_64-apple-darwin && cargo build --release --target x86_64-apple-darwin"
+        	sh -c "rustup target add x86_64-apple-darwin && cargo build --target x86_64-apple-darwin && cargo build --release --target x86_64-apple-darwin"
 
 # Build release and debug container images.
 # Use IMAGE_NAME argument to specify the container registry and image name. Defaults to 'quilkin'.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,10 +26,32 @@ steps:
       - BUILD_IMAGE_ARG=--cache-from ${_BUILD_IMAGE_TAG}
       - test
     id: test
+  - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
+    dir: ./build
+    args:
+      - BUILD_IMAGE_TAG=${_BUILD_IMAGE_TAG}
+      - BUILD_IMAGE_ARG=--cache-from ${_BUILD_IMAGE_TAG}
+      - build
+    id: build
+  # Run the built images for 5 seconds to make sure that the entrypoint and default config works out of the box
+  - name: gcr.io/cloud-builders/docker
+    dir: ./build
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'timeout --signal=INT --preserve-status 5s docker run --rm quilkin:$(make version)'
+    id: test-quilkin-debug
+  - name: gcr.io/cloud-builders/docker
+    dir: ./build
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'timeout --signal=INT --preserve-status 5s docker run --rm quilkin:$(make version)-debug'
+    id: test-quilkin-release
 options:
   env:
     - "CARGO_HOME=/workspace/.cargo"
-  machineType: E2_HIGHCPU_8
+  machineType: E2_HIGHCPU_32
   dynamic_substitutions: true
 timeout: 1800s
 substitutions:


### PR DESCRIPTION
Identifying that we accidentally keep breaking either the release process and/or the released container images since we don't automate testing of it.

So this PR does several things:

* Fix the issues I found in compiling for macos when testing this CI improvement.
* Adds cross compilation into the CI process.
* Add building the image into the CI process.
* Run the Quilkin release and debug images against their default configuration (which does nothing) for a few seconds, to make sure they don't error.
* Increase build image to 32 cores, which keeps the CI build process to ~13 minutes, which is not too bad.

Long term, if we wanted to keep images/binaries temporarily for PR builds, we can also do so.

Work on #318