### PR TITLE
Move iPerf benchmark to use Docker

### DIFF
--- a/examples/iperf3/Dockerfile
+++ b/examples/iperf3/Dockerfile
@@ -1,9 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 FROM rust:latest
-WORKDIR /quilkin
+WORKDIR /app
 # How to install quilkin
 ARG install_args="--git https://github.com/googleforgames/quilkin quilkin"
 RUN apt update && apt install -y iperf3 socat
 RUN cargo install $install_args
-COPY ./run.sh /quilkin
-COPY ./proxy.yaml /quilkin/quilkin.yaml
-CMD ["/quilkin/run.sh"]
+COPY ./run.sh /app
+COPY ./proxy.yaml /app/quilkin.yaml
+CMD ["/app/run.sh"]

--- a/examples/iperf3/README.md
+++ b/examples/iperf3/README.md
@@ -37,6 +37,10 @@ to be set, such as bandwidth and source.
 
 Several files are captured during the process and stored in `/quilkin`:
 
+```
+docker run -it -v /tmp/quilkin:/quilkin quilkin-iperf
+```
+
 * client.log - output from the iperf3 client.
 * metrics.json - a copy of the Quilkin prometheus metrics on test completion.
 * quilkin.log - output from Quilkin.

--- a/examples/iperf3/run.sh
+++ b/examples/iperf3/run.sh
@@ -18,6 +18,8 @@
 set -eo pipefail
 set +x
 
+mkdir -p /quilkin
+
 # Number of parallel streams to test simultaneously. Default: (maximum: 128)
 PARALLEL="${PARALLEL:-128}"
 # The bitrate for each stream.
@@ -44,7 +46,7 @@ echo "Waiting for startup..."
 sleep 5
 
 set -x
-iperf3 --client 127.0.0.1 --port $PORT -l $MTU --interval 10 --parallel $PARALLEL --bidir --bandwidth $BANDWIDTH --time 60 --udp | tee client.log
+iperf3 --client 127.0.0.1 --port $PORT -l $MTU --interval 10 --parallel $PARALLEL --bidir --bandwidth $BANDWIDTH --time 60 --udp | tee /quilkin/client.log
 set +x
 
 echo "Taking a snapshot of Quilkin metrics..."


### PR DESCRIPTION
More work around #410. Since we're in general agreement on having linux as our performance target, we need an easy way for developers not on linux to be able to test performance changes. This PR updates the iPerf example for this purpose by moving it to using docker as the environment.

In addition, I've updated the load that we test with iperf, to find something where I could see a noticeable difference between a direct iperf connection and a Quilkin proxied connection, and roughly that seems to be 128 streams trying to send 10Mbit/sec divided into packets of 512 bytes. Here is a comparison of direct and quilkin using this benchmark. You can see it most notably on the receiving side having more packet and thus less throughput than the direct (both are losing some percentage of packets on the receiving at this rate)

### Quilkin
<img width="725" alt="Screenshot 2021-10-13 at 12 07 36" src="https://user-images.githubusercontent.com/4464295/137114016-0d5ba46b-1622-4d9b-a889-ba09796a0a80.png">

### Direct
<img width="725" alt="Screenshot 2021-10-13 at 12 09 36" src="https://user-images.githubusercontent.com/4464295/137114246-49756027-bce8-4af4-a3e8-d88e7cbd0347.png">

