### PR TITLE
Update to Rust 1.57

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.56.0"
+channel = "1.57.0"
 components = ["rustfmt", "clippy"]

--- a/src/filters/factory.rs
+++ b/src/filters/factory.rs
@@ -87,7 +87,7 @@ impl CreateFilterArgs<'_> {
         config: Option<&serde_yaml::Value>,
     ) -> CreateFilterArgs {
         CreateFilterArgs {
-            config: config.map(|config| ConfigType::Static(config)),
+            config: config.map(ConfigType::Static),
             metrics_registry,
         }
     }


### PR DESCRIPTION
Updates to latest rust, required since `spdx 0.7.0` which is used in `cargo-deny` requires  at least 1.56.1