### PR TITLE
xds-server: Create informers before starting informer factory

### DIFF
--- a/xds/cmd/controller.go
+++ b/xds/cmd/controller.go
@@ -68,9 +68,12 @@ func createAgonesClusterProvider(
 		agonesClient,
 		0,
 		externalversions.WithNamespace(flags.GameServersNamespace))
+
+	gameServerLister := informerFactory.Agones().V1().GameServers().Lister()
+
 	informerFactory.Start(ctx.Done())
 
-	return agonescluster.NewProvider(logger, informerFactory.Agones().V1().GameServers().Lister(), agonescluster.Config{
+	return agonescluster.NewProvider(logger, gameServerLister, agonescluster.Config{
 		GameServersNamespace:    flags.GameServersNamespace,
 		GameServersPollInterval: flags.GameServersPollInterval,
 	})
@@ -91,12 +94,15 @@ func createFilterChainProvider(
 			options.LabelSelector = k8sfilterchain.LabelSelectorProxyRole
 		}),
 	)
+
+	podLister := informerFactory.Core().V1().Pods().Lister()
+
 	informerFactory.Start(ctx.Done())
 
 	return k8sfilterchain.NewProvider(
 		logger,
 		clock.RealClock{},
-		informerFactory.Core().V1().Pods().Lister(),
+		podLister,
 		flags.ProxyPollInterval)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
/kind bug

**What this PR does / Why we need it**:

Fixes the Kubernetes controller implementation of the xds management server. Without the fix, the controller isn't able to list any `GameServers` or `Pods` in the cluster, and doesn't update connected Quilkin instances with endpoints.

The informer factory only starts informers that were already requested when `Start()` is called. The informers are requested when getting the Lister for a specific type. As we are calling `Lister()` after `Start()`, the informer never watches for the resources, and `List()` will always return the empty list.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

**Special notes for your reviewer**:

