### PR TITLE
Fix duplicate metric registration for filters

### DIFF
--- a/src/filters/capture_bytes/metrics.rs
+++ b/src/filters/capture_bytes/metrics.rs
@@ -32,7 +32,7 @@ impl Metrics {
                 "CaptureBytes",
                 "Total number of packets dropped due capture size being larger than the received packet",
             ))?
-            .register(registry)?,
+            .register_if_not_exists(registry)?,
         })
     }
 }

--- a/src/filters/compress/metrics.rs
+++ b/src/filters/compress/metrics.rs
@@ -38,21 +38,21 @@ impl Metrics {
             ),
             &operation_labels,
         )?
-        .register(registry)?;
+        .register_if_not_exists(registry)?;
 
         let decompressed_bytes_total = IntCounter::with_opts(filter_opts(
             "decompressed_bytes_total",
             "Compress",
             "Total number of decompressed bytes either received or sent.",
         ))?
-        .register(registry)?;
+        .register_if_not_exists(registry)?;
 
         let compressed_bytes_total = IntCounter::with_opts(filter_opts(
             "compressed_bytes_total",
             "Compress",
             "Total number of compressed bytes either received or sent.",
         ))?
-        .register(registry)?;
+        .register_if_not_exists(registry)?;
 
         Ok(Metrics {
             packets_dropped_compress: dropped_metric

--- a/src/filters/local_rate_limit/metrics.rs
+++ b/src/filters/local_rate_limit/metrics.rs
@@ -31,7 +31,7 @@ impl Metrics {
                 "LocalRateLimit",
                 "Total number of packets dropped due to rate limiting",
             ))?
-            .register(registry)?,
+            .register_if_not_exists(registry)?,
         })
     }
 }

--- a/src/filters/token_router/metrics.rs
+++ b/src/filters/token_router/metrics.rs
@@ -36,7 +36,7 @@ impl Metrics {
             ),
             &label_names,
         )?
-        .register(registry)?;
+        .register_if_not_exists(registry)?;
 
         Ok(Metrics {
             packets_dropped_no_token_found: metric


### PR DESCRIPTION
Some filter currently call `register` (rather than
`register_if_not_exists`) which throws an error if the metric
has already been registered - this meant that we couldn't use
multiple instances of those filter in the filter chain