### PR TITLE
Use hostname as default proxy id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ slog-async = "2.6.0"
 slog-json = "2.3.0"
 slog-term = "2.5.0"
 snap = "1.0.3"
+sys-info = "0.9.0"
 tokio = { version = "1.8.2", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
 tokio-stream = "0.1.2"
 tonic = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,12 +63,14 @@ slog-async = "2.6.0"
 slog-json = "2.3.0"
 slog-term = "2.5.0"
 snap = "1.0.3"
-sys-info = "0.9.0"
 tokio = { version = "1.8.2", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
 tokio-stream = "0.1.2"
 tonic = "0.5.0"
 uuid = {version = "0.8.1", default-features = false, features = ["v4"]}
 thiserror = "1.0.25"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+sys-info = "0.9.0"
 
 [dev-dependencies]
 reqwest = "0.11.0"

--- a/docs/src/proxy-configuration.md
+++ b/docs/src/proxy-configuration.md
@@ -25,7 +25,7 @@ properties:
         type: string
         description: |
           An identifier for the proxy instance.
-        default: <uuid> A unique ID is generated for the proxy.
+        default: the machine hostname is used a default. Otherwise it falls back to generating a UUID for the proxy.
       port:
         type: integer
         description: |

--- a/docs/src/proxy-configuration.md
+++ b/docs/src/proxy-configuration.md
@@ -25,7 +25,7 @@ properties:
         type: string
         description: |
           An identifier for the proxy instance.
-        default: the machine hostname is used a default. Otherwise it falls back to generating a UUID for the proxy.
+        default: On linux, the machine hostname is used as default. On all other platforms a UUID is generated for the proxy.
       port:
         type: integer
         description: |

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,7 +112,7 @@ pub struct Proxy {
 }
 
 fn default_proxy_id() -> String {
-    Uuid::new_v4().to_hyphenated().to_string()
+    sys_info::hostname().unwrap_or_else(|_| Uuid::new_v4().to_hyphenated().to_string())
 }
 
 fn default_proxy_port() -> u16 {
@@ -258,7 +258,7 @@ static:
         let config = parse_config(yaml);
 
         assert_eq!(config.proxy.port, 7000);
-        assert_eq!(config.proxy.id.len(), 36);
+        assert!(config.proxy.id.len() > 1);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,12 @@ pub struct Proxy {
     pub port: u16,
 }
 
+#[cfg(not(target_os = "linux"))]
+fn default_proxy_id() -> String {
+    Uuid::new_v4().to_hyphenated().to_string()
+}
+
+#[cfg(target_os = "linux")]
 fn default_proxy_id() -> String {
     sys_info::hostname().unwrap_or_else(|_| Uuid::new_v4().to_hyphenated().to_string())
 }

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -470,7 +470,7 @@ impl Server {
 
     /// log_config outputs a log of what is configured
     fn log_config(&self) {
-        info!(self.log, "Starting"; "port" => self.config.proxy.port);
+        info!(self.log, "Starting"; "port" => self.config.proxy.port, "proxy_id" => &self.config.proxy.id);
     }
 
     /// bind binds the local configured port


### PR DESCRIPTION
If we don't provide a default proxy id this falls back to using the
hostname instead of uuid (and if that fails, then we use a uuid).

For environments like kubernetes, we would like the proxy's id to match
the pod id so that the management server can easily find pod information
for the proxy that is connected to it (the proxy passes its ID when it
connects to the server)