### PR TITLE
Align Filter Chain metrics with conventions

### DIFF
--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -32,12 +32,12 @@ There are a few things we note here:
 
 **Metrics**
 
-* `filter_read_duration_seconds` The duration it took for a `filter`'s
+* `quilkin_filter_read_duration_seconds` The duration it took for a `filter`'s
   `read` implementation to execute.
   * Labels
     * `filter` The name of the filter being executed.
 
-* `filter_write_duration_seconds` The duration it took for a `filter`'s
+* `quilkin_filter_write_duration_seconds` The duration it took for a `filter`'s
   `write` implementation to execute.
   * Labels
     * `filter` The name of the filter being executed.

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-use prometheus::{Error as PrometheusError, Histogram, HistogramOpts, Registry};
+use std::sync::Arc;
+
+use prometheus::{exponential_buckets, Error as PrometheusError, Histogram, Registry};
 
 use crate::config::{Filter as FilterConfig, ValidationError};
 use crate::filters::{prelude::*, FilterRegistry};
-use crate::metrics::CollectorExt;
-use std::sync::Arc;
+use crate::metrics::{histogram_opts, CollectorExt};
 
 const FILTER_LABEL: &str = "filter";
 
@@ -54,14 +55,18 @@ impl From<PrometheusError> for Error {
 
 impl FilterChain {
     pub fn new(filters: Vec<(String, FilterInstance)>, registry: &Registry) -> Result<Self, Error> {
+        let subsystem = "filter";
+
         Ok(Self {
             filter_read_duration_seconds: filters
                 .iter()
                 .map(|(name, _)| {
                     Histogram::with_opts(
-                        HistogramOpts::new(
-                            "filter_read_duration_seconds",
+                        histogram_opts(
+                            "read_duration_seconds",
+                            subsystem,
                             "Seconds taken to execute a given filter's `read`.",
+                            Some(exponential_buckets(0.000125, 2.5, 11).unwrap()),
                         )
                         .const_label(FILTER_LABEL, name),
                     )
@@ -72,9 +77,11 @@ impl FilterChain {
                 .iter()
                 .map(|(name, _)| {
                     Histogram::with_opts(
-                        HistogramOpts::new(
-                            "filter_write_duration_seconds",
+                        histogram_opts(
+                            "write_duration_seconds",
+                            subsystem,
                             "Seconds taken to execute a given filter's `write`.",
+                            Some(exponential_buckets(0.000125, 2.5, 11).unwrap()),
                         )
                         .const_label(FILTER_LABEL, name),
                     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Changes:

* Utilise `histogram_opts` to generate the options for the Histogram to bring the naming inline with other metrics.
* The default Histogram buckets are too large for our usage case. Implemented some exponential buckets based on testing total duration metrics (coming in a later separate PR, for #292).
* Updates the documentation to match.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A