### PR TITLE
Fix 404 in docs

### DIFF
--- a/docs/src/filters/compress.md
+++ b/docs/src/filters/compress.md
@@ -72,7 +72,7 @@ definitions:
 > Snappy is a compression/decompression library. It does not aim for maximum compression, or compatibility with any 
 > other compression library; instead, it aims for very high speeds and reasonable compression.
 
-Currently, this filter only provides the [Snappy](http://google.github.io/snappy/) compression format via the
+Currently, this filter only provides the [Snappy](https://github.com/google/snappy/) compression format via the
 [rust-snappy](https://github.com/BurntSushi/rust-snappy) crate, but more will be
 provided in the future.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Looks like Snappy got rid of their github pages, so the link was 404'ing.

This fixed it!

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

Unblocks #469 

**Special notes for your reviewer**:

N/A

