### PR TITLE
xds: delete snapshot for disconnected proxies

### DIFF
--- a/xds/README.md
+++ b/xds/README.md
@@ -95,7 +95,7 @@ The project has two binaries depending on the external source of configuration:
         where to send the associated packet.
         Note that the token is stripped off the packet. This annotation cannot be provided together with
         `quilkin.dev/routing-token-prefix-size`.
-      - **quilkin.dev/routing-token-prefix-size**: Works exactly the same as `quilkin.dev/routing-token-prefix-size`
+      - **quilkin.dev/routing-token-prefix-size**: Works exactly the same as `quilkin.dev/routing-token-suffix-size`
         with the difference that the token is a prefix on the packet rather than a suffix.
    
    As an example, the following runs the server against a cluster (using default kubeconfig configuration) where Quilkin pods run in the `quilkin` namespace and game-server pods run in the `gameservers` namespace:

--- a/xds/cmd/controller.go
+++ b/xds/cmd/controller.go
@@ -206,9 +206,7 @@ func main() {
 	snapshotUpdater := snapshot.NewUpdater(
 		logger,
 		clusterCh,
-		filterChainCh,
-		100*time.Millisecond,
-		clock.RealClock{})
+		filterChainCh)
 	snapshotCache := snapshotUpdater.GetSnapshotCache()
 	go snapshotUpdater.Run(ctx)
 

--- a/xds/cmd/file/file.go
+++ b/xds/cmd/file/file.go
@@ -20,9 +20,6 @@ import (
 	"context"
 	"os"
 	"os/signal"
-	"time"
-
-	"k8s.io/apimachinery/pkg/util/clock"
 
 	"quilkin.dev/xds-management-server/pkg/providers"
 
@@ -58,9 +55,7 @@ func main() {
 	snapshotUpdater := snapshot.NewUpdater(
 		logger,
 		clusterCh,
-		filterChainCh,
-		100*time.Millisecond,
-		clock.RealClock{})
+		filterChainCh)
 	snapshotCache := snapshotUpdater.GetSnapshotCache()
 	go snapshotUpdater.Run(ctx)
 


### PR DESCRIPTION
When proxies disconnect this clears their snapshot from
the cache. It periodically checks for snapshots that have
open watches (i.e has a proxy waiting for an update) and
if a snapshot seems idle after a while (the proxy isn't likely
to reconnect) it removes it from the cache.
