### PR TITLE
Fix 404: Writing Custom Filters

### DIFF
--- a/docs/src/filters/writing_custom_filters.md
+++ b/docs/src/filters/writing_custom_filters.md
@@ -387,21 +387,21 @@ However, it usually contains a Protobuf equivalent of the filter's static config
        }
        ```
 
-[Filter]: ../../../api/quilkin/filters/trait.Filter.html
-[FilterFactory]: ../../../api/quilkin/filters/trait.FilterFactory.html
-[filter-factory-name]: ../../../api/quilkin/filters/trait.FilterFactory.html#tymethod.name
-[FilterRegistry]: ../../../api/quilkin/filters/struct.FilterRegistry.html
-[runner::run]: ../../../api/quilkin/runner/fn.run.html
-[CreateFilterArgs::config]: ../../../api/quilkin/filters/prelude/struct.CreateFilterArgs.html#structfield.config
-[ConfigType::dynamic]: ../../../api/quilkin/config/enum.ConfigType.html#variant.Dynamic
+[Filter]: ../../api/quilkin/filters/trait.Filter.html
+[FilterFactory]: ../../api/quilkin/filters/trait.FilterFactory.html
+[filter-factory-name]: ../../api/quilkin/filters/trait.FilterFactory.html#tymethod.name
+[FilterRegistry]: ../../api/quilkin/filters/struct.FilterRegistry.html
+[runner::run]: ../../api/quilkin/runner/fn.run.html
+[CreateFilterArgs::config]: ../../api/quilkin/filters/prelude/struct.CreateFilterArgs.html#structfield.config
+[ConfigType::dynamic]: ../../api/quilkin/config/enum.ConfigType.html#variant.Dynamic
 
 [anchor-static-config]: #static-configuration
 [Filters]: ../filters.md
 [filter chain]: ../filters.md#filters-and-filter-chain
 [built-in-filters]: ../filters.md#built-in-filters
 [filter configuration]: ../filters.md#filter-config
-[proxy-config]: ../../proxy-configuration.md
-[management server]: ../../xds.md
+[proxy-config]: ../proxy-configuration.md
+[management server]: ../xds.md
 [Tokio]: https://docs.rs/tokio/1.5.0/tokio/
 [Prost]: https://docs.rs/prost/0.7.0/prost/
 [Protobuf]: https://developers.google.com/protocol-buffers


### PR DESCRIPTION
This should give me impetus to complete #367 since I just checked all the links by hand.

Noticed that on local `make docs` you can go extra levels deep on `../` relative links, and they still work locally, but not online.

Anyway, fixed all that up now, so the links aren't 404'd.

Work on #373