### PR TITLE
archive_dependencies.sh: Handle no dependencies

### DIFF
--- a/image/archive_dependencies.sh
+++ b/image/archive_dependencies.sh
@@ -26,15 +26,19 @@ CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
 # This should be reviewed before each release to make sure we're capturing all
 # the dependencies we need.
 
-rm dependencies-src.zip || true
-
 dependencies=("slog-json")
 
 zip="$(pwd)/dependencies-src.zip"
 
+rm "$zip" || true
+
 echo "Archiving dependencies to: $zip"
+
+# create an empty zip, so we always have a file, even if we don't have dependencies
+echo UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA== | base64 -d > "$zip"
+
 pushd "$CARGO_HOME/registry/src"
 for d in "${dependencies[@]}"; do
-  find . -type d -name "$d-*" | xargs -I {} zip -rv "$zip" "{}"
+  find . -type d -name "$d-*" | xargs -I {} zip -ruv "$zip" "{}"
 done
 popd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

If there are no dependencies utilised that we need to archive source for, this breaks the build process since no dependencies-src.zip file is created, and the Dockerfile has nothing to copy.

This changes the script such that it starts with an empty zip file, and then appends dependencies if and when they exist.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Unblocks #457

**Special notes for your reviewer**:

If @XAMPPRocky is still on vacation, this will let us merge #457, and I can handle the removal of `slog-json` from this script separately. Since the dependency is no longer used, the library isn't on the cloud build machine, so the archive zip is correct even with the item in the `dependencies` list.