### PR TITLE
Update custom filter example and add CI

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -47,7 +47,10 @@ version:
 	@echo $(package_version)
 
 # Run all tests
-test: ensure-build-image
+test: ensure-build-image test-quilkin test-examples
+
+# test only the quilkin crate
+test-quilkin: ensure-build-image
 	docker run --rm $(common_rust_args) \
      		--entrypoint=cargo $(BUILD_IMAGE_TAG) deny check
 	docker run --rm $(common_rust_args) \
@@ -56,6 +59,13 @@ test: ensure-build-image
  		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
 	docker run --rm $(common_rust_args) \
      		--entrypoint=cargo $(BUILD_IMAGE_TAG) test
+
+# Run tests against the examples
+test-examples: ensure-build-image
+	docker run --rm $(common_rust_args) -w /workspace/examples/quilkin-filter-example \
+		--entrypoint=cargo $(BUILD_IMAGE_TAG) clippy --tests -- -D warnings
+	docker run --rm $(common_rust_args) -w /workspace/examples/quilkin-filter-example \
+		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
 
 # Build all binaries, images and related artifacts
 build: binary-archive build-image

--- a/examples/quilkin-filter-example/Cargo.toml
+++ b/examples/quilkin-filter-example/Cargo.toml
@@ -28,6 +28,7 @@ edition = "2018"
 # quilkin = "0.2.0"
 quilkin = { path = "../../" }
 tokio = { version = "1", features = ["full"] }
+tonic = "0.5.0"
 prost = "0.8"
 prost-types = "0.8"
 serde = "1.0"

--- a/examples/quilkin-filter-example/Cargo.toml
+++ b/examples/quilkin-filter-example/Cargo.toml
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+[workspace]
+
 [package]
 name = "quilkin-filter-example"
 version = "0.1.0"
@@ -22,13 +24,15 @@ repository = "https://github.com/googleforgames/quilkin"
 edition = "2018"
 
 [dependencies]
-quilkin = "0.1.0"
-tokio = { version = "1", features = ["full"]}
-prost = "0.7"
-prost-types = "0.7"
+# If lifting this example, you will want to be explicit about the Quilkin version, e.g.
+# quilkin = "0.2.0"
+quilkin = { path = "../../" }
+tokio = { version = "1", features = ["full"] }
+prost = "0.8"
+prost-types = "0.8"
 serde = "1.0"
 serde_yaml = "0.8"
 bytes = "1.0"
 
 [build-dependencies]
-prost-build = "0.7"
+prost-build = "0.8"

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+quilkin::include_proto!("greet");
 use greet::Greet as ProtoGreet;
 use quilkin::filters::prelude::*;
 
@@ -33,10 +34,6 @@ impl TryFrom<ProtoGreet> for Config {
             greeting: p.greeting,
         })
     }
-}
-
-mod greet {
-    include!(concat!(env!("OUT_DIR"), "/greet.rs"));
 }
 
 pub const NAME: &str = "greet.v1";


### PR DESCRIPTION
Update the custom filter example to the new API surface, and also setup CI so that it ensures that it always compiles against dev Quilkin, and therefore will stay in sync going forward.

Next I want to block out pieces of code and inject them into our docs via mdbook when updating https://googleforgames.github.io/quilkin/main/book/filters/writing_custom_filters.html as well, rather than have them copy pasted.

Work on #373