### PR TITLE
Remove reqwest from dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,6 @@ ipnetwork = "0.18.0"
 sys-info = "0.9.0"
 
 [dev-dependencies]
-reqwest = "0.11.5"
 regex = "1.5.4"
 criterion = { version = "0.3.5", features = ["html_reports"] }
 once_cell = "1.8.0"


### PR DESCRIPTION
This PR removes `reqwest` from our `dev-dependencies` and replaces it with using `hyper` directly. This removes a number of dependencies that were only present with `reqwest` and on my machine reduces the total time for clean debug builds by five seconds. Dependency graphs generated with `cargo-depgraph`.

### With Reqwest
```
  cargo build --all --tests  226.34s user 21.31s system 445% cpu 55.542 total
```

![graph-reqwest](https://user-images.githubusercontent.com/4464295/139230650-5fb257e8-42a9-4bb0-8180-bd104f56dfbe.png)

### No Reqwest
```
cargo build --all --tests  220.04s user 20.43s system 472% cpu 50.937 total
```

![graph](https://user-images.githubusercontent.com/4464295/139230596-9dfbed49-5b68-4289-bf77-09cd45315f34.png)