### PR TITLE
Add more tracing spans, add flamegraph to benchmarks, and refactor downstream in proxy into its own module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,8 @@ regex = "1.5.4"
 criterion = { version = "0.3.5", features = ["html_reports"] }
 once_cell = "1.8.0"
 tracing-test = "0.2"
+tracing-flame = "0.2.0"
+inferno = "0.10.10"
 
 [build-dependencies]
 tonic-build = { version = "0.6.0", default_features = false, features = ["transport", "prost"] }

--- a/deny.toml
+++ b/deny.toml
@@ -20,6 +20,8 @@
 ignore = [
     "RUSTSEC-2020-0071",
     "RUSTSEC-2020-0159",
+    # Inferno (dev-dependency)'s DashMap, not in main binary.
+    "RUSTSEC-2022-0002",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -32,5 +34,5 @@ default = "allow"
 exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
-    { allow = ["MPL-2.0"], name = "slog-json", version = "*" },
+    { allow = ["CDDL-1.0"], name = "inferno", version = "*" },
 ]

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -148,6 +148,7 @@ impl FilterChain {
 }
 
 impl Filter for FilterChain {
+    #[tracing::instrument(skip(self, ctx))]
     fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
         self.filters
             .iter()
@@ -161,6 +162,7 @@ impl Filter for FilterChain {
             .map(ReadResponse::from)
     }
 
+    #[tracing::instrument(skip(self, ctx))]
     fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
         self.filters
             .iter()

--- a/src/proxy/admin.rs
+++ b/src/proxy/admin.rs
@@ -50,6 +50,7 @@ impl Admin {
         }
     }
 
+    #[tracing::instrument(skip_all, level = "trace")]
     pub(crate) fn run(
         &self,
         cluster_manager: SharedClusterManager,

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -109,6 +109,7 @@ impl From<Arc<Config>> for Builder<PendingValidation> {
 }
 
 impl ValidatedConfig {
+    #[tracing::instrument(skip_all)]
     fn validate(
         config: Arc<Config>,
         filter_registry: &FilterRegistry,

--- a/src/proxy/server/downstream.rs
+++ b/src/proxy/server/downstream.rs
@@ -1,0 +1,203 @@
+use prometheus::HistogramTimer;
+use tokio::sync::{mpsc, watch};
+use tokio::time::Duration;
+use tracing::Instrument;
+
+use crate::{
+    cluster::cluster_manager::SharedClusterManager,
+    endpoint::{Endpoint, EndpointAddress},
+    filters::{manager::SharedFilterManager, Filter, ReadContext},
+    proxy::sessions::{
+        metrics::Metrics as SessionMetrics, session_manager::SessionManager, Session, SessionArgs,
+        SessionKey, UpstreamPacket,
+    },
+};
+
+use super::metrics::Metrics as ProxyMetrics;
+
+/// Packet received from local port
+#[derive(Debug)]
+pub(crate) struct DownstreamPacket {
+    pub source: EndpointAddress,
+    pub contents: Vec<u8>,
+    pub timer: HistogramTimer,
+}
+
+/// Represents the required arguments to run a worker task that
+/// processes packets received downstream.
+pub(crate) struct DownstreamReceiveWorker {
+    /// ID of the worker.
+    pub worker_id: usize,
+    /// Channel from which the worker picks up the downstream packets.
+    pub packet_rx: mpsc::Receiver<DownstreamPacket>,
+    /// Configuration required to process a received downstream packet.
+    pub processor: DownstreamReceiveProcessor,
+    /// The worker task exits when a value is received from this shutdown channel.
+    pub shutdown_rx: watch::Receiver<()>,
+}
+
+impl DownstreamReceiveWorker {
+    // For each worker config provided, spawn a background task that sits in a
+    // loop, receiving packets from a queue and processing them through
+    // the filter chain.
+    #[tracing::instrument(skip_all, fields(worker_id))]
+    pub async fn run(self) {
+        let Self {
+            worker_id,
+            mut packet_rx,
+            mut shutdown_rx,
+            processor,
+        } = self;
+
+        loop {
+            tokio::select! {
+                packet = packet_rx.recv().instrument(tracing::trace_span!("Received downstream packet")) => {
+                    match packet {
+                        Some(packet) => processor.process_downstream_received_packet(packet).await,
+                        None => {
+                            tracing::debug!(id = worker_id, "work sender channel was closed.");
+                            return;
+                        }
+                    }
+                }
+                _ = shutdown_rx.changed() => {
+                    tracing::debug!(id = worker_id, "received shutdown signal.");
+                    return;
+                }
+            }
+        }
+    }
+}
+
+/// Contains arguments to process a received downstream packet, through the
+/// filter chain and session pipeline.
+pub(crate) struct DownstreamReceiveProcessor {
+    pub proxy_metrics: ProxyMetrics,
+    pub session_metrics: SessionMetrics,
+    pub cluster_manager: SharedClusterManager,
+    pub filter_manager: SharedFilterManager,
+    pub session_manager: SessionManager,
+    pub session_ttl: Duration,
+    pub send_packets: mpsc::Sender<UpstreamPacket>,
+}
+
+impl DownstreamReceiveProcessor {
+    /// Processes a packet by running it through the filter chain.
+    #[tracing::instrument(skip_all)]
+    async fn process_downstream_received_packet(&self, packet: DownstreamPacket) {
+        let endpoints = match self.cluster_manager.read().get_all_endpoints() {
+            Some(endpoints) => endpoints,
+            None => {
+                self.proxy_metrics.packets_dropped_no_endpoints.inc();
+                return;
+            }
+        };
+
+        let filter_chain = {
+            let filter_manager_guard = self.filter_manager.read();
+            filter_manager_guard.get_filter_chain()
+        };
+        let result = filter_chain.read(ReadContext::new(
+            endpoints,
+            packet.source.clone(),
+            packet.contents,
+        ));
+
+        if let Some(response) = result {
+            for endpoint in response.endpoints.iter() {
+                self.session_send_packet(&response.contents, packet.source.clone(), endpoint)
+                    .await;
+            }
+        }
+        packet.timer.stop_and_record();
+    }
+
+    /// Send a packet received from `recv_addr` to an endpoint.
+    #[tracing::instrument(level = "trace", skip_all, fields(%recv_addr, %endpoint.address))]
+    async fn session_send_packet(
+        &self,
+        packet: &[u8],
+        recv_addr: EndpointAddress,
+        endpoint: &Endpoint,
+    ) {
+        let session_key = SessionKey {
+            source: recv_addr,
+            dest: endpoint.address.clone(),
+        };
+
+        // Grab a read lock and find the session.
+        let guard = self.session_manager.get_sessions().await;
+        if let Some(session) = guard.get(&session_key) {
+            // If it exists then send the packet, we're done.
+            Self::session_send_packet_helper(session, packet, self.session_ttl).await
+        } else {
+            // If it does not exist, grab a write lock so that we can create it.
+            //
+            // NOTE: We must drop the lock guard to release the lock before
+            // trying to acquire a write lock since these lock aren't reentrant,
+            // otherwise we will deadlock with our self.
+            drop(guard);
+
+            // Grab a write lock.
+            let mut guard = self.session_manager.get_sessions_mut().await;
+
+            // Although we have the write lock now, check whether some other thread
+            // managed to create the session in-between our dropping the read
+            // lock and grabbing the write lock.
+            if let Some(session) = guard.get(&session_key) {
+                // If the session now exists then we have less work to do,
+                // simply send the packet.
+                Self::session_send_packet_helper(session, packet, self.session_ttl).await;
+            } else {
+                // Otherwise, create the session and insert into the map.
+                let session_args = SessionArgs {
+                    metrics: self.session_metrics.clone(),
+                    proxy_metrics: self.proxy_metrics.clone(),
+                    filter_manager: self.filter_manager.clone(),
+                    source: session_key.source.clone(),
+                    dest: endpoint.clone(),
+                    sender: self.send_packets.clone(),
+                    ttl: self.session_ttl,
+                };
+                match session_args.into_session().await {
+                    Ok(session) => {
+                        // Insert the session into the map and release the write lock
+                        // immediately since we don't want to block other threads while we send
+                        // the packet. Instead, re-acquire a read lock and send the packet.
+                        guard.insert(session.key(), session);
+
+                        // Release the write lock.
+                        drop(guard);
+
+                        // Grab a read lock to send the packet.
+                        let guard = self.session_manager.get_sessions().await;
+                        if let Some(session) = guard.get(&session_key) {
+                            Self::session_send_packet_helper(session, packet, self.session_ttl)
+                                .await;
+                        } else {
+                            tracing::warn!(
+                                key = %format!("({}:{})", session_key.source, session_key.dest),
+                                "Could not find session"
+                            )
+                        }
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "Failed to ensure session exists");
+                    }
+                }
+            }
+        }
+    }
+
+    // A helper function to push a session's packet on its socket.
+    async fn session_send_packet_helper(session: &Session, packet: &[u8], ttl: Duration) {
+        match session.send(packet).await {
+            Ok(_) => {
+                if let Err(error) = session.update_expiration(ttl) {
+                    tracing::warn!(%error, "Error updating session expiration")
+                }
+            }
+            Err(error) => tracing::error!(%error, "Error sending packet from session"),
+        };
+    }
+}


### PR DESCRIPTION
This PR adds flamegraph output for the benchmarks, this is helpful for more fine-grained optimisation, as it will allow for us to see the duration of a different tasks.  The flamegraphs are available in `target/tmp/flamegraph.svg`. For the sake of review currently this only adds spans for the most obvious code paths, and focused more on the downstream. This also refactors some of the downstream related types into their own module for both readability and to make it easier to instrument.

I've included an example of how it looks so far.

![flamegraph](https://user-images.githubusercontent.com/4464295/151158394-65a6c57d-07d2-4708-8e82-678051bbb1a3.svg)