### PR TITLE
Add a rate limited logger

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -31,10 +31,11 @@ static SERVER_INIT: Lazy<()> = Lazy::new(|| {
                 )],
             )
             .build();
-        let server = quilkin::Builder::from(std::sync::Arc::new(config))
-            .validate()
-            .unwrap()
-            .build();
+        let server =
+            quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger())
+                .validate()
+                .unwrap()
+                .build();
 
         runtime.block_on(async move {
             let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel::<()>(());

--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -65,7 +65,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 2);
-# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 # }
 ```
 

--- a/docs/src/filters/capture_bytes.md
+++ b/docs/src/filters/capture_bytes.md
@@ -30,7 +30,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 ```
 
 ### Configuration Options

--- a/docs/src/filters/compress.md
+++ b/docs/src/filters/compress.md
@@ -24,7 +24,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 ```
 
 The above example shows a proxy that could be used with a typical game client, where the original client data is 

--- a/docs/src/filters/concatenate_bytes.md
+++ b/docs/src/filters/concatenate_bytes.md
@@ -24,7 +24,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 ```
 
 ### Configuration Options

--- a/docs/src/filters/debug.md
+++ b/docs/src/filters/debug.md
@@ -23,7 +23,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 ```
 
 ### Configuration Options

--- a/docs/src/filters/load_balancer.md
+++ b/docs/src/filters/load_balancer.md
@@ -23,7 +23,7 @@ static:
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-#   quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 # }
 ```
 

--- a/docs/src/filters/local_rate_limit.md
+++ b/docs/src/filters/local_rate_limit.md
@@ -27,7 +27,7 @@ static:
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-#   quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 # }
 ```
 To configure a rate limiter, we specify the maximum rate at which the proxy is allowed to forward packets. In the example above, we configured the proxy to forward a maximum of 1000 packets per second).

--- a/docs/src/filters/token_router.md
+++ b/docs/src/filters/token_router.md
@@ -35,7 +35,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 1);
-# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 ```
 
 View the [CaptureBytes](./capture_bytes.md) filter documentation for more details.
@@ -102,7 +102,7 @@ static:
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.source.get_static_filters().unwrap().len(), 2);
-# quilkin::Builder::from(std::sync::Arc::new(config)).validate().unwrap();
+# quilkin::builder_from_config(std::sync::Arc::new(config), quilkin::log::test_logger()).validate().unwrap();
 ```
 
 On the game client side the [ConcatenateBytes](./concatenate_bytes.md) filter could also be used to add authentication

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,12 +31,9 @@ use crate::endpoint::Endpoint;
 pub(crate) use self::error::ValueInvalidArgs;
 
 pub use self::{builder::Builder, config_type::ConfigType, error::ValidationError};
+use crate::log::SharedLogger;
 
 base64_serde_type!(Base64Standard, base64::STANDARD);
-
-// For some log messages on the hot path (potentially per-packet), we log 1 out
-// of every `LOG_SAMPLING_RATE` occurrences to avoid spamming the logs.
-pub(crate) const LOG_SAMPLING_RATE: u64 = 1000;
 
 /// Config is the configuration of a proxy
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -62,7 +59,7 @@ impl Config {
     /// error if the found configuration is invalid, or if no configuration
     /// could be found at any location.
     pub fn find(
-        log: &slog::Logger,
+        log: &SharedLogger,
         path: Option<&str>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         const ENV_CONFIG_PATH: &str = "QUILKIN_CONFIG";
@@ -76,7 +73,7 @@ impl Config {
         )
         .canonicalize()?;
 
-        slog::info!(log, "Found configuration file"; "path" => config_path.display());
+        crate::info!(log, "Found configuration file"; "path" => config_path.display());
 
         std::fs::File::open(&config_path)
             .or_else(|error| {

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -160,14 +160,15 @@ mod tests {
         config,
         endpoint::{Endpoint, Endpoints, UpstreamEndpoints},
         filters::{debug, FilterRegistry, FilterSet},
-        test_utils::{logger, new_test_chain, TestFilterFactory},
+        test_utils::{new_test_chain, TestFilterFactory},
     };
 
     use super::*;
+    use crate::log::test_logger;
 
     #[test]
     fn from_config() {
-        let log = logger();
+        let log = test_logger();
         let provider = debug::factory(&log);
 
         // everything is fine

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -57,11 +57,12 @@ impl FilterRegistry {
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-    use crate::test_utils::{logger, new_registry};
+    use crate::test_utils::new_registry;
 
     use super::*;
     use crate::endpoint::{Endpoint, Endpoints};
     use crate::filters::{Filter, ReadContext, ReadResponse, WriteContext, WriteResponse};
+    use crate::log::test_logger;
     use prometheus::Registry;
 
     struct TestFilter {}
@@ -78,7 +79,7 @@ mod tests {
 
     #[test]
     fn insert_and_get() {
-        let reg = new_registry(&logger());
+        let reg = new_registry(&test_logger());
 
         match reg.get(
             &String::from("not.found"),

--- a/src/filters/set.rs
+++ b/src/filters/set.rs
@@ -16,12 +16,11 @@
 
 use std::iter::FromIterator;
 
-use slog::Logger;
-
 use crate::filters::{self, DynFilterFactory};
 
 #[cfg(doc)]
 use crate::filters::{FilterFactory, FilterRegistry};
+use crate::log::SharedLogger;
 
 /// A map of [`FilterFactory::name`]s to [`DynFilterFactory`] values.
 pub type FilterMap = std::collections::HashMap<&'static str, DynFilterFactory>;
@@ -42,7 +41,7 @@ impl FilterSet {
     /// - [`capture_bytes`][filters::capture_bytes]
     /// - [`token_router`][filters::token_router]
     /// - [`compress`][filters::compress]
-    pub fn default(base: &Logger) -> Self {
+    pub fn default(base: &SharedLogger) -> Self {
         Self::default_with(base, Option::into_iter(None))
     }
 
@@ -52,7 +51,7 @@ impl FilterSet {
     ///
     /// See [`FilterSet::default`] for a list of the current defaults.
     pub fn default_with(
-        base: &Logger,
+        base: &SharedLogger,
         filters: impl IntoIterator<Item = DynFilterFactory>,
     ) -> Self {
         Self::with(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
  */
 
 mod cluster;
+pub mod log;
 pub mod metadata;
 pub(crate) mod metrics;
 pub(crate) mod prost;
@@ -36,7 +37,9 @@ pub type Result<T, E = runner::Error> = std::result::Result<T, E>;
 #[doc(inline)]
 pub use self::{
     config::Config,
-    proxy::{logger, Builder, PendingValidation, Server, Validated},
+    proxy::{
+        builder::from_config as builder_from_config, Builder, PendingValidation, Server, Validated,
+    },
     runner::{run, run_with_config},
 };
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,333 @@
+use slog::{o, Drain};
+use slog_term::{FullFormat, PlainSyncDecorator};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+/// Logger is an optionally rate-limited logger.
+pub struct Logger {
+    pub inner: slog::Logger,
+    tokens: Arc<AtomicU64>,
+    max_messages_per_sec: usize,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+pub type SharedLogger = Arc<Logger>;
+
+impl Drop for Logger {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            // Ignore any error when sending the shutdown signal since
+            // it means the receiver is no longer on the other end anyway.
+            shutdown_tx.send(()).ok();
+        }
+    }
+}
+
+impl Logger {
+    /// Returns a child logger. Note that the root logger still must continue to be in scope
+    /// otherwise the returned logger could get permanently rate limited.
+    pub fn child<T>(&self, values: slog::OwnedKV<T>) -> SharedLogger
+    where
+        T: slog::SendSyncRefUnwindSafeKV + 'static,
+    {
+        Arc::new(Logger {
+            inner: self.inner.new(values),
+            tokens: self.tokens.clone(),
+            max_messages_per_sec: self.max_messages_per_sec,
+            // No shutdown since only one token bucket exists and refill is done
+            // by the root logger.
+            shutdown_tx: None,
+        })
+    }
+
+    /// Returns a root logger that is rate limited.
+    pub fn with_rate_limit(inner: slog::Logger, max_messages_per_sec: usize) -> SharedLogger {
+        Self::new(inner, Some(max_messages_per_sec))
+    }
+
+    /// Returns a root logger that is optionally rate limited.
+    pub fn new(inner: slog::Logger, max_messages_per_sec: Option<usize>) -> SharedLogger {
+        // If we have a rate limit, then spawn a background task to refill tokens.
+        let (max_messages_per_sec, tokens, shutdown_tx) =
+            if let Some(max_messages_per_sec) = max_messages_per_sec {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+                let tokens = Arc::new(AtomicU64::new(0));
+                let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+                let reset_tokens = tokens.clone();
+                tokio::spawn(async move {
+                    loop {
+                        tokio::select! {
+                            _ = interval.tick() => {
+                                reset_tokens.store(0, Ordering::Relaxed);
+                            },
+                            _ = &mut shutdown_rx => {
+                                break;
+                            }
+                        }
+                    }
+                });
+
+                (max_messages_per_sec, tokens, Some(shutdown_tx))
+            } else {
+                // If not running with rate limit, use max values so we never run out of tokens.
+                (usize::MAX, Arc::new(AtomicU64::new(0)), None)
+            };
+
+        Arc::new(Logger {
+            inner,
+            tokens,
+            max_messages_per_sec,
+            shutdown_tx,
+        })
+    }
+
+    pub fn acquire_token(&self) -> Option<()> {
+        match self.tokens.fetch_add(1, Ordering::Relaxed) {
+            v if v == self.max_messages_per_sec as u64 => {
+                // We've now crossed the rate limit threshold, notify only once.
+                slog::warn!(self.inner, "Log messages are being rate limited"; "limit" => format!("{}/s", self.max_messages_per_sec));
+                None
+            }
+            v if v > self.max_messages_per_sec as u64 => None,
+            _ => Some(()),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! error (
+    ($l:expr, #$tag:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::error!($l.inner, $tag, $($args)+)
+        }
+    };
+    ($l:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::error!($l.inner, $($args)+)
+        }
+    };
+);
+
+#[macro_export]
+macro_rules! warn (
+    ($l:expr, #$tag:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::warn!($l.inner, $tag, $($args)+)
+        }
+    };
+    ($l:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::warn!($l.inner, $($args)+)
+        }
+    };
+);
+
+#[macro_export]
+macro_rules! info (
+    ($l:expr, #$tag:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::info!($l.inner, $tag, $($args)+)
+        }
+    };
+    ($l:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::info!($l.inner, $($args)+)
+        }
+    };
+);
+
+#[macro_export]
+macro_rules! debug (
+    ($l:expr, #$tag:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::debug!($l.inner, $tag, $($args)+)
+        }
+    };
+    ($l:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::debug!($l.inner, $($args)+)
+        }
+    };
+);
+
+#[macro_export]
+macro_rules! trace (
+    ($l:expr, #$tag:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::trace!($l.inner, $tag, $($args)+)
+        }
+    };
+    ($l:expr, $($args:tt)+) => {
+        if let Some(()) = $l.acquire_token() {
+            slog::trace!($l.inner, $($args)+)
+        }
+    };
+);
+
+/// Returns a rate limited logger that logs via JSON format.
+pub fn create_default_rate_limited_logger() -> SharedLogger {
+    let drain = slog_json::Json::new(std::io::stdout())
+        .set_pretty(false)
+        .add_default_keys()
+        .build()
+        .fuse();
+    let async_logger = slog_async::Async::new(drain).build().fuse();
+
+    Logger::with_rate_limit(slog::Logger::root(async_logger, o!()), 50)
+}
+
+// Returns a standard out, non rate-limited, non structured terminal logger
+// suitable for using in tests since it's more human readable.
+pub fn test_logger() -> SharedLogger {
+    let plain = PlainSyncDecorator::new(std::io::stdout());
+    let drain = FullFormat::new(plain).build().fuse();
+    Logger::new(slog::Logger::root(drain, o!()), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::eventually;
+    use slog::{o, Drain};
+    use std::io::Write;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use tokio::time;
+
+    #[derive(Clone)]
+    struct Sink(Arc<Mutex<Vec<u8>>>);
+    impl std::io::Write for Sink {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut inner = self.0.lock().unwrap();
+            inner.write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            let mut inner = self.0.lock().unwrap();
+            inner.flush()
+        }
+    }
+    impl Sink {
+        fn collect(&mut self) -> String {
+            self.flush().unwrap();
+            let mut inner = self.0.lock().unwrap();
+            String::from_utf8(std::mem::take(&mut *inner)).unwrap()
+        }
+    }
+
+    fn rate_limited_logger(max: usize) -> (super::SharedLogger, Sink) {
+        let sink = Sink(Arc::new(Mutex::new(Vec::new())));
+        (
+            super::Logger::with_rate_limit(
+                slog::Logger::root(
+                    slog_term::FullFormat::new(slog_term::PlainSyncDecorator::new(sink.clone()))
+                        .build()
+                        .fuse(),
+                    o!(),
+                ),
+                max,
+            ),
+            sink,
+        )
+    }
+    #[tokio::test]
+    async fn rate_limit_max() {
+        // Test that we do not log messages after hitting the rate limit window.
+
+        let max = 2;
+        let (log, mut sink) = rate_limited_logger(max);
+        for i in 0..max * 2 {
+            warn!(log, "line"; "count" => i);
+        }
+
+        let output = sink.collect();
+        assert_eq!((max + 1) as usize, output.lines().count());
+
+        for i in 0..max {
+            assert!(output.contains(format!("WARN line, count: {}\n", i).as_str()));
+        }
+        assert!(output.contains("WARN Log messages are being rate limited, limit: 2/s"));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_refill_tokens() {
+        // Test that we reset the token counter after the rate limit window has elapsed.
+
+        time::pause();
+
+        let max = 2;
+        let (log, mut sink) = rate_limited_logger(max);
+        for i in 0..max * 2 {
+            warn!(log, "line"; "count" => i);
+        }
+
+        let output = sink.collect();
+        assert_eq!((max + 1) as usize, output.lines().count());
+
+        for i in 0..max {
+            assert!(output.contains(format!("WARN line, count: {}\n", i).as_str()));
+        }
+        assert!(output.contains("WARN Log messages are being rate limited, limit: 2/s"));
+
+        time::advance(std::time::Duration::from_secs(2)).await;
+
+        // Wait for a token refill.
+        eventually(
+            || (log.tokens.load(Ordering::SeqCst) == 0).then(|| ()),
+            Duration::from_millis(10),
+            Duration::from_millis(500),
+        )
+        .await
+        .unwrap();
+
+        // Try logging again, we should be able to log new lines now.
+        for i in 0..max * 2 {
+            warn!(log, "line 2"; "count" => i);
+        }
+
+        let output = sink.collect();
+        assert_eq!((max + 1) as usize, output.lines().count());
+
+        for i in 0..max {
+            assert!(output.contains(format!("WARN line 2, count: {}\n", i).as_str()));
+        }
+        assert!(output.contains("WARN Log messages are being rate limited, limit: 2/s"));
+    }
+
+    #[tokio::test]
+    async fn logging_levels() {
+        let max = 10;
+        let (log, mut sink) = rate_limited_logger(max);
+        error!(log, "error");
+        warn!(log, "warn");
+        info!(log, "info");
+        debug!(log, "debug");
+        trace!(log, "trace");
+
+        let output = sink.collect();
+        assert_eq!(4, output.lines().count());
+
+        assert!(output.contains("WARN warn\n"));
+        assert!(output.contains("ERRO error\n"));
+        assert!(output.contains("INFO info\n"));
+        assert!(output.contains("DEBG debug\n"));
+    }
+
+    #[tokio::test]
+    async fn child() {
+        let max = 10;
+        let (log, mut sink) = rate_limited_logger(max);
+
+        let child = log.child(slog::o!("foo" => "bar"));
+
+        warn!(child, "child log 1");
+
+        let output = sink.collect();
+        assert_eq!(1, output.lines().count());
+
+        assert!(output.contains("WARN child log 1"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[tokio::main]
 async fn main() -> quilkin::Result<()> {
-    let log = quilkin::logger();
+    let log = quilkin::log::create_default_rate_limited_logger();
     let version: std::borrow::Cow<'static, str> = if cfg!(debug_assertions) {
         format!("{}+debug", VERSION).into()
     } else {
@@ -48,7 +48,7 @@ async fn main() -> quilkin::Result<()> {
         )
         .get_matches();
 
-    slog::info!(log, "Starting Quilkin"; "version" => &*version);
+    quilkin::info!(log, "Starting Quilkin"; "version" => &*version);
 
     match cli.subcommand() {
         ("run", Some(matches)) => {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -15,14 +15,14 @@
  */
 
 pub(crate) use admin::Admin;
-pub use builder::{logger, Builder, PendingValidation, Validated};
+pub use builder::{from_config, Builder, PendingValidation, Validated};
 pub(crate) use health::Health;
 pub(crate) use metrics::Metrics;
 pub use server::Server;
 pub use sessions::SessionKey;
 
 mod admin;
-mod builder;
+pub(crate) mod builder;
 mod config_dump;
 mod health;
 mod metrics;

--- a/src/proxy/admin.rs
+++ b/src/proxy/admin.rs
@@ -20,15 +20,17 @@ use std::sync::Arc;
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Method, Request, Response, Server as HyperServer, StatusCode};
-use slog::{error, info, o, Logger};
+use slog::o;
 use tokio::sync::watch;
 
 use crate::cluster::cluster_manager::SharedClusterManager;
 use crate::filters::manager::SharedFilterManager;
+use crate::log::SharedLogger;
 use crate::proxy::{config_dump, Health, Metrics};
+use crate::{error, info};
 
 pub struct Admin {
-    log: Logger,
+    log: SharedLogger,
     /// The address that the Admin server starts on
     addr: SocketAddr,
     metrics: Arc<Metrics>,
@@ -44,9 +46,14 @@ struct HandleRequestArgs {
 }
 
 impl Admin {
-    pub fn new(base: &Logger, addr: SocketAddr, metrics: Arc<Metrics>, heath: Health) -> Self {
+    pub fn new(
+        base: &SharedLogger,
+        addr: SocketAddr,
+        metrics: Arc<Metrics>,
+        heath: Health,
+    ) -> Self {
         Admin {
-            log: base.new(o!("source" => "proxy::Admin")),
+            log: base.child(o!("source" => "proxy::Admin")),
             addr,
             metrics,
             health: Arc::new(heath),

--- a/src/proxy/config_dump.rs
+++ b/src/proxy/config_dump.rs
@@ -113,7 +113,7 @@ mod tests {
     use crate::endpoint::{Endpoint, Endpoints};
     use crate::filters::manager::FilterManager;
     use crate::filters::{CreateFilterArgs, FilterChain};
-    use crate::test_utils::logger;
+    use crate::log::test_logger;
     use prometheus::Registry;
     use std::sync::Arc;
 
@@ -132,7 +132,7 @@ id: hello
         )
         .unwrap();
 
-        let debug_factory = crate::filters::debug::factory(&logger());
+        let debug_factory = crate::filters::debug::factory(&test_logger());
         let debug_filter = debug_factory
             .create_filter(CreateFilterArgs::fixed(
                 registry.clone(),

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -16,19 +16,18 @@
 
 use std::net::SocketAddr;
 
-use slog::info;
 use tokio::time::{timeout, Duration};
 
 use quilkin::{
     config::{Builder, Filter},
     endpoint::Endpoint,
     filters::compress,
-    test_utils::{logger, TestHelper},
+    info,
+    test_utils::TestHelper,
 };
 
 #[tokio::test]
 async fn client_and_server() {
-    let log = logger();
     let mut t = TestHelper::default();
     let echo = t.run_echo_server().await;
 
@@ -42,7 +41,7 @@ on_write: COMPRESS
         .with_port(server_port)
         .with_static(
             vec![Filter {
-                name: compress::factory(&log).name().into(),
+                name: compress::factory(&t.log).name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             vec![Endpoint::new(echo)],
@@ -61,7 +60,7 @@ on_write: DECOMPRESS
         .with_port(client_port)
         .with_static(
             vec![Filter {
-                name: compress::factory(&log).name().into(),
+                name: compress::factory(&t.log).name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             vec![Endpoint::new(

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -20,14 +20,14 @@ use std::{
 };
 
 use serde_yaml::{Mapping, Value};
-use slog::info;
 
 use quilkin::{
+    builder_from_config,
     config::{Builder as ConfigBuilder, Filter},
     endpoint::Endpoint,
     filters::debug,
+    info,
     test_utils::{new_registry, TestHelper},
-    Builder as ProxyBuilder,
 };
 
 #[tokio::test]
@@ -53,7 +53,7 @@ async fn test_filter() {
     // Run server proxy.
     let registry = new_registry(&t.log);
     t.run_server_with_builder(
-        ProxyBuilder::from(Arc::new(server_config))
+        builder_from_config(Arc::new(server_config), t.log.clone())
             .with_filter_registry(registry)
             .disable_admin(),
     );
@@ -77,7 +77,7 @@ async fn test_filter() {
     // Run client proxy.
     let registry = new_registry(&t.log);
     t.run_server_with_builder(
-        ProxyBuilder::from(Arc::new(client_config))
+        builder_from_config(Arc::new(client_config), t.log.clone())
             .with_filter_registry(registry)
             .disable_admin(),
     );

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -16,10 +16,10 @@
 use std::{panic, sync::Arc};
 
 use quilkin::{
+    builder_from_config,
     config::{Admin, Builder},
     endpoint::Endpoint,
     test_utils::TestHelper,
-    Builder as ProxyBuilder,
 };
 
 #[tokio::test]
@@ -35,7 +35,7 @@ async fn health_server() {
             address: "[::]:9093".parse().unwrap(),
         })
         .build();
-    t.run_server_with_builder(ProxyBuilder::from(Arc::new(server_config)));
+    t.run_server_with_builder(builder_from_config(Arc::new(server_config), t.log.clone()));
 
     let resp = reqwest::get("http://localhost:9093/live")
         .await

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -18,7 +18,6 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use tokio::time::{timeout, Duration};
 
-use quilkin::test_utils::logger;
 use quilkin::{
     config::{Builder as ConfigBuilder, Filter},
     endpoint::Endpoint,
@@ -41,7 +40,7 @@ period: 1
         .with_port(server_port)
         .with_static(
             vec![Filter {
-                name: local_rate_limit::factory(&logger()).name().into(),
+                name: local_rate_limit::factory(&t.log).name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             vec![Endpoint::new(echo)],

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -19,13 +19,12 @@ use std::{
     sync::Arc,
 };
 
-use slog::info;
-
 use quilkin::{
+    builder_from_config,
     config::{Admin, Builder as ConfigBuilder},
     endpoint::Endpoint,
+    info,
     test_utils::TestHelper,
-    Builder,
 };
 
 #[tokio::test]
@@ -44,7 +43,7 @@ async fn metrics_server() {
             address: "[::]:9092".parse().unwrap(),
         })
         .build();
-    t.run_server_with_builder(Builder::from(Arc::new(server_config)));
+    t.run_server_with_builder(builder_from_config(Arc::new(server_config), t.log.clone()));
 
     // create a local client
     let client_port = 12347;
@@ -58,7 +57,7 @@ async fn metrics_server() {
             ))],
         )
         .build();
-    t.run_server_with_builder(Builder::from(Arc::new(client_config)));
+    t.run_server_with_builder(builder_from_config(Arc::new(client_config), t.log.clone()));
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -23,14 +23,13 @@ use quilkin::{
     endpoint::Endpoint,
     filters::{capture_bytes, token_router},
     metadata::MetadataView,
-    test_utils::{logger, TestHelper},
+    test_utils::TestHelper,
 };
 
 /// This test covers both token_router and capture_bytes filters,
 /// since they work in concert together.
 #[tokio::test]
 async fn token_router() {
-    let log = logger();
     let mut t = TestHelper::default();
     let echo = t.run_echo_server().await;
 
@@ -49,11 +48,11 @@ quilkin.dev:
         .with_static(
             vec![
                 Filter {
-                    name: capture_bytes::factory(&log).name().into(),
+                    name: capture_bytes::factory(&t.log).name().into(),
                     config: serde_yaml::from_str(capture_yaml).unwrap(),
                 },
                 Filter {
-                    name: token_router::factory(&log).name().into(),
+                    name: token_router::factory(&t.log).name().into(),
                     config: None,
                 },
             ],


### PR DESCRIPTION
We currently have a `LOG_SAMPLING_RATE` variable which is a more naive
solution to limit the messages we log. Instead, this
makes sure that we don't log over a threshold across the proxy in a
single time window.

Impl wise its a tiny wrapper (log.rs) around the log macros that check if we're
allowed to log a message and drops it otherwise. The remaining changes
update usages so even though this touches a few files its not as large a
change

This has a breaking change, now the function to create a `Builder` from `Config` takes in a logger

