### PR TITLE
Completely remove `slog` and replace with `tracing`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,10 +57,6 @@ rand = "0.8.4"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = "1.0.68"
 serde_yaml = "0.8.21"
-slog = "2.7.0"
-slog-async = "2.7.0"
-slog-json = "2.4.0"
-slog-term = "2.8.0"
 snap = "1.0.5"
 tokio = { version = "1.13.1", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
 tokio-stream = "0.1.8"
@@ -73,6 +69,7 @@ tryhard = "0.4.0"
 eyre = "0.6.5"
 stable-eyre = "0.2.2"
 ipnetwork = "0.18.0"
+futures = "0.3.17"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.0"

--- a/src/endpoint/address.rs
+++ b/src/endpoint/address.rs
@@ -227,17 +227,6 @@ impl<'de> Deserialize<'de> for EndpointAddress {
     }
 }
 
-impl slog::Value for EndpointAddress {
-    fn serialize(
-        &self,
-        _: &slog::Record,
-        key: slog::Key,
-        serializer: &mut dyn slog::Serializer,
-    ) -> slog::Result {
-        serializer.emit_arguments(key, &format_args!("{}", self))
-    }
-}
-
 /// The kind of address, such as Domain Name or IP address. **Note** that
 /// the `FromStr` implementation doesn't actually validate that the name is
 /// resolvable. Use [`EndpointAddress`] for complete address validation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub type Result<T, E = eyre::Error> = std::result::Result<T, E>;
 #[doc(inline)]
 pub use self::{
     config::Config,
-    proxy::{logger, Builder, PendingValidation, Server, Validated},
+    proxy::{Builder, PendingValidation, Server, Validated},
     runner::{run, run_with_config},
 };
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -15,7 +15,7 @@
  */
 
 pub(crate) use admin::Admin;
-pub use builder::{logger, Builder, PendingValidation, Validated};
+pub use builder::{Builder, PendingValidation, Validated};
 pub(crate) use health::Health;
 pub(crate) use metrics::Metrics;
 pub use server::Server;

--- a/src/proxy/sessions/session_manager.rs
+++ b/src/proxy/sessions/session_manager.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use slog::{debug, warn, Logger};
 use tokio::sync::{watch, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::proxy::sessions::{Session, SessionKey};
@@ -37,11 +36,11 @@ const SESSION_EXPIRY_POLL_INTERVAL: u64 = 60;
 pub struct SessionManager(Sessions);
 
 impl SessionManager {
-    pub fn new(log: Logger, shutdown_rx: watch::Receiver<()>) -> Self {
+    pub fn new(shutdown_rx: watch::Receiver<()>) -> Self {
         let poll_interval = Duration::from_secs(SESSION_EXPIRY_POLL_INTERVAL);
         let sessions: Sessions = Arc::new(RwLock::new(HashMap::new()));
 
-        Self::run_prune_sessions(log.clone(), sessions.clone(), poll_interval, shutdown_rx);
+        Self::run_prune_sessions(sessions.clone(), poll_interval, shutdown_rx);
 
         Self(sessions)
     }
@@ -59,7 +58,6 @@ impl SessionManager {
     /// Pruning will occur ~ every interval period. So the timeout expiration may sometimes
     /// exceed the expected, but we don't have to write lock the Sessions map as often to clean up.
     fn run_prune_sessions(
-        log: Logger,
         mut sessions: Sessions,
         poll_interval: Duration,
         mut shutdown_rx: watch::Receiver<()>,
@@ -70,12 +68,12 @@ impl SessionManager {
             loop {
                 tokio::select! {
                     _ = shutdown_rx.changed() => {
-                        debug!(log, "Exiting Prune Sessions due to shutdown signal.");
+                        tracing::debug!("Exiting Prune Sessions due to shutdown signal.");
                         break;
                     }
                     _ = interval.tick() => {
-                        debug!(log, "Attempting to Prune Sessions");
-                        Self::prune_sessions(&log, &mut sessions).await;
+                        tracing::debug!("Attempting to Prune Sessions");
+                        Self::prune_sessions(&mut sessions).await;
 
                     }
                 }
@@ -86,11 +84,11 @@ impl SessionManager {
     /// Removes expired [`Session`]s from `sessions`. This should be run
     /// regularly such as on a time interval. This will only write lock
     /// `sessions` if it first finds expired sessions.
-    async fn prune_sessions(log: &Logger, sessions: &mut Sessions) {
+    async fn prune_sessions(sessions: &mut Sessions) {
         let now = if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
             now.as_secs()
         } else {
-            warn!(log, "Failed to get current time when pruning sessions");
+            tracing::warn!("Failed to get current time when pruning sessions");
             return;
         };
 
@@ -130,7 +128,6 @@ mod tests {
                 UpstreamPacket,
             },
         },
-        test_utils::TestHelper,
     };
 
     use super::SessionManager;
@@ -144,7 +141,6 @@ mod tests {
 
     #[tokio::test]
     async fn run_prune_sessions() {
-        let t = TestHelper::default();
         let sessions = Arc::new(RwLock::new(HashMap::new()));
         let (from, to) = address_pair();
         let (send, _recv) = mpsc::channel::<UpstreamPacket>(1);
@@ -157,12 +153,7 @@ mod tests {
 
         //let config = Arc::new(config_with_dummy_endpoint().build());
         //let server = Builder::from(config).validate().unwrap().build();
-        SessionManager::run_prune_sessions(
-            t.log.clone(),
-            sessions.clone(),
-            poll_interval,
-            shutdown_rx,
-        );
+        SessionManager::run_prune_sessions(sessions.clone(), poll_interval, shutdown_rx);
 
         let key = SessionKey::from((from.clone(), to.clone()));
 
@@ -181,10 +172,7 @@ mod tests {
                 sender: send,
                 ttl,
             };
-            sessions.insert(
-                key.clone(),
-                session_args.into_session(&t.log).await.unwrap(),
-            );
+            sessions.insert(key.clone(), session_args.into_session().await.unwrap());
         }
 
         // session map should be the same since, we haven't passed expiry
@@ -219,7 +207,6 @@ mod tests {
 
     #[tokio::test]
     async fn prune_sessions() {
-        let t = TestHelper::default();
         let mut sessions: Sessions = Arc::new(RwLock::new(HashMap::new()));
         let (from, to) = address_pair();
         let (send, _recv) = mpsc::channel::<UpstreamPacket>(1);
@@ -242,10 +229,7 @@ mod tests {
                 sender: send,
                 ttl,
             };
-            sessions.insert(
-                key.clone(),
-                session_args.into_session(&t.log).await.unwrap(),
-            );
+            sessions.insert(key.clone(), session_args.into_session().await.unwrap());
         }
 
         // Insert key.
@@ -256,7 +240,7 @@ mod tests {
         }
 
         // session map should be the same since, we haven't passed expiry
-        SessionManager::prune_sessions(&t.log, &mut sessions).await;
+        SessionManager::prune_sessions(&mut sessions).await;
         {
             let map = sessions.read().await;
             assert!(map.contains_key(&key));
@@ -266,7 +250,7 @@ mod tests {
         // Wait until the key has expired.
         tokio::time::sleep_until(tokio::time::Instant::now().add(ttl)).await;
 
-        SessionManager::prune_sessions(&t.log, &mut sessions).await;
+        SessionManager::prune_sessions(&mut sessions).await;
         {
             let map = sessions.read().await;
             assert!(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -22,7 +22,6 @@ use tracing::{debug, info, span, Level};
 use crate::{
     config::Config,
     filters::{DynFilterFactory, FilterRegistry, FilterSet},
-    proxy::logger,
     proxy::Builder,
     Result,
 };
@@ -42,12 +41,10 @@ pub async fn run_with_config(
     config: Arc<Config>,
     filter_factories: impl IntoIterator<Item = DynFilterFactory>,
 ) -> Result<()> {
-    let base_log = logger(); // TODO: remove this, when tracing is replaceed in Server
     let span = span!(Level::INFO, "source::run");
     let _enter = span.enter();
 
     let server = Builder::from(config)
-        .with_log(base_log)
         .with_filter_registry(FilterRegistry::new(FilterSet::default_with(
             filter_factories.into_iter(),
         )))

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -16,7 +16,6 @@
 
 use std::net::SocketAddr;
 
-use slog::info;
 use tokio::time::{timeout, Duration};
 
 use quilkin::{
@@ -76,7 +75,7 @@ on_write: DECOMPRESS
 
     // game_client
     let local_addr: SocketAddr = format!("127.0.0.1:{}", client_port).parse().unwrap();
-    info!(t.log, "Sending hello"; "address" => local_addr);
+    tracing::info!(address = %local_addr, "Sending hello");
     tx.send_to(b"hello", &local_addr).await.unwrap();
 
     let expected = timeout(Duration::from_secs(5), rx.recv())

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -20,7 +20,6 @@ use std::{
 };
 
 use serde_yaml::{Mapping, Value};
-use slog::info;
 
 use quilkin::{
     config::{Builder as ConfigBuilder, Filter},
@@ -86,7 +85,7 @@ async fn test_filter() {
 
     // game_client
     let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
-    info!(t.log, "Sending hello"; "address" => local_addr);
+    tracing::info!(address = %local_addr, "Sending hello");
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
     let result = recv_chan.recv().await.unwrap();
@@ -157,7 +156,7 @@ async fn debug_filter() {
 
     // game client
     let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
-    info!(t.log, "Sending hello"; "address" => local_addr);
+    tracing::info!(address = %local_addr, "Sending hello");
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
     // since the debug filter doesn't change the data, it should be exactly the same

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -18,7 +18,6 @@ use quilkin::config::{Builder, Filter};
 use quilkin::endpoint::Endpoint;
 use quilkin::filters::firewall;
 use quilkin::test_utils::TestHelper;
-use slog::info;
 use std::net::SocketAddr;
 use tokio::sync::oneshot::Receiver;
 use tokio::time::{timeout, Duration};
@@ -99,7 +98,7 @@ async fn test(t: &mut TestHelper, server_port: u16, yaml: &str) -> Receiver<Stri
     let yaml = yaml
         .replace("%1", client_addr.port().to_string().as_str())
         .replace("%2", echo.port().to_string().as_str());
-    info!(t.log, "Config"; "config" => yaml.as_str());
+    tracing::info!(config = yaml.as_str(), "Config");
 
     let server_config = Builder::empty()
         .with_port(server_port)
@@ -114,7 +113,7 @@ async fn test(t: &mut TestHelper, server_port: u16, yaml: &str) -> Receiver<Stri
     t.run_server_with_config(server_config);
 
     let local_addr: SocketAddr = (std::net::Ipv4Addr::LOCALHOST, server_port).into();
-    info!(t.log, "Sending hello"; "from" => client_addr, "address" => local_addr);
+    tracing::info!(from = %client_addr, address = %local_addr, "Sending hello");
     recv.socket.send_to(b"hello", &local_addr).await.unwrap();
 
     recv.packet_rx

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -19,8 +19,6 @@ use std::{
     sync::Arc,
 };
 
-use slog::info;
-
 use quilkin::{
     config::{Admin, Builder as ConfigBuilder},
     endpoint::Endpoint,
@@ -64,7 +62,7 @@ async fn metrics_server() {
 
     // game_client
     let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), client_port);
-    info!(t.log, "Sending hello"; "address" => local_addr);
+    tracing::info!(address = %local_addr, "Sending hello");
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
     let _ = recv_chan.recv().await.unwrap();


### PR DESCRIPTION
With the release of https://github.com/tokio-rs/console I wanted to move over to tracing sooner rather than later, so this pulls out all instances of `slog` and replaces them with `tracing`.

resolves #317  