### PR TITLE
Add support for versioned filter chains

### DIFF
--- a/docs/src/filters/capture_bytes.md
+++ b/docs/src/filters/capture_bytes.md
@@ -18,9 +18,10 @@ quilkin.extensions.filters.capture_bytes.v1alpha1.CaptureBytes
 # let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.capture_bytes.v1alpha1.CaptureBytes
-      config:
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.capture_bytes.v1alpha1.CaptureBytes
+        config:
           strategy: PREFIX
           metadataKey: myapp.com/myownkey
           size: 3
@@ -29,7 +30,7 @@ static:
     - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 1);
 # quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 

--- a/docs/src/filters/compress.md
+++ b/docs/src/filters/compress.md
@@ -13,9 +13,10 @@ quilkin.extensions.filters.compress.v1alpha1.Compress
 # let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.compress.v1alpha1.Compress
-      config:
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.compress.v1alpha1.Compress
+        config:
           on_read: COMPRESS
           on_write: DECOMPRESS
           mode: SNAPPY
@@ -23,7 +24,7 @@ static:
     - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 1);
 # quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 

--- a/docs/src/filters/concatenate_bytes.md
+++ b/docs/src/filters/concatenate_bytes.md
@@ -13,9 +13,10 @@ quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes
 # let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes
-      config:
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes
+        config:
           on_read: APPEND
           on_write: DO_NOTHING
           bytes: MXg3aWp5Ng==
@@ -23,7 +24,7 @@ static:
     - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 1);
 # quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 

--- a/docs/src/filters/debug.md
+++ b/docs/src/filters/debug.md
@@ -14,15 +14,16 @@ quilkin.extensions.filters.debug_filter.v1alpha1.Debug
 # let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.debug.v1alpha1.Debug
-      config:
-        id: debug-1
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.debug.v1alpha1.Debug
+        config:
+          id: debug-1
   endpoints:
     - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 1);
 # quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 

--- a/docs/src/filters/load_balancer.md
+++ b/docs/src/filters/load_balancer.md
@@ -14,15 +14,16 @@ quilkin.extensions.filters.load_balancer.v1alpha1.LoadBalancer
 #   let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.load_balancer.v1alpha1.LoadBalancer
-      config:
-        policy: ROUND_ROBIN
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.load_balancer.v1alpha1.LoadBalancer
+        config:
+          policy: ROUND_ROBIN
   endpoints:
     - address: 127.0.0.1:7001
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 1);
 #   quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 # }
 ```

--- a/docs/src/filters/local_rate_limit.md
+++ b/docs/src/filters/local_rate_limit.md
@@ -17,16 +17,17 @@ quilkin.extensions.filters.local_rate_limit.v1alpha1.LocalRateLimit
 #   let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.local_rate_limit.v1alpha1.LocalRateLimit
-      config:
-        max_packets: 1000
-        period: 1
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.local_rate_limit.v1alpha1.LocalRateLimit
+        config:
+          max_packets: 1000
+          period: 1
   endpoints:
     - address: 127.0.0.1:7001
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 1);
 #   quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 # }
 ```

--- a/docs/src/filters/token_router.md
+++ b/docs/src/filters/token_router.md
@@ -16,9 +16,10 @@ quilkin.extensions.filters.token_router.v1alpha1.TokenRouter
 # let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.token_router.v1alpha1.TokenRouter
-      config:
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.token_router.v1alpha1.TokenRouter
+        config:
           metadataKey: myapp.com/myownkey
   endpoints: 
     - address: 127.0.0.1:26000
@@ -34,7 +35,7 @@ static:
             - bmt1eTcweA==
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 1);
 # quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 
@@ -81,12 +82,13 @@ For example, a configuration would look like:
 # let yaml = "
 version: v1alpha1
 static:
-  filters:
-    - name: quilkin.extensions.filters.capture_bytes.v1alpha1.CaptureBytes # Capture and remove the authentication token
-      config:
+  filter_chain:
+    filters:
+      - name: quilkin.extensions.filters.capture_bytes.v1alpha1.CaptureBytes # Capture and remove the authentication token
+        config:
           size: 3
           remove: true
-    - name: quilkin.extensions.filters.token_router.v1alpha1.TokenRouter
+      - name: quilkin.extensions.filters.token_router.v1alpha1.TokenRouter
   endpoints: 
     - address: 127.0.0.1:26000
       metadata:
@@ -101,7 +103,7 @@ static:
             - bmt1eTcweA==
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
-# assert_eq!(config.source.get_static_filters().unwrap().len(), 2);
+# assert_eq!(config.source.get_static_non_versioned_filters().unwrap().len(), 2);
 # quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
 ```
 

--- a/docs/src/filters/writing_custom_filters.md
+++ b/docs/src/filters/writing_custom_filters.md
@@ -149,8 +149,9 @@ version: v1alpha1
 proxy:
   port: 7001
 static:
-  filters:
-  - name: greet.v1
+  filter_chain:
+    filters:
+    - name: greet.v1
   endpoints:
   - address: 127.0.0.1:4321
 ```

--- a/docs/src/proxy.md
+++ b/docs/src/proxy.md
@@ -45,8 +45,9 @@ The proxy exposes the following general metrics (See the metrics sub-sections fo
 
   The total number of packets (not associated with any session) that were dropped by proxy.
   Not that packets reflected by this metric were dropped at an earlier stage before they were associated with any session. For session based metrics, see the list of [session metrics][session-metrics] instead.
-  * `reason = NoConfiguredEndpoints`
+  * `reason`
     - `NoConfiguredEndpoints`: No upstream endpoints were available to send the packet to. This can occur e.g if the endpoints cluster was scaled down to zero and the proxy is configured via a control plane.
+    - `NoFilterChainMatched`: Either no filter chain was found with a version matching the packet, or no version could be captured from the packet.
 
 - `quilkin_cluster_active` (Gauge)
 

--- a/src/capture_bytes.rs
+++ b/src/capture_bytes.rs
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+/// Strategy to apply for acquiring a set of bytes in a packet
+pub enum Strategy {
+    #[serde(rename = "PREFIX")]
+    /// Looks for the set of bytes at the beginning of the packet
+    Prefix,
+    #[serde(rename = "SUFFIX")]
+    /// Look for the set of bytes at the end of the packet
+    Suffix,
+}
+
+pub struct Context {
+    pub strategy: Strategy,
+    pub size: usize,
+    pub remove: bool,
+}
+
+pub struct ProcessedPacket {
+    pub packet: Vec<u8>,
+    pub captured_bytes: Vec<u8>,
+}
+
+impl Context {
+    /// Captures bytes from the input packet according to the configured parameters.
+    /// Returns None if the input packet is too small to contain the configured capture
+    /// size.
+    pub fn capture(&self, mut packet: Vec<u8>) -> Option<ProcessedPacket> {
+        if self.size > packet.len() {
+            return None;
+        }
+
+        let size = self.size;
+        let captured_bytes = match self.strategy {
+            Strategy::Prefix => {
+                if self.remove {
+                    packet.drain(..size).collect()
+                } else {
+                    packet.iter().cloned().take(size).collect()
+                }
+            }
+            Strategy::Suffix => {
+                if self.remove {
+                    packet.split_off(packet.len() - size)
+                } else {
+                    packet.iter().skip(packet.len() - size).cloned().collect()
+                }
+            }
+        };
+
+        Some(ProcessedPacket {
+            packet,
+            captured_bytes,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Context, Strategy};
+
+    #[test]
+    fn capture() {
+        let tests = vec![
+            // (capture_strategy, capture_remove, expected_packet, expected_capture)
+            (Strategy::Prefix, true, "ello", "h"),
+            (Strategy::Prefix, false, "hello", "h"),
+            (Strategy::Suffix, true, "hell", "o"),
+            (Strategy::Suffix, false, "hello", "o"),
+        ];
+
+        for (strategy, remove, expected_packet, expected_capture) in tests {
+            let processed_packet = Context {
+                strategy,
+                size: 1,
+                remove,
+            }
+            .capture("hello".to_string().into_bytes())
+            .unwrap();
+
+            assert_eq!(
+                expected_packet,
+                String::from_utf8(processed_packet.packet).unwrap()
+            );
+
+            assert_eq!(
+                expected_capture,
+                String::from_utf8(processed_packet.captured_bytes).unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn capture_packet_too_small() {
+        let tests = vec![
+            // (capture_strategy, capture_remove, expected_packet)
+            (Strategy::Prefix, true),
+            (Strategy::Suffix, true),
+            (Strategy::Prefix, false),
+            (Strategy::Suffix, false),
+        ];
+        for (strategy, remove) in tests {
+            let ctx = Context {
+                strategy,
+                size: 6,
+                remove,
+            };
+
+            assert!(ctx.capture("hello".to_string().into_bytes()).is_none());
+            assert!(ctx.capture("hello!".to_string().into_bytes()).is_some());
+        }
+    }
+}

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -15,6 +15,10 @@
  */
 
 use super::{Config, Filter};
+use crate::config::{
+    CaptureVersion, DynamicFilterChainConfig, ManagementServer, StaticFilterChainConfig,
+    VersionedStaticFilterChain,
+};
 use crate::{
     config::{Admin, Proxy, Source, Version},
     endpoint::Endpoint,
@@ -35,7 +39,7 @@ impl Builder {
             port: 0,
             admin: Admin::default(),
             source: Source::Static {
-                filters: vec![],
+                filter_chain: StaticFilterChainConfig::NonVersioned(vec![]),
                 endpoints: vec![],
             },
         }
@@ -46,7 +50,38 @@ impl Builder {
     }
 
     pub fn with_static(self, filters: Vec<Filter>, endpoints: Vec<Endpoint>) -> Self {
-        let source = Source::Static { filters, endpoints };
+        let source = Source::Static {
+            filter_chain: StaticFilterChainConfig::NonVersioned(filters),
+            endpoints,
+        };
+        Builder { source, ..self }
+    }
+
+    pub fn with_static_versioned(
+        self,
+        capture_version: CaptureVersion,
+        filter_chains: Vec<VersionedStaticFilterChain>,
+        endpoints: Vec<Endpoint>,
+    ) -> Self {
+        let source = Source::Static {
+            filter_chain: StaticFilterChainConfig::Versioned {
+                capture_version,
+                filter_chains,
+            },
+            endpoints,
+        };
+        Builder { source, ..self }
+    }
+
+    pub fn with_dynamic(
+        self,
+        filter_chain_config: Option<DynamicFilterChainConfig>,
+        management_servers: Vec<ManagementServer>,
+    ) -> Self {
+        let source = Source::Dynamic {
+            filter_chain: filter_chain_config,
+            management_servers,
+        };
         Builder { source, ..self }
     }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -93,7 +93,7 @@ pub struct Metadata {
 /// boundary. Accepts a list of strings representing Base64 encoded data,
 /// this list is then converted into its binary representation while in memory,
 /// and then encoded back as a list of base64 strings.
-mod base64_set {
+pub(crate) mod base64_set {
     use serde::de::Error;
 
     pub type Set<T = Vec<u8>> = std::collections::BTreeSet<T>;

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -55,6 +55,7 @@ pub use self::{
 };
 
 pub(crate) use self::chain::FilterChain;
+pub(crate) use self::chain::FilterChainSource;
 
 /// Trait for routing and manipulating packets.
 ///

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -16,9 +16,14 @@
 
 use prometheus::{Error as PrometheusError, Histogram, HistogramOpts, Registry};
 
-use crate::config::{Filter as FilterConfig, ValidationError};
+use crate::capture_bytes::Context as CaptureBytesContext;
+use crate::config::{
+    CaptureVersion, Filter as FilterConfig, ValidationError,
+    VersionedStaticFilterChain as VersionedStaticFilterChainConfig,
+};
 use crate::filters::{prelude::*, FilterRegistry};
 use crate::metrics::CollectorExt;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 const FILTER_LABEL: &str = "filter";
@@ -33,6 +38,203 @@ pub struct FilterChain {
     filters: Vec<(String, FilterInstance)>,
     filter_read_duration_seconds: Vec<Histogram>,
     filter_write_duration_seconds: Vec<Histogram>,
+}
+
+/// Filter chains can either be versioned of non versioned. So
+/// this acts as a wrapper around a set of filter chains, providing
+/// an API to retrieve them.
+pub(crate) enum FilterChainSource {
+    Versioned {
+        capture_version: CaptureVersion,
+        filter_chains: HashMap<Version, Arc<FilterChain>>,
+    },
+    NonVersioned(Arc<FilterChain>),
+}
+
+/// A filter chain version.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub(crate) struct Version(Vec<u8>);
+
+impl From<Vec<u8>> for Version {
+    fn from(value: Vec<u8>) -> Self {
+        Version(value)
+    }
+}
+
+impl AsRef<Vec<u8>> for Version {
+    fn as_ref(&self) -> &Vec<u8> {
+        &self.0
+    }
+}
+
+/// The return value of [`FilterChainSource::get_filter_chain`]
+pub(crate) struct GetFilterChainResult {
+    pub packet: Vec<u8>,
+    pub version: Option<Version>,
+    pub filter_chain: Arc<FilterChain>,
+}
+
+impl FilterChainSource {
+    /// Creates a non-versioned filter chain from the provided config and
+    /// returns an instance backed by that filter chain.
+    pub fn non_versioned_from_config(
+        filter_registry: &FilterRegistry,
+        metrics_registry: &Registry,
+        filter_configs: Vec<FilterConfig>,
+    ) -> Result<Arc<FilterChainSource>, Error> {
+        FilterChain::try_create(filter_configs, filter_registry, metrics_registry)
+            .map(|filter_chain| Arc::new(FilterChainSource::NonVersioned(Arc::new(filter_chain))))
+    }
+
+    /// Creates a set of versioned filter chains from the provided config and
+    /// returns an instance backed by the filter chains.
+    pub fn versioned_from_config(
+        filter_registry: &FilterRegistry,
+        metrics_registry: &Registry,
+        capture_version: CaptureVersion,
+        filter_chains_config: Vec<VersionedStaticFilterChainConfig>,
+    ) -> Result<Arc<FilterChainSource>, Error> {
+        filter_chains_config
+            .into_iter()
+            .map(|config| {
+                let filters = config.filters;
+                let versions = config.versions;
+                FilterChain::try_create(filters, filter_registry, metrics_registry)
+                    .map(Arc::new)
+                    .map(|filter_chain| {
+                        versions
+                            .into_iter()
+                            .map(|version| (Version(version), filter_chain.clone()))
+                            .collect::<Vec<_>>()
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(|filter_chains| {
+                Arc::new(FilterChainSource::Versioned {
+                    capture_version,
+                    filter_chains: filter_chains.into_iter().flatten().collect(),
+                })
+            })
+    }
+
+    /// Returns an instance backed by the provided non-versioned filter chain.
+    pub fn non_versioned(filter_chain: FilterChain) -> Arc<FilterChainSource> {
+        Arc::new(FilterChainSource::NonVersioned(Arc::new(filter_chain)))
+    }
+
+    /// Returns an instance backed by the provided set of versioned filter chains.
+    pub fn versioned(
+        capture_version: CaptureVersion,
+        filter_chains: HashMap<Version, Arc<FilterChain>>,
+    ) -> Arc<FilterChainSource> {
+        Arc::new(FilterChainSource::Versioned {
+            capture_version,
+            filter_chains,
+        })
+    }
+
+    /// Returns the capture version information if the proxy is configured to
+    /// use versioned filter chains.
+    pub fn get_capture_version(&self) -> Option<CaptureVersion> {
+        match self {
+            FilterChainSource::Versioned {
+                capture_version,
+                filter_chains: _,
+            } => Some(capture_version.clone()),
+            FilterChainSource::NonVersioned(_) => None,
+        }
+    }
+
+    /// Returns the filter chain that matches the specified version.
+    ///
+    /// An error is returned if no match is found or the current instance
+    /// is not backed by versioned filter chains.
+    pub fn get_filter_chain_for_version(
+        &self,
+        version: &Version,
+    ) -> Result<Arc<FilterChain>, GetFilterChainError> {
+        match self {
+            FilterChainSource::Versioned {
+                filter_chains,
+                capture_version: _,
+            } => filter_chains
+                .get(version)
+                .cloned()
+                .ok_or(GetFilterChainError::NoVersionMatch),
+            FilterChainSource::NonVersioned(_) => Err(GetFilterChainError::NoVersionMatch),
+        }
+    }
+
+    /// Returns the single non versioned filter chain only if this is a
+    /// non versioned filter chain implementation.
+    pub fn get_filter_chain_non_versioned(&self) -> Option<Arc<FilterChain>> {
+        match self {
+            FilterChainSource::NonVersioned(filter_chain) => Some(filter_chain.clone()),
+            FilterChainSource::Versioned { .. } => None,
+        }
+    }
+
+    /// Selects a filter chain for a packet - potentially capturing a version
+    /// from the packet if configured to use a versioned filter chain.
+    ///
+    /// The potentially modified packet is returned back with the selected filter
+    /// chain and any captured version.
+    pub fn get_filter_chain(
+        &self,
+        packet: Vec<u8>,
+    ) -> Result<GetFilterChainResult, GetFilterChainError> {
+        match self {
+            FilterChainSource::Versioned {
+                capture_version,
+                filter_chains: _,
+            } => {
+                // Capture the version from the packet.
+                let capture_context = CaptureBytesContext {
+                    strategy: capture_version.strategy.clone(),
+                    size: capture_version.size,
+                    remove: capture_version.remove,
+                };
+
+                let version_size = capture_version.size;
+                let packet_size = packet.len();
+                let processed_packet =
+                    capture_context
+                        .capture(packet)
+                        .ok_or(GetFilterChainError::PacketTooSmall {
+                            version_size,
+                            packet_size,
+                        })?;
+
+                let packet = processed_packet.packet;
+                let version = Version(processed_packet.captured_bytes);
+
+                // Find a filter chain that matches the captured version.
+                let filter_chain = self.get_filter_chain_for_version(&version)?;
+                Ok(GetFilterChainResult {
+                    packet,
+                    version: Some(version),
+                    filter_chain,
+                })
+            }
+            FilterChainSource::NonVersioned(filter_chain) => Ok(GetFilterChainResult {
+                packet,
+                version: None,
+                filter_chain: filter_chain.clone(),
+            }),
+        }
+    }
+}
+
+/// Error returned when retrieving a filter chain.
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub(crate) enum GetFilterChainError {
+    #[error("the configured version size {version_size}Bytes is smaller larger than packet size {packet_size}Bytes")]
+    PacketTooSmall {
+        version_size: usize,
+        packet_size: usize,
+    },
+    #[error("no filter matched the version captured from the packet")]
+    NoVersionMatch,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -164,6 +366,8 @@ mod tests {
     };
 
     use super::*;
+    use crate::capture_bytes::Strategy;
+    use crate::test_utils::{append_bytes_filter, new_registry};
 
     #[test]
     fn from_config() {
@@ -357,5 +561,191 @@ mod tests {
             ],
             configs
         )
+    }
+
+    #[test]
+    fn get_versioned_filter_chain() {
+        // Test that we can capture the version from packets and match
+        // it to a filter chain.
+
+        let filter_registry = new_registry(&logger());
+        let filter_chain_source = FilterChainSource::versioned_from_config(
+            &filter_registry,
+            &prometheus::Registry::default(),
+            CaptureVersion {
+                strategy: Strategy::Prefix,
+                size: 1,
+                remove: true,
+            },
+            vec![
+                VersionedStaticFilterChainConfig {
+                    versions: vec![vec![0], vec![1]].into_iter().collect(),
+                    filters: vec![append_bytes_filter("filter-0")],
+                },
+                VersionedStaticFilterChainConfig {
+                    versions: vec![vec![2]].into_iter().collect(),
+                    filters: vec![append_bytes_filter("filter-1")],
+                },
+            ],
+        )
+        .unwrap();
+
+        let tests = vec![
+            // (packet_version, expected_filter_chain)
+            (vec![0], "filter-0"),
+            (vec![1], "filter-0"),
+            (vec![2], "filter-1"),
+        ];
+
+        let endpoints_fixture = endpoints();
+        for (version, expected) in tests {
+            let packet = vec![version.clone(), String::from("hello-").into_bytes()].concat();
+            let got = filter_chain_source.get_filter_chain(packet).unwrap();
+            let response = got
+                .filter_chain
+                .read(ReadContext::new(
+                    upstream_endpoints(endpoints_fixture.clone()),
+                    "127.0.0.1:70".parse().unwrap(),
+                    got.packet,
+                ))
+                .unwrap();
+
+            // Check that the version we extracted is what we expect.
+            assert_eq!(version, got.version.unwrap().0);
+
+            // Check the filter chain that got selected.
+            assert_eq!(
+                format!("hello-{}", expected),
+                from_utf8(response.contents.as_slice()).unwrap()
+            );
+        }
+
+        // No filter chain matches this version.
+        let packet = vec![vec![3], String::from("hello-").into_bytes()].concat();
+        assert_eq!(
+            Some(GetFilterChainError::NoVersionMatch),
+            filter_chain_source.get_filter_chain(packet).err()
+        )
+    }
+
+    #[test]
+    fn get_versioned_filter_chain_packet_too_small() {
+        // Test that we get an error if a packet is too small to contain a version.
+        let tests = vec![
+            (Strategy::Prefix, true),
+            (Strategy::Prefix, false),
+            (Strategy::Suffix, true),
+            (Strategy::Suffix, false),
+        ];
+
+        for (strategy, remove) in tests {
+            let filter_registry = new_registry(&logger());
+            let filter_chain_source = FilterChainSource::versioned_from_config(
+                &filter_registry,
+                &prometheus::Registry::default(),
+                CaptureVersion {
+                    strategy,
+                    size: 10,
+                    remove,
+                },
+                vec![VersionedStaticFilterChainConfig {
+                    versions: vec![vec![0]].into_iter().collect(),
+                    filters: vec![append_bytes_filter("filter-0")],
+                }],
+            )
+            .unwrap();
+            let packet = vec![vec![0], String::from("hello-").into_bytes()].concat();
+
+            assert_eq!(
+                Some(GetFilterChainError::PacketTooSmall {
+                    version_size: 10,
+                    packet_size: 7,
+                }),
+                filter_chain_source.get_filter_chain(packet).err()
+            );
+        }
+    }
+
+    #[test]
+    fn get_versioned_filter_chain_different_capture_versions() {
+        let metrics_registry = prometheus::Registry::default();
+        let endpoints_fixture = endpoints();
+
+        let tests = vec![
+            // (packet_version, capture_strategy, capture_remove, expected_packet)
+            (vec![104], Strategy::Prefix, true, "ello"),
+            (vec![104], Strategy::Prefix, false, "hello"),
+            (vec![108], Strategy::Suffix, true, "helo"),
+            (vec![108], Strategy::Suffix, false, "hello"),
+        ];
+
+        for (version, strategy, remove, expected) in tests {
+            let filter_registry = new_registry(&logger());
+            let filter_chain_source = FilterChainSource::versioned_from_config(
+                &filter_registry,
+                &metrics_registry,
+                CaptureVersion {
+                    strategy,
+                    size: 1,
+                    remove,
+                },
+                vec![VersionedStaticFilterChainConfig {
+                    versions: vec![version.clone()].into_iter().collect(),
+                    filters: vec![append_bytes_filter("o")],
+                }],
+            )
+            .unwrap();
+
+            let packet = String::from("hell").into_bytes();
+            let got = filter_chain_source.get_filter_chain(packet).unwrap();
+
+            let response = got
+                .filter_chain
+                .read(ReadContext::new(
+                    upstream_endpoints(endpoints_fixture.clone()),
+                    "127.0.0.1:70".parse().unwrap(),
+                    got.packet,
+                ))
+                .unwrap();
+
+            // Check that the version we extracted is what we expect.
+            assert_eq!(version, got.version.unwrap().0);
+
+            // Check if the version was removed from the packet when requested.
+            assert_eq!(expected, from_utf8(response.contents.as_slice()).unwrap());
+        }
+    }
+
+    #[test]
+    fn empty_filter_chain() {
+        // Test that an empty versioned filter chain returns error for packets,
+        // while an empty non-versioned filter chain does not
+        let metrics_registry = prometheus::Registry::default();
+
+        let filter_registry = new_registry(&logger());
+        let versioned_filter_chain_source = FilterChainSource::versioned_from_config(
+            &filter_registry,
+            &metrics_registry,
+            CaptureVersion {
+                strategy: Strategy::Prefix,
+                size: 1,
+                remove: false,
+            },
+            vec![],
+        )
+        .unwrap();
+        let non_versioned_filter_chain_source =
+            FilterChainSource::non_versioned(FilterChain::new(vec![], &metrics_registry).unwrap());
+
+        let packet = String::from("hello").into_bytes();
+        assert_eq!(
+            Some(GetFilterChainError::NoVersionMatch),
+            versioned_filter_chain_source
+                .get_filter_chain(packet.clone())
+                .err()
+        );
+        assert!(non_versioned_filter_chain_source
+            .get_filter_chain(packet)
+            .is_ok());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+pub(crate) mod capture_bytes;
 mod cluster;
 pub mod metadata;
 pub(crate) mod metrics;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -19,7 +19,6 @@ pub use builder::{logger, Builder, PendingValidation, Validated};
 pub(crate) use health::Health;
 pub(crate) use metrics::Metrics;
 pub use server::Server;
-pub use sessions::SessionKey;
 
 mod admin;
 mod builder;

--- a/src/proxy/config_dump.rs
+++ b/src/proxy/config_dump.rs
@@ -17,10 +17,14 @@
 use crate::cluster::cluster_manager::SharedClusterManager;
 use crate::filters::manager::SharedFilterManager;
 
-use crate::endpoint::Endpoint;
+use crate::config::CaptureVersion;
+use crate::endpoint::{base64_set, Endpoint};
+use crate::filters::{FilterChain, FilterChainSource};
 use hyper::http::HeaderValue;
 use hyper::{Body, Response, StatusCode};
 use serde::Serialize;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[derive(Debug, Serialize)]
@@ -32,7 +36,7 @@ struct ClusterDump {
 #[derive(Debug, Serialize)]
 struct ConfigDump {
     clusters: Vec<ClusterDump>,
-    filterchain: FilterChainDump,
+    filter_chain: FilterChainsDump,
 }
 
 #[derive(Debug, Serialize)]
@@ -42,8 +46,38 @@ struct FilterConfigDump {
 }
 
 #[derive(Debug, Serialize)]
-struct FilterChainDump {
-    filters: Vec<FilterConfigDump>,
+struct FilterChainDump(Vec<FilterConfigDump>);
+
+impl From<&Arc<FilterChain>> for FilterChainDump {
+    fn from(filter_chain: &Arc<FilterChain>) -> Self {
+        FilterChainDump(
+            filter_chain
+                .get_configs()
+                .map(|(name, config)| FilterConfigDump {
+                    name: name.into(),
+                    config,
+                })
+                .collect(),
+        )
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct VersionedFilterChainDump {
+    #[serde(with = "base64_set")]
+    versions: base64_set::Set,
+    filters: FilterChainDump,
+}
+
+#[derive(Debug, Serialize)]
+enum FilterChainsDump {
+    #[serde(rename = "versioned")]
+    Versioned {
+        capture_version: CaptureVersion,
+        filter_chains: Vec<VersionedFilterChainDump>,
+    },
+    #[serde(rename = "filters")]
+    NonVersioned(FilterChainDump),
 }
 
 pub(crate) fn handle_request(
@@ -81,18 +115,56 @@ fn create_config_dump_json(
             .map(|upstream_endpoints| upstream_endpoints.iter().cloned().collect::<Vec<_>>())
             .unwrap_or_default()
     };
-    let filters = {
+
+    let filter_chains = {
         let filter_manager = filter_manager.read();
         // Clone the list of filter configs immediately so that we don't hold on
         // to the filter manager's lock while serializing.
-        filter_manager
-            .get_filter_chain()
-            .get_configs()
-            .map(|(name, config)| FilterConfigDump {
-                name: name.into(),
-                config,
-            })
-            .collect::<Vec<_>>()
+        let filter_chain_source = filter_manager.get_filter_chain_source();
+        match filter_chain_source {
+            FilterChainSource::Versioned {
+                capture_version,
+                filter_chains,
+            } => {
+                let grouped_by_chain = filter_chains.iter().fold(
+                    HashMap::new(),
+                    |mut acc: HashMap<*const _, VersionedFilterChainDump>,
+                     (version, filter_chain)| {
+                        match acc.entry(Arc::as_ptr(filter_chain)) {
+                            Entry::Vacant(entry) => {
+                                entry.insert(VersionedFilterChainDump {
+                                    versions: Some(version.as_ref().clone()).into_iter().collect(),
+                                    filters: filter_chain.into(),
+                                });
+                            }
+                            Entry::Occupied(mut entry) => {
+                                let dump = &mut entry.get_mut();
+                                dump.versions.insert(version.as_ref().clone());
+                            }
+                        };
+
+                        acc
+                    },
+                );
+
+                let capture_version = capture_version.clone();
+                // No need to hold on to the lock after we've copied the data we want.
+                drop(filter_manager);
+
+                let mut filter_chains = grouped_by_chain.into_values().collect::<Vec<_>>();
+                // Sort the list of versioned filters by their versions list so that we
+                // get a consistent ordering in the output.
+                // Versions are unique across filter chains so we can use an unstable sort.
+                filter_chains.sort_unstable_by(|a, b| a.versions.cmp(&b.versions));
+                FilterChainsDump::Versioned {
+                    capture_version,
+                    filter_chains,
+                }
+            }
+            FilterChainSource::NonVersioned(filter_chain) => {
+                FilterChainsDump::NonVersioned(filter_chain.into())
+            }
+        }
     };
 
     let dump = ConfigDump {
@@ -100,7 +172,7 @@ fn create_config_dump_json(
             name: "default-quilkin-cluster",
             endpoints,
         }],
-        filterchain: FilterChainDump { filters },
+        filter_chain: filter_chains,
     };
 
     serde_json::to_string_pretty(&dump)
@@ -109,10 +181,12 @@ fn create_config_dump_json(
 #[cfg(test)]
 mod tests {
     use super::handle_request;
+    use crate::capture_bytes::Strategy;
     use crate::cluster::cluster_manager::ClusterManager;
+    use crate::config::CaptureVersion;
     use crate::endpoint::{Endpoint, Endpoints};
     use crate::filters::manager::FilterManager;
-    use crate::filters::{CreateFilterArgs, FilterChain};
+    use crate::filters::{CreateFilterArgs, FilterChain, FilterChainSource, FilterInstance};
     use crate::test_utils::logger;
     use prometheus::Registry;
     use std::sync::Arc;
@@ -120,63 +194,148 @@ mod tests {
     #[tokio::test]
     async fn test_handle_request() {
         let registry = Registry::default();
-        let cluster_manager = ClusterManager::fixed(
-            &registry,
-            Endpoints::new(vec![Endpoint::new("127.0.0.1:8080".parse().unwrap())]).unwrap(),
-        )
-        .unwrap();
-        let debug_config = &serde_yaml::from_str(
-            "
-id: hello
+
+        fn debug_filter(value: &'static str) -> (String, FilterInstance) {
+            let debug_factory = crate::filters::debug::factory(&logger());
+            (
+                debug_factory.name().into(),
+                debug_factory
+                    .create_filter(CreateFilterArgs::fixed(
+                        Registry::default(),
+                        Some(
+                            &serde_yaml::from_str(
+                                format!(
+                                    "
+id: {}
 ",
-        )
-        .unwrap();
+                                    value
+                                )
+                                .as_str(),
+                            )
+                            .unwrap(),
+                        ),
+                    ))
+                    .unwrap(),
+            )
+        }
 
-        let debug_factory = crate::filters::debug::factory(&logger());
-        let debug_filter = debug_factory
-            .create_filter(CreateFilterArgs::fixed(
-                registry.clone(),
-                Some(debug_config),
-            ))
+        let tests = vec![
+            {
+                (
+                    FilterManager::fixed(FilterChainSource::non_versioned(
+                        FilterChain::new(vec![debug_filter("hello")], &registry).unwrap(),
+                    )),
+                    serde_json::json!({
+                        "clusters": [{
+                          "name": "default-quilkin-cluster",
+                          "endpoints": [{
+                              "address": "127.0.0.1:8080",
+                              "metadata": {
+                                  "quilkin.dev": {
+                                      "tokens": []
+                                  }
+                              }
+                          }]
+                        }],
+                        "filter_chain": {
+                            "filters": [{
+                                "name": "quilkin.extensions.filters.debug.v1alpha1.Debug",
+                                "config":{
+                                    "id": "hello"
+                                }
+                            }]
+                        }
+                    }),
+                )
+            },
+            {
+                (
+                    FilterManager::fixed(FilterChainSource::versioned(
+                        CaptureVersion {
+                            strategy: Strategy::Suffix,
+                            size: 3,
+                            remove: true,
+                        },
+                        {
+                            let chain1 = Arc::new(
+                                FilterChain::new(vec![debug_filter("hello-1")], &registry).unwrap(),
+                            );
+                            let chain2 = Arc::new(
+                                FilterChain::new(vec![debug_filter("hello-2")], &registry).unwrap(),
+                            );
+                            vec![
+                                (vec![0].into(), chain1.clone()),
+                                (vec![1].into(), chain1),
+                                (vec![2].into(), chain2),
+                            ]
+                            .into_iter()
+                            .collect()
+                        },
+                    )),
+                    serde_json::json!({
+                        "clusters": [{
+                          "name": "default-quilkin-cluster",
+                          "endpoints": [{
+                              "address": "127.0.0.1:8080",
+                              "metadata": {
+                                  "quilkin.dev": {
+                                      "tokens": []
+                                  }
+                              }
+                          }]
+                        }],
+                        "filter_chain": {
+                            "versioned": {
+                                "capture_version": {
+                                    "strategy": "SUFFIX",
+                                    "size": 3,
+                                    "remove": true
+                                },
+                                "filter_chains": [
+                                    {
+                                        "versions": [ "AA==", "AQ==" ],
+                                        "filters": [{
+                                            "name": "quilkin.extensions.filters.debug.v1alpha1.Debug",
+                                            "config":{
+                                                "id": "hello-1"
+                                            }
+                                        }]
+                                    },
+                                    {
+                                        "versions": [ "Ag==" ],
+                                        "filters": [{
+                                            "name": "quilkin.extensions.filters.debug.v1alpha1.Debug",
+                                            "config":{
+                                                "id": "hello-2"
+                                            }
+                                        }]
+                                    }
+                                ]
+                            }
+                        }
+                    }),
+                )
+            },
+        ];
+
+        for (filter_manager, expected) in tests {
+            let cluster_manager = ClusterManager::fixed(
+                &registry,
+                Endpoints::new(vec![Endpoint::new("127.0.0.1:8080".parse().unwrap())]).unwrap(),
+            )
             .unwrap();
-        let filter_manager = FilterManager::fixed(Arc::new(
-            FilterChain::new(vec![(debug_factory.name().into(), debug_filter)], &registry).unwrap(),
-        ));
-
-        let mut response = handle_request(cluster_manager, filter_manager);
-        assert_eq!(response.status(), hyper::StatusCode::OK);
-        assert_eq!(
-            response.headers().get("Content-Type").unwrap(),
-            "application/json"
-        );
-        let body = hyper::body::to_bytes(response.body_mut()).await.unwrap();
-        let body = String::from_utf8(body.into_iter().collect()).unwrap();
-
-        let expected = serde_json::json!({
-            "clusters": [{
-              "name": "default-quilkin-cluster",
-              "endpoints": [{
-                  "address": "127.0.0.1:8080",
-                  "metadata": {
-                      "quilkin.dev": {
-                          "tokens": []
-                      }
-                  }
-              }]
-            }],
-            "filterchain": {
-                "filters": [{
-                    "name": "quilkin.extensions.filters.debug.v1alpha1.Debug",
-                    "config":{
-                        "id": "hello"
-                    }
-                }]
-            }
-        });
-
-        assert_eq!(
-            expected,
-            serde_json::from_str::<serde_json::Value>(body.as_str()).unwrap()
-        );
+            let mut response = handle_request(cluster_manager, filter_manager);
+            assert_eq!(response.status(), hyper::StatusCode::OK);
+            assert_eq!(
+                response.headers().get("Content-Type").unwrap(),
+                "application/json"
+            );
+            let body = hyper::body::to_bytes(response.body_mut()).await.unwrap();
+            let body = String::from_utf8(body.into_iter().collect()).unwrap();
+            assert_eq!(
+                expected,
+                serde_json::from_str::<serde_json::Value>(body.as_str()).unwrap()
+            );
+        }
     }
 }

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-pub use session::{Packet, Session, SessionKey};
+pub(crate) use session::{Packet, Session, SessionArgs, SessionKey};
 pub use session_manager::SESSION_TIMEOUT_SECONDS;
 
 pub(crate) mod error;

--- a/src/proxy/sessions/error.rs
+++ b/src/proxy/sessions/error.rs
@@ -14,31 +14,14 @@
  *  limitations under the License.
  */
 
-use std::fmt::{self, Display, Formatter};
-
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("failed to bind to UDP socket on address: {0}")]
     BindUdpSocket(tokio::io::Error),
+    #[error("failed to send a packet to the destination address: {0}")]
     SendToDst(std::io::Error),
+    #[error("failed to update session expiration time: {0}")]
     UpdateSessionExpiration(String),
+    #[error("packet was dropped because it has a different version from the session's configured version")]
+    VersionMismatch,
 }
-
-impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::BindUdpSocket(inner) => {
-                write!(f, "failed to bind to UDP socket on address: {}", inner)
-            }
-            Error::SendToDst(inner) => write!(
-                f,
-                "failed to send a packet to the destination address: {}",
-                inner
-            ),
-            Error::UpdateSessionExpiration(reason) => {
-                write!(f, "failed to update session expiration time: {}", reason)
-            }
-        }
-    }
-}
-
-impl std::error::Error for Error {}

--- a/src/xds/ads_client.rs
+++ b/src/xds/ads_client.rs
@@ -535,6 +535,7 @@ mod tests {
             ListenerManagerArgs::new(
                 Registry::default(),
                 FilterRegistry::default(),
+                None,
                 filter_chain_updates_tx,
             ),
             shutdown_rx,

--- a/tests/filter_chain.rs
+++ b/tests/filter_chain.rs
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use quilkin::test_utils::{wait_for, wait_for_ok, TestHelper};
+
+#[tokio::test]
+async fn static_versioned_filter_chains() {
+    let mut t = TestHelper::default();
+
+    // create an echo server as a server.
+    let server_address = t.run_echo_server().await;
+
+    let proxy_port = "12348";
+    let yaml = format!(
+        "
+version: v1alpha1
+proxy:
+  id: test-versioned-filter-chain
+  port: {}
+static:
+  filter_chain:
+    versioned:
+      capture_version:
+        strategy: PREFIX
+        size: 1
+      filter_chains:
+      - versions:
+        - AA==
+        - AQ==
+        filters:
+        - name: quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes
+          config:
+            on_read: APPEND
+            on_write: DO_NOTHING
+            bytes: ZmlsdGVyLTE=
+      - versions:
+        - Ag==
+        filters:
+        - name: quilkin.extensions.filters.concatenate_bytes.v1alpha1.ConcatenateBytes
+          config:
+            on_read: APPEND
+            on_write: DO_NOTHING
+            bytes: ZmlsdGVyLTI=
+  endpoints:
+  - address: {}
+",
+        proxy_port, server_address
+    );
+
+    t.run_server_with_config(serde_yaml::from_str(yaml.as_str()).unwrap());
+
+    let tests = vec![
+        // (version, expected_response_packet)
+        (vec![0], "hello-filter-1".to_string()),
+        (vec![1], "hello-filter-1".to_string()),
+        (vec![2], "hello-filter-2".to_string()),
+    ];
+
+    // Test that for each version we get the expected filter chain transformation.
+    for (version, expected) in tests {
+        // Create a new client each time since we can't use different versions for
+        // the same client.
+        let (mut client_packet_rx, client_socket) = t.open_socket_and_recv_multiple_packets().await;
+        client_socket
+            .connect(format!("127.0.0.1:{}", proxy_port))
+            .await
+            .unwrap();
+
+        // Use the client to send the packet to Quilkin.
+        let packet: Vec<u8> = vec![version.clone(), String::from("hello-").into_bytes()].concat();
+        wait_for_ok(client_socket.send(&packet)).await.unwrap();
+
+        // Wait for the client to receive a response back.
+        let response = wait_for(client_packet_rx.recv()).await.unwrap();
+
+        assert_eq!(Some(expected), response);
+    }
+}


### PR DESCRIPTION
As discussed in #401, this adds support to specify multiple filter
chains and have quilkin strip off a byte slice
from packets and compare that against several filter chains
to find a filter chain match that would be used to process the
packet.
The updated docs and tests should show how this works from a user's pov.
Config wise, it works similar to what was proposed in the ticket, the
only difference being that confuring the single filter chain we have
today lives 1 level nested at `static.filter_chain.filters` as opposed
to `static.filters` that we have today.

Closes #401

