### PR TITLE
Refactor FilterRegistry into private static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ test = true
 quilkin-macros = { version = "0.3.0", path = "./macros" }
 
 # Crates.io
+arc-swap = "1.5.0"
 base64 = "0.13.0"
 base64-serde = "0.6.1"
 bytes = { version = "1.1.0", features = ["serde"] }
@@ -52,6 +53,7 @@ futures = "0.3.21"
 hyper = "0.14.17"
 ipnetwork = "0.18.0"
 num_cpus = "1.13.0"
+once_cell = "1.9.0"
 parking_lot = "0.12"
 prometheus = { version = "0.13.0", default-features = false }
 prost = "=0.9.0"

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -122,7 +122,7 @@ mod tests {
     use crate::{
         endpoint::{Endpoint, Endpoints},
         filters::metadata::CAPTURED_BYTES,
-        filters::{prelude::*, FilterRegistry},
+        filters::prelude::*,
         metadata::Value,
         test_utils::assert_write_no_change,
     };
@@ -159,7 +159,6 @@ mod tests {
 
         let filter = factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(YamlValue::Mapping(map)),
             ))
@@ -183,7 +182,6 @@ mod tests {
 
         let filter = factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(YamlValue::Mapping(map)),
             ))
@@ -202,7 +200,6 @@ mod tests {
         );
 
         let result = factory.create_filter(CreateFilterArgs::fixed(
-            FilterRegistry::default(),
             Registry::default(),
             Some(YamlValue::Mapping(map)),
         ));

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -185,7 +185,7 @@ mod tests {
     use crate::endpoint::{Endpoint, Endpoints, UpstreamEndpoints};
     use crate::filters::{
         compress::{compressor::Snappy, Compressor},
-        CreateFilterArgs, Filter, FilterFactory, FilterRegistry, ReadContext, WriteContext,
+        CreateFilterArgs, Filter, FilterFactory, ReadContext, WriteContext,
     };
 
     use super::quilkin::filters::compress::v1alpha1::{
@@ -297,7 +297,6 @@ mod tests {
         );
         let filter = factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(Value::Mapping(map)),
             ))
@@ -320,8 +319,7 @@ mod tests {
             Value::String("COMPRESS".into()),
         );
         let config = Value::Mapping(map);
-        let args =
-            CreateFilterArgs::fixed(FilterRegistry::default(), Registry::default(), Some(config));
+        let args = CreateFilterArgs::fixed(Registry::default(), Some(config));
 
         let filter = factory
             .create_filter(args)

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -119,7 +119,6 @@ impl TryFrom<ProtoDebug> for Config {
 
 #[cfg(test)]
 mod tests {
-    use crate::filters::FilterRegistry;
     use crate::test_utils::{assert_filter_read_no_change, assert_write_no_change};
     use serde_yaml::Mapping;
     use serde_yaml::Value;
@@ -153,7 +152,6 @@ mod tests {
         map.insert(Value::from("id"), Value::from("name"));
         assert!(factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(Value::Mapping(map)),
             ))
@@ -168,7 +166,6 @@ mod tests {
         map.insert(Value::from("id"), Value::from("name"));
         assert!(factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(Value::Mapping(map)),
             ))
@@ -183,7 +180,6 @@ mod tests {
         map.insert(Value::from("id"), Value::Sequence(vec![]));
         assert!(factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(Value::Mapping(map))
             ))

--- a/src/filters/factory.rs
+++ b/src/filters/factory.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::{
     config::ConfigType,
-    filters::{Error, Filter, FilterRegistry},
+    filters::{Error, Filter},
 };
 
 /// An owned pointer to a dynamic [`FilterFactory`] instance.
@@ -75,22 +75,15 @@ pub trait FilterFactory: Sync + Send {
 pub struct CreateFilterArgs {
     /// Configuration for the filter.
     pub config: Option<ConfigType>,
-    /// Used if the filter needs to reference or use other filters.
-    pub filter_registry: FilterRegistry,
     /// metrics_registry is used to register filter metrics collectors.
     pub metrics_registry: Registry,
 }
 
 impl CreateFilterArgs {
     /// Create a new instance of [`CreateFilterArgs`].
-    pub fn new(
-        filter_registry: FilterRegistry,
-        metrics_registry: Registry,
-        config: Option<ConfigType>,
-    ) -> CreateFilterArgs {
+    pub fn new(metrics_registry: Registry, config: Option<ConfigType>) -> CreateFilterArgs {
         Self {
             config,
-            filter_registry,
             metrics_registry,
         }
     }
@@ -98,29 +91,19 @@ impl CreateFilterArgs {
     /// Creates a new instance of [`CreateFilterArgs`] using a
     /// fixed [`ConfigType`].
     pub fn fixed(
-        filter_registry: FilterRegistry,
         metrics_registry: Registry,
         config: Option<serde_yaml::Value>,
     ) -> CreateFilterArgs {
-        Self::new(
-            filter_registry,
-            metrics_registry,
-            config.map(ConfigType::Static),
-        )
+        Self::new(metrics_registry, config.map(ConfigType::Static))
     }
 
     /// Creates a new instance of [`CreateFilterArgs`] using a
     /// dynamic [`ConfigType`].
     pub fn dynamic(
-        filter_registry: FilterRegistry,
         metrics_registry: Registry,
         config: Option<prost_types::Any>,
     ) -> CreateFilterArgs {
-        CreateFilterArgs::new(
-            filter_registry,
-            metrics_registry,
-            config.map(ConfigType::Dynamic),
-        )
+        CreateFilterArgs::new(metrics_registry, config.map(ConfigType::Dynamic))
     }
 
     /// Consumes `self` and returns a new instance of [`Self`] using

--- a/src/filters/load_balancer.rs
+++ b/src/filters/load_balancer.rs
@@ -76,7 +76,7 @@ mod tests {
         endpoint::{Endpoint, EndpointAddress, Endpoints},
         filters::{
             load_balancer::LoadBalancerFilterFactory, CreateFilterArgs, Filter, FilterFactory,
-            FilterRegistry, ReadContext,
+            ReadContext,
         },
     };
     use prometheus::Registry;
@@ -85,7 +85,6 @@ mod tests {
         let factory = LoadBalancerFilterFactory;
         factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(serde_yaml::from_str(config).unwrap()),
             ))

--- a/src/filters/local_rate_limit.rs
+++ b/src/filters/local_rate_limit.rs
@@ -282,7 +282,6 @@ period: 0
             .create_filter(CreateFilterArgs {
                 config: Some(ConfigType::Static(serde_yaml::from_str(config).unwrap())),
                 metrics_registry: Default::default(),
-                filter_registry: crate::filters::FilterRegistry::default(),
             })
             .err()
             .unwrap();

--- a/src/filters/manager.rs
+++ b/src/filters/manager.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::filters::{chain::Error as FilterChainError, FilterChain, FilterRegistry};
+use crate::filters::{chain::Error as FilterChainError, FilterChain};
 
 use std::sync::Arc;
 
@@ -35,19 +35,16 @@ pub struct FilterManager {
 #[derive(Clone)]
 pub(crate) struct ListenerManagerArgs {
     pub filter_chain_updates_tx: mpsc::Sender<Arc<FilterChain>>,
-    pub filter_registry: FilterRegistry,
     pub metrics_registry: Registry,
 }
 
 impl ListenerManagerArgs {
     pub fn new(
         metrics_registry: Registry,
-        filter_registry: FilterRegistry,
         filter_chain_updates_tx: mpsc::Sender<Arc<FilterChain>>,
     ) -> ListenerManagerArgs {
         ListenerManagerArgs {
             filter_chain_updates_tx,
-            filter_registry,
             metrics_registry,
         }
     }

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -14,39 +14,38 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
+use arc_swap::ArcSwap;
+use once_cell::sync::Lazy;
 
-use crate::filters::{CreateFilterArgs, Error, FilterInstance, FilterMap, FilterSet};
+use crate::filters::{CreateFilterArgs, DynFilterFactory, Error, FilterInstance, FilterSet};
+
+static REGISTRY: Lazy<ArcSwap<FilterSet>> =
+    Lazy::new(|| ArcSwap::new(std::sync::Arc::new(FilterSet::default())));
 
 /// Registry of all [`Filter`][crate::filters::Filter]s that can be applied in the system.
 ///
 /// **Note:** Cloning [`FilterRegistry`], clones a new reference to the data and
 /// does not clone the data itself. In other words the clone is "shallow" and
 /// not deep.
-#[derive(Clone, Default)]
-pub struct FilterRegistry {
-    registry: Arc<FilterMap>,
-}
+#[derive(Debug)]
+pub struct FilterRegistry;
 
 impl FilterRegistry {
-    /// Creates a new registry using the provided [`FilterSet`] as the set of
-    /// available filters.
-    pub fn new(factories: FilterSet) -> Self {
-        Self {
-            registry: Arc::new(
-                factories
-                    .into_iter()
-                    .map(|factory| (factory.name(), factory))
-                    .collect(),
-            ),
+    /// Loads the provided [`FilterSet`] into the registry of available filters.
+    pub fn register(factories: impl IntoIterator<Item = DynFilterFactory>) {
+        let mut registry = FilterSet::clone(&REGISTRY.load_full());
+        for factory in factories {
+            registry.insert(factory);
         }
+
+        REGISTRY.store(std::sync::Arc::from(registry));
     }
 
     /// Creates and returns a new dynamic instance of [`Filter`][crate::filters::Filter] for a given
     /// `key`. Errors if the filter cannot be found, or if there is a
     /// configuration issue.
-    pub fn get(&self, key: &str, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        match self.registry.get(key).map(|p| p.create_filter(args)) {
+    pub fn get(key: &str, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
+        match REGISTRY.load().get(key).map(|p| p.create_filter(args)) {
             None => Err(Error::NotFound(key.to_owned())),
             Some(filter) => filter,
         }
@@ -57,11 +56,13 @@ impl FilterRegistry {
 mod tests {
     use std::net::Ipv4Addr;
 
-    use crate::test_utils::new_registry;
+    use crate::test_utils::load_test_filters;
 
     use super::*;
     use crate::endpoint::{Endpoint, EndpointAddress, Endpoints};
-    use crate::filters::{Filter, ReadContext, ReadResponse, WriteContext, WriteResponse};
+    use crate::filters::{
+        Filter, FilterRegistry, ReadContext, ReadResponse, WriteContext, WriteResponse,
+    };
     use prometheus::Registry;
 
     struct TestFilter {}
@@ -78,30 +79,28 @@ mod tests {
 
     #[test]
     fn insert_and_get() {
-        let reg = new_registry();
+        load_test_filters();
 
-        match reg.get(
+        match FilterRegistry::get(
             &String::from("not.found"),
-            CreateFilterArgs::fixed(reg.clone(), Registry::default(), None),
+            CreateFilterArgs::fixed(Registry::default(), None),
         ) {
             Ok(_) => unreachable!("should not be filter"),
             Err(err) => assert_eq!(Error::NotFound("not.found".to_string()), err),
         };
 
-        assert!(reg
-            .get(
-                &String::from("TestFilter"),
-                CreateFilterArgs::fixed(reg.clone(), Registry::default(), None)
-            )
-            .is_ok());
+        assert!(FilterRegistry::get(
+            &String::from("TestFilter"),
+            CreateFilterArgs::fixed(Registry::default(), None)
+        )
+        .is_ok());
 
-        let filter = reg
-            .get(
-                &String::from("TestFilter"),
-                CreateFilterArgs::fixed(reg.clone(), Registry::default(), None),
-            )
-            .unwrap()
-            .filter;
+        let filter = FilterRegistry::get(
+            &String::from("TestFilter"),
+            CreateFilterArgs::fixed(Registry::default(), None),
+        )
+        .unwrap()
+        .filter;
 
         let addr: EndpointAddress = (Ipv4Addr::LOCALHOST, 8080).into();
         let endpoint = Endpoint::new(addr.clone());

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -194,8 +194,7 @@ mod tests {
         default_metadata_key, Config, Metrics, ProtoConfig, TokenRouter, TokenRouterFactory,
     };
     use crate::filters::{
-        metadata::CAPTURED_BYTES, CreateFilterArgs, Filter, FilterFactory, FilterRegistry,
-        ReadContext,
+        metadata::CAPTURED_BYTES, CreateFilterArgs, Filter, FilterFactory, ReadContext,
     };
 
     const TOKEN_KEY: &str = "TOKEN";
@@ -249,7 +248,6 @@ mod tests {
 
         let filter = factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(serde_yaml::Value::Mapping(map)),
             ))
@@ -270,7 +268,6 @@ mod tests {
 
         let filter = factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 Registry::default(),
                 Some(serde_yaml::Value::Mapping(map)),
             ))
@@ -289,11 +286,7 @@ mod tests {
         let factory = TokenRouterFactory::new();
 
         let filter = factory
-            .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
-                Registry::default(),
-                None,
-            ))
+            .create_filter(CreateFilterArgs::fixed(Registry::default(), None))
             .unwrap()
             .filter;
         let mut ctx = new_ctx();

--- a/src/proxy/config_dump.rs
+++ b/src/proxy/config_dump.rs
@@ -111,7 +111,7 @@ mod tests {
     use super::handle_request;
     use crate::cluster::cluster_manager::ClusterManager;
     use crate::endpoint::{Endpoint, Endpoints};
-    use crate::filters::{manager::FilterManager, CreateFilterArgs, FilterChain, FilterRegistry};
+    use crate::filters::{manager::FilterManager, CreateFilterArgs, FilterChain};
     use prometheus::Registry;
     use std::sync::Arc;
 
@@ -128,7 +128,6 @@ mod tests {
         let debug_factory = crate::filters::debug::factory();
         let debug_filter = debug_factory
             .create_filter(CreateFilterArgs::fixed(
-                FilterRegistry::default(),
                 registry.clone(),
                 Some(debug_config),
             ))

--- a/src/proxy/server/resource_manager.rs
+++ b/src/proxy/server/resource_manager.rs
@@ -20,7 +20,7 @@ use crate::{
     endpoint::Endpoints,
     filters::{
         manager::{FilterManager, ListenerManagerArgs, SharedFilterManager},
-        FilterChain, FilterRegistry,
+        FilterChain,
     },
     xds::ads_client::{AdsClient, ClusterUpdate, UPDATES_CHANNEL_BUFFER_SIZE},
 };
@@ -70,7 +70,6 @@ impl DynamicResourceManagers {
     pub(super) async fn new(
         xds_node_id: String,
         metrics_registry: Registry,
-        filter_registry: FilterRegistry,
         management_servers: Vec<ManagementServer>,
         shutdown_rx: watch::Receiver<()>,
     ) -> Result<DynamicResourceManagers, InitializeError> {
@@ -78,11 +77,8 @@ impl DynamicResourceManagers {
         let (filter_chain_updates_tx, filter_chain_updates_rx) =
             Self::filter_chain_updates_channel();
 
-        let listener_manager_args = ListenerManagerArgs::new(
-            metrics_registry.clone(),
-            filter_registry,
-            filter_chain_updates_tx,
-        );
+        let listener_manager_args =
+            ListenerManagerArgs::new(metrics_registry.clone(), filter_chain_updates_tx);
 
         let (execution_result_tx, execution_result_rx) = oneshot::channel::<crate::Result<()>>();
         Self::spawn_ads_client(SpawnAdsClient {
@@ -164,7 +160,7 @@ mod tests {
 
     use super::DynamicResourceManagers;
     use crate::config::ManagementServer;
-    use crate::filters::{manager::ListenerManagerArgs, FilterRegistry};
+    use crate::filters::manager::ListenerManagerArgs;
 
     use std::time::Duration;
 
@@ -193,7 +189,6 @@ mod tests {
             cluster_updates_tx,
             listener_manager_args: ListenerManagerArgs::new(
                 Registry::default(),
-                FilterRegistry::default(),
                 filter_chain_updates_tx,
             ),
             execution_result_tx,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info, span, Level};
 
 use crate::{
     config::Config,
-    filters::{DynFilterFactory, FilterRegistry, FilterSet},
+    filters::{DynFilterFactory, FilterRegistry},
     proxy::Builder,
     Result,
 };
@@ -38,12 +38,8 @@ pub async fn run(
     let span = span!(Level::INFO, "source::run");
     let _enter = span.enter();
 
-    let server = Builder::from(Arc::new(config))
-        .with_filter_registry(FilterRegistry::new(FilterSet::default_with(
-            filter_factories.into_iter(),
-        )))
-        .validate()?
-        .build();
+    FilterRegistry::register(filter_factories);
+    let server = Builder::from(Arc::new(config)).validate()?.build();
 
     #[cfg(target_os = "linux")]
     let mut sig_term_fut = signal::unix::signal(signal::unix::SignalKind::terminate())?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -24,7 +24,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::config::{Builder as ConfigBuilder, Config};
 use crate::endpoint::{Endpoint, EndpointAddress, Endpoints};
-use crate::filters::{prelude::*, FilterChain, FilterRegistry, FilterSet};
+use crate::filters::{prelude::*, FilterChain, FilterRegistry};
 use crate::metadata::Value;
 use crate::proxy::{Builder, PendingValidation};
 
@@ -318,10 +318,8 @@ pub fn new_test_chain(registry: &prometheus::Registry) -> Arc<FilterChain> {
     )
 }
 
-pub fn new_registry() -> FilterRegistry {
-    FilterRegistry::new(FilterSet::default_with([DynFilterFactory::from(
-        Box::from(TestFilterFactory {}),
-    )]))
+pub fn load_test_filters() {
+    FilterRegistry::register([DynFilterFactory::from(Box::from(TestFilterFactory {}))]);
 }
 
 #[cfg(test)]

--- a/src/xds/ads_client.rs
+++ b/src/xds/ads_client.rs
@@ -464,7 +464,6 @@ pub(super) async fn send_discovery_req(
 mod tests {
     use super::AdsClient;
     use crate::config::ManagementServer;
-    use crate::filters::FilterRegistry;
     use crate::xds::ads_client::ListenerManagerArgs;
     use crate::xds::envoy::service::discovery::v3::DiscoveryRequest;
     use crate::xds::google::rpc::Status as GrpcStatus;
@@ -489,11 +488,7 @@ mod tests {
                 address: "localhost:18000".into(),
             }],
             cluster_updates_tx,
-            ListenerManagerArgs::new(
-                Registry::default(),
-                FilterRegistry::default(),
-                filter_chain_updates_tx,
-            ),
+            ListenerManagerArgs::new(Registry::default(), filter_chain_updates_tx),
             shutdown_rx,
         );
 

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -25,7 +25,7 @@ use quilkin::{
     config::{Builder as ConfigBuilder, Filter},
     endpoint::Endpoint,
     filters::debug,
-    test_utils::{new_registry, TestHelper},
+    test_utils::{load_test_filters, TestHelper},
     Builder as ProxyBuilder,
 };
 
@@ -50,12 +50,8 @@ async fn test_filter() {
         .build();
 
     // Run server proxy.
-    let registry = new_registry();
-    t.run_server_with_builder(
-        ProxyBuilder::from(Arc::new(server_config))
-            .with_filter_registry(registry)
-            .disable_admin(),
-    );
+    load_test_filters();
+    t.run_server_with_builder(ProxyBuilder::from(Arc::new(server_config)).disable_admin());
 
     // create a local client
     let client_port = 12347;
@@ -73,12 +69,7 @@ async fn test_filter() {
         .build();
 
     // Run client proxy.
-    let registry = new_registry();
-    t.run_server_with_builder(
-        ProxyBuilder::from(Arc::new(client_config))
-            .with_filter_registry(registry)
-            .disable_admin(),
-    );
+    t.run_server_with_builder(ProxyBuilder::from(Arc::new(client_config)).disable_admin());
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;


### PR DESCRIPTION
This PR refactors the state of `FilterRegistry` to being internal to `FilterRegistry` and is now a global append-only and always safe to load (e.g. not blocking) registry of filters. This simplifies some of the state in our code, removing the need for a `FilterRegistry` to be passed down at every level, you can get access to new instances with `FilterRegistry::get` which is available anywhere.

