### PR TITLE
export proxy, runner module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ mod cluster;
 pub mod metadata;
 pub(crate) mod metrics;
 pub(crate) mod prost;
-mod proxy;
-mod runner;
+pub mod proxy;
+pub mod runner;
 pub(crate) mod utils;
 pub(crate) mod xds;
 


### PR DESCRIPTION
As Below:
```
#[doc(inline)]
pub use self::{
    config::Config,
    proxy::{logger, Builder, PendingValidation, Server, Validated},
    runner::{run, run_with_config},
};
```
The `config` module is exported as pub, but `proxy`, `runner` module does not export as pub.
This pr solved this issue.