### PR TITLE
Add initial version of the test subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,13 @@ bytes = "1.1.0"
 clap = "2.33.3"
 dashmap = "4.0.2"
 either = "1.6.1"
+eyre = "0.6.5"
+futures = "0.3.16"
+humantime-serde = "1.0.0"
 hyper = "0.14.13"
+itertools = "0.10.1"
 num_cpus = "1.13.0"
+once_cell = "1.8.0"
 parking_lot = "0.11.2"
 prometheus = { version = "0.13.0", default-features = false }
 prost = "=0.8"
@@ -63,13 +68,12 @@ slog-async = "2.7.0"
 slog-json = "2.4.0"
 slog-term = "2.8.0"
 snap = "1.0.5"
+stable-eyre = "0.2.2"
+thiserror = "1.0.30"
 tokio = { version = "1.12.0", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
 tokio-stream = "0.1.7"
 tonic = "0.5.2"
 uuid = { version = "0.8.2", default-features = false, features = ["v4"] }
-thiserror = "1.0.30"
-eyre = "0.6.5"
-stable-eyre = "0.2.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.0"
@@ -79,6 +83,7 @@ reqwest = "0.11.5"
 regex = "1.5.4"
 criterion = { version = "0.3.5", features = ["html_reports"] }
 once_cell = "1.8.0"
+assert_cmd = "2.0.0"
 
 [build-dependencies]
 tonic-build = { version = "0.5.2", default_features = false, features = ["transport", "prost"] }

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -37,8 +37,9 @@ static SERVER_INIT: Lazy<()> = Lazy::new(|| {
             .build();
 
         runtime.block_on(async move {
-            let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel::<()>(());
-            server.run(shutdown_rx).await.unwrap();
+            let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+            let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
+            server.run(ready_tx, shutdown_rx).await.unwrap();
         });
     });
 });

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,10 +96,7 @@ impl Config {
     /// or the `/etc/quilkin` directory (on unix platforms only). Returns an
     /// error if the found configuration is invalid, or if no configuration
     /// could be found at any location.
-    pub fn find(
-        log: &slog::Logger,
-        path: Option<&str>,
-    ) -> Result<Self> {
+    pub fn find(log: &slog::Logger, path: Option<&str>) -> Result<Self> {
         find_config_file(log, path)
             .map_err(From::from)
             .and_then(|s| serde_yaml::from_str(&s).map_err(From::from))
@@ -188,15 +185,6 @@ impl Source {
     /// Returns a slice list of endpoints if the configuration
     /// is [`Self::Static`].
     pub fn get_static_endpoints(&self) -> Option<&[Endpoint]> {
-        match self {
-            Source::Static { endpoints, .. } => Some(endpoints),
-            _ => None,
-        }
-    }
-
-    /// Returns a mutable reference to the list of endpoints if the
-    /// configuration is [`Self::Static`].
-    pub fn get_static_endpoints_mut(&mut self) -> Option<&mut Vec<Endpoint>> {
         match self {
             Source::Static { endpoints, .. } => Some(endpoints),
             _ => None,

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -1,0 +1,184 @@
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
+
+use prometheus::proto::MetricType;
+use serde::{
+    de::{Error, MapAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
+use super::{error::TestSuiteDecodeError, Config};
+
+/// The configuration of a Quilkin testsuite.
+pub struct TestSuite {
+    pub config: Config,
+    pub options: TestConfig,
+}
+
+#[derive(Deserialize)]
+pub struct TestConfig {
+    pub config: Option<PathBuf>,
+    pub tests: std::collections::HashMap<String, TestCase>,
+}
+
+impl TestSuite {
+    pub fn find<P: AsRef<Path>>(
+        log: &slog::Logger,
+        path: Option<P>,
+    ) -> Result<Self, TestSuiteDecodeError> {
+        super::find_config_file(log, path)
+            .map_err(From::from)
+            .and_then(|s| Self::from_yaml(&s))
+    }
+
+    /// Attempts to deserialize [`Self`] from a YAML document. A valid source is
+    /// either a combination of [`Config`] document followed by [`TestConfig`]
+    /// document separated by a `---` (YAML document separator), or a
+    /// `TestConfig` document containing a `config` key that points to a valid
+    /// `Config` file.
+    pub fn from_yaml(src: &str) -> Result<Self, TestSuiteDecodeError> {
+        Ok(
+            if let Ok(options) = serde_yaml::from_str::<TestConfig>(src) {
+                let path = options
+                    .config
+                    .as_deref()
+                    .ok_or(TestSuiteDecodeError::MissingConfigInTestOptions)?;
+                let config = serde_yaml::from_reader(std::fs::File::open(path)?)?;
+                Self { config, options }
+            } else {
+                let mut de = serde_yaml::Deserializer::from_str(src);
+                let config =
+                    Config::deserialize(de.next().ok_or(TestSuiteDecodeError::MissingConfig)?)?;
+                let options = TestConfig::deserialize(
+                    de.next().ok_or(TestSuiteDecodeError::MissingTestOptions)?,
+                )?;
+                Self { config, options }
+            },
+        )
+    }
+}
+
+#[derive(Deserialize)]
+pub struct TestCase {
+    /// The data to be given to Quilkin.
+    pub input: Data,
+    /// What we expect Quilkin to send to the game server.
+    pub output: Data,
+    /// Metrics we expect to be set.
+    pub metrics: Option<std::collections::HashMap<String, MetricComparison>>,
+}
+
+#[derive(Deserialize)]
+pub struct MetricComparison {
+    pub name: String,
+    #[serde(deserialize_with = "metric_type_from_str")]
+    pub r#type: MetricType,
+    pub r#value: f64,
+}
+
+fn metric_type_from_str<'de, D>(deserializer: D) -> Result<MetricType, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    const METRIC_TYPES: &[(&str, MetricType)] = &[
+        ("counter", MetricType::COUNTER),
+        ("gauge", MetricType::GAUGE),
+        ("histogram", MetricType::HISTOGRAM),
+        ("summary", MetricType::SUMMARY),
+        ("untyped", MetricType::UNTYPED),
+    ];
+
+    let input = <&str>::deserialize(deserializer)?.to_lowercase();
+
+    METRIC_TYPES
+        .iter()
+        .find(|(key, _)| *key == input)
+        .map(|(_, value)| *value)
+        .ok_or_else(|| {
+            Error::custom(format!(
+                "Invalid Prometheus metric type. Expected: {}",
+                itertools::Itertools::intersperse(
+                    METRIC_TYPES.iter().map(|(key, _)| format!("`{}`", key)),
+                    String::from(", ")
+                )
+                .collect::<String>(),
+            ))
+        })
+}
+
+pub enum Data {
+    String(String),
+    Binary(Vec<u8>),
+    Base64(Vec<u8>),
+}
+
+impl Data {
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            Self::String(string) => string.as_bytes(),
+            Self::Binary(bytes) => bytes,
+            Self::Base64(bytes) => bytes,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Data {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize, Serialize)]
+        struct DataObject<'ty, 'value> {
+            r#type: &'ty str,
+            value: &'value str,
+        }
+
+        struct DataVisitor;
+
+        impl<'de> Visitor<'de> for DataVisitor {
+            type Value = Data;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter
+                    .write_str("a string, an array of bytes or a map containing `type` and `value`")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Data::String(value.to_owned()))
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Ok(Data::Binary(value.to_owned()))
+            }
+
+            fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                // `MapAccessDeserializer` is a wrapper that turns a `MapAccess`
+                // into a `Deserializer`, allowing it to be used as the input to
+                // DataObject's `Deserialize` implementation. DataObject then
+                // deserializes itself using the entries from the map visitor.
+                let object =
+                    DataObject::deserialize(serde::de::value::MapAccessDeserializer::new(map))?;
+
+                match (&*object.r#type.to_lowercase(), object.value) {
+                    ("base64", value) => base64::decode(&value)
+                        .map_err(Error::custom)
+                        .map(Data::Base64),
+                    (key, _) => Err(Error::custom(format!("Unknown data type: `{}`", key))),
+                }
+            }
+        }
+
+        deserializer.deserialize_any(DataVisitor)
+    }
+}

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -54,7 +54,7 @@ impl Endpoint {
 impl Default for Endpoint {
     fn default() -> Self {
         Self {
-            address: std::net::SocketAddrV6::new(std::net::Ipv6Addr::UNSPECIFIED, 0, 0, 0).into(),
+            address: (std::net::Ipv4Addr::UNSPECIFIED, 0).into(),
             metadata: <_>::default(),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub type Result<T, E = eyre::Error> = std::result::Result<T, E>;
 pub use self::{
     config::Config,
     proxy::{logger, Builder, PendingValidation, Server, Validated},
-    runner::{run, run_with_config},
+    runner::{run, run_with_config, test},
 };
 
 pub use quilkin_macros::include_proto;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,11 @@ async fn main() -> quilkin::Result<()> {
                 .about("Start Quilkin process.")
                 .arg(config_arg.clone()),
         )
+        .subcommand(
+            SubCommand::with_name("test")
+                .about("Execute one or more sets of tests.")
+                .arg(config_arg),
+        )
         .get_matches();
 
     slog::info!(log, "Starting Quilkin"; "version" => &*version);
@@ -58,6 +63,12 @@ async fn main() -> quilkin::Result<()> {
                 quilkin::config::Config::find(&log, matches.value_of("config")).map(Arc::new)?;
 
             quilkin::run_with_config(log, config, vec![]).await
+        }
+
+        ("test", Some(matches)) => {
+            let config = quilkin::config::TestSuite::find(&log, matches.value_of("config"))?;
+
+            quilkin::test(log, config, vec![]).await
         }
 
         (_, _) => unreachable!(),

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use slog::{debug, error, info, trace, warn, Logger};
 use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
@@ -95,10 +95,15 @@ struct ProcessDownstreamReceiveConfig {
 impl Server {
     /// start the async processing of incoming UDP packets. Will block until an
     /// event is sent through the stop Receiver.
-    pub async fn run(self, mut shutdown_rx: watch::Receiver<()>) -> Result<()> {
+    pub async fn run(
+        self,
+        ready_tx: oneshot::Sender<SocketAddr>,
+        mut shutdown_rx: watch::Receiver<()>,
+    ) -> Result<()> {
         self.log_config();
 
         let socket = Arc::new(Server::bind(self.config.proxy.port).await?);
+        let local_addr = socket.local_addr().unwrap();
         let session_manager = SessionManager::new(self.log.clone(), shutdown_rx.clone());
         let (send_packets, receive_packets) = mpsc::channel::<Packet>(1024);
 
@@ -127,6 +132,7 @@ impl Server {
         });
 
         slog::info!(self.log, "Quilkin is ready.");
+        let _ = ready_tx.send(local_addr);
 
         tokio::select! {
             join_result = recv_loop => {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
+use std::{net::Ipv4Addr, sync::Arc};
 
 use slog::{debug, info, o};
-use tokio::{signal, sync::watch};
+use tokio::{
+    signal,
+    sync::{oneshot, watch},
+};
 
 use crate::{
-    config::Config,
+    config::{Config, TestSuite},
+    endpoint::Endpoint,
     filters::{DynFilterFactory, FilterRegistry, FilterSet},
     proxy::Builder,
     Result,
@@ -63,6 +67,7 @@ pub async fn run_with_config(
 
     let (shutdown_tx, shutdown_rx) = watch::channel::<()>(());
     let signal_log = log.clone();
+    let (ready_tx, _ready_rx) = oneshot::channel();
     tokio::spawn(async move {
         #[cfg(target_os = "linux")]
         let sig_term = sig_term_fut.recv();
@@ -84,10 +89,88 @@ pub async fn run_with_config(
         shutdown_tx.send(()).ok();
     });
 
-    if let Err(err) = server.run(shutdown_rx).await {
+    if let Err(err) = server.run(ready_tx, shutdown_rx).await {
         info!(log, "Shutting down with error"; "error" => %err);
         Err(err)
     } else {
         Ok(())
     }
+}
+
+/// Start and run a proxy. Any passed in [`FilterFactory`]s are included
+/// alongside the default filter factories.
+pub async fn test(
+    base_log: slog::Logger,
+    mut testsuite: TestSuite,
+    filter_factories: impl IntoIterator<Item = DynFilterFactory>,
+) -> Result<()> {
+    let socket = std::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+    let mut receiver = socket.local_addr().unwrap();
+    receiver.set_ip(Ipv4Addr::LOCALHOST.into());
+
+    std::thread::spawn(move || {
+        let mut packet = [0; 0xffff];
+        loop {
+            let (length, addr) = socket.recv_from(&mut packet).unwrap();
+            let packet = &packet[..length];
+            socket.send_to(packet, addr).unwrap();
+        }
+    });
+
+    let log = base_log.new(o!("source" => "run"));
+
+    {
+        let endpoints = testsuite.config.source.get_static_endpoints_mut().unwrap();
+        *endpoints = vec![Endpoint::new(receiver)];
+    }
+
+    let builder = Builder::from(Arc::new(dbg!(testsuite.config)))
+        .with_log(base_log)
+        .disable_admin()
+        .with_filter_registry(FilterRegistry::new(FilterSet::default_with(
+            &log,
+            filter_factories.into_iter(),
+        )))
+        .validate()?;
+
+    let server = builder.build();
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(());
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let server_handle = tokio::spawn(server.run(ready_tx, shutdown_rx));
+
+    let mut address = ready_rx.await?;
+    address.set_ip(Ipv4Addr::LOCALHOST.into());
+
+    let handles =
+        futures::future::join_all(testsuite.options.tests.into_iter().map(|(name, options)| {
+            let log = log.clone();
+            tokio::spawn(async move {
+                let socket = tokio::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))
+                    .await
+                    .unwrap();
+
+                socket
+                    .send_to(options.input.as_bytes(), address)
+                    .await
+                    .unwrap();
+
+                let mut buf = vec![0; 0xffff];
+                let length = socket.recv(&mut buf).await.unwrap();
+                assert_eq!(options.output.as_bytes(), &buf[..length]);
+                slog::info!(log, "{} Completed Successfully ✅", name);
+            })
+        }))
+        .await;
+
+    if handles.into_iter().any(|result| result.is_err()) {
+        panic!("Some tests failed to complete.");
+    } else {
+        slog::info!(log, "All tests completed successfully 🎉");
+    }
+
+    shutdown_tx.send(())?;
+    server_handle.await.unwrap().unwrap();
+
+    Ok(())
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -238,14 +238,15 @@ impl TestHelper {
     }
 
     pub fn run_server_with_builder(&mut self, builder: Builder<PendingValidation>) {
-        let (shutdown_tx, shutdown_rx) = watch::channel::<()>(());
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let (ready_tx, _ready_rx) = oneshot::channel();
         self.server_shutdown_tx.push(Some(shutdown_tx));
         tokio::spawn(async move {
             builder
                 .validate()
                 .unwrap()
                 .build()
-                .run(shutdown_rx)
+                .run(ready_tx, shutdown_rx)
                 .await
                 .unwrap();
         });

--- a/tests/hello_world.yaml
+++ b/tests/hello_world.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: v1alpha1
+static:
+  endpoints:
+    - address: 127.0.0.1:7001
+---
+tests:
+  it_works:
+    input: Hello
+    output: Hello

--- a/tests/test_cmd.rs
+++ b/tests/test_cmd.rs
@@ -1,0 +1,10 @@
+use assert_cmd::prelude::*;
+
+use std::process::Command;
+
+#[test]
+fn hello_world() {
+    let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    let cmd = cmd.args(&["test", "-c", "./tests/hello_world.yaml"]);
+    assert!(cmd.status().unwrap().success());
+}

--- a/tests/test_cmd.rs
+++ b/tests/test_cmd.rs
@@ -5,6 +5,6 @@ use std::process::Command;
 #[test]
 fn hello_world() {
     let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-    let cmd = cmd.args(&["test", "-c", "./tests/hello_world.yaml"]);
+    let cmd = cmd.args(&["test", "-c", "./tests/hello_world.yaml", "--echo-server"]);
     assert!(cmd.status().unwrap().success());
 }

--- a/tests/xds.rs
+++ b/tests/xds.rs
@@ -240,6 +240,7 @@ dynamic:
         .build();
 
     let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
     let (discovery_response_tx, discovery_response_rx) = mpsc::channel(1);
 
     let mut control_plane_shutdown_rx = shutdown_rx.clone();
@@ -261,7 +262,7 @@ dynamic:
 
     // Run the server.
     tokio::spawn(async move {
-        server.run(shutdown_rx).await.unwrap();
+        server.run(ready_tx, shutdown_rx).await.unwrap();
     });
 
     let timeout = time::sleep(Duration::from_secs(10));


### PR DESCRIPTION
This PR adds an initial version of the `test` subcommand discussed in #318. Adding a `Testsuite` type which represents a given config and a set of tests to be run against that. In addition, the server now accepts a oneshot sender that is used to indicate when the server is ready to start receiving packets, this removes the need to sleep or wait.

Closes #318 as while this currently this only does basic string equality testing, we can add to it and replace tests incrementally, and I think will make more sense to split things up into feature specific issues.