### PR TITLE
Fix licence field in macros Cargo.toml

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@
 name = "quilkin-macros"
 version = "0.3.0-dev"
 authors = ["Erin Power <erin.power@embark-studios.com>"]
-license-file = "../LICENSE"
+license = "Apache-2.0"
 description = "Quilkin is a non-transparent UDP proxy specifically designed for use with large scale multiplayer dedicated game server deployments, to ensure security, access control, telemetry data, metrics and more."
 homepage = "https://github.com/googleforgames/quilkin"
 repository = "https://github.com/googleforgames/quilkin"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

cargo deny can interpret the `license` field, but gets a little confused by the `license-file` since it can't parse the file.

Also crates.io likes it better too, since right now it reports `quilkin-macros` as a non-standard OSS licence.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A