### PR TITLE
Add conversion to protobuf for most core types

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -75,6 +75,22 @@ impl std::str::FromStr for Endpoint {
     }
 }
 
+impl From<Endpoint> for crate::xds::config::endpoint::v3::LbEndpoint {
+    fn from(endpoint: Endpoint) -> Self {
+        use crate::xds::config::endpoint::v3::{
+            lb_endpoint::HostIdentifier, Endpoint as EnvoyEndpoint,
+        };
+        Self {
+            host_identifier: Some(HostIdentifier::Endpoint(EnvoyEndpoint {
+                address: Some(endpoint.address.into()),
+                ..<_>::default()
+            })),
+            metadata: Some(endpoint.metadata.into()),
+            ..<_>::default()
+        }
+    }
+}
+
 /// Represents the set of all known upstream endpoints.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Endpoints(Arc<Vec<Endpoint>>);
@@ -124,6 +140,28 @@ impl std::ops::Deref for Endpoints {
 pub struct Metadata {
     #[serde(with = "base64_set")]
     pub tokens: base64_set::Set,
+}
+
+impl From<Metadata> for prost_types::Struct {
+    fn from(metadata: Metadata) -> Self {
+        let tokens = prost_types::Value {
+            kind: Some(prost_types::value::Kind::ListValue(
+                prost_types::ListValue {
+                    values: metadata
+                        .tokens
+                        .into_iter()
+                        .map(base64::encode)
+                        .map(prost_types::value::Kind::StringValue)
+                        .map(|k| prost_types::Value { kind: Some(k) })
+                        .collect(),
+                },
+            )),
+        };
+
+        Self {
+            fields: <_>::from([("tokens".into(), tokens)]),
+        }
+    }
 }
 
 /// A module for providing base64 encoding for a `BTreeSet` at the `serde`

--- a/src/endpoint/address.rs
+++ b/src/endpoint/address.rs
@@ -158,6 +158,19 @@ impl From<(Ipv6Addr, u16)> for EndpointAddress {
     }
 }
 
+impl From<EndpointAddress> for EnvoySocketAddress {
+    fn from(address: EndpointAddress) -> Self {
+        use crate::xds::config::core::v3::socket_address::{PortSpecifier, Protocol};
+
+        Self {
+            protocol: Protocol::Udp as i32,
+            address: address.host.to_string(),
+            port_specifier: address.port.map(u32::from).map(PortSpecifier::PortValue),
+            ..<_>::default()
+        }
+    }
+}
+
 impl TryFrom<EnvoySocketAddress> for EndpointAddress {
     type Error = eyre::Error;
 
@@ -179,6 +192,20 @@ impl TryFrom<EnvoySocketAddress> for EndpointAddress {
         address.to_socket_addrs()?;
 
         Ok(address)
+    }
+}
+
+impl From<EndpointAddress> for crate::xds::config::core::v3::Address {
+    fn from(address: EndpointAddress) -> Self {
+        Self {
+            address: Some(address.into()),
+        }
+    }
+}
+
+impl From<EndpointAddress> for EnvoyAddress {
+    fn from(address: EndpointAddress) -> Self {
+        Self::SocketAddress(address.into())
     }
 }
 

--- a/src/filters/capture/config.rs
+++ b/src/filters/capture/config.rs
@@ -165,6 +165,15 @@ impl<'de> serde::Deserialize<'de> for Config {
     }
 }
 
+impl From<Config> for proto::Capture {
+    fn from(config: Config) -> Self {
+        Self {
+            metadata_key: Some(config.metadata_key),
+            strategy: Some(config.strategy.into()),
+        }
+    }
+}
+
 impl TryFrom<proto::Capture> for Config {
     type Error = ConvertProtoConfigError;
 
@@ -179,6 +188,24 @@ impl TryFrom<proto::Capture> for Config {
             })?,
             strategy: strategy.try_into()?,
         })
+    }
+}
+
+impl From<Strategy> for proto::capture::Strategy {
+    fn from(strategy: Strategy) -> Self {
+        match strategy {
+            Strategy::Prefix(prefix) => Self::Prefix(proto::capture::Prefix {
+                size: prefix.size,
+                remove: Some(prefix.remove),
+            }),
+            Strategy::Suffix(suffix) => Self::Suffix(proto::capture::Suffix {
+                size: suffix.size,
+                remove: Some(suffix.remove),
+            }),
+            Strategy::Regex(regex) => Self::Regex(proto::capture::Regex {
+                regex: Some(regex.pattern.as_str().into()),
+            }),
+        }
     }
 }
 

--- a/src/filters/concatenate_bytes.rs
+++ b/src/filters/concatenate_bytes.rs
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+crate::include_proto!("quilkin.filters.concatenate_bytes.v1alpha1");
+
 mod config;
 
 use crate::filters::prelude::*;
 
-use config::ProtoConfig;
+use self::quilkin::filters::concatenate_bytes::v1alpha1 as proto;
 pub use config::{Config, Strategy};
 
 pub const NAME: &str = "quilkin.filters.concatenate_bytes.v1alpha1.ConcatenateBytes";
@@ -93,7 +95,7 @@ impl FilterFactory for ConcatBytesFactory {
     fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
         let (config_json, config) = self
             .require_config(args.config)?
-            .deserialize::<Config, ProtoConfig>(self.name())?;
+            .deserialize::<Config, proto::ConcatenateBytes>(self.name())?;
         let filter = ConcatenateBytes::new(config);
         Ok(FilterInstance::new(
             config_json,

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+crate::include_proto!("quilkin.filters.debug.v1alpha1");
+
 use std::convert::TryFrom;
 
 use crate::filters::prelude::*;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-crate::include_proto!("quilkin.filters.debug.v1alpha1");
-use self::quilkin::filters::debug::v1alpha1::Debug as ProtoDebug;
+use self::quilkin::filters::debug::v1alpha1 as proto;
 
 /// Debug logs all incoming and outgoing packets
 struct Debug {}
@@ -87,7 +88,7 @@ impl FilterFactory for DebugFactory {
     fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
         let config: Option<(_, Config)> = args
             .config
-            .map(|config| config.deserialize::<Config, ProtoDebug>(self.name()))
+            .map(|config| config.deserialize::<Config, proto::Debug>(self.name()))
             .transpose()?;
 
         let (config_json, config) = config
@@ -109,10 +110,16 @@ pub struct Config {
     pub id: Option<String>,
 }
 
-impl TryFrom<ProtoDebug> for Config {
+impl From<Config> for proto::Debug {
+    fn from(config: Config) -> Self {
+        Self { id: config.id }
+    }
+}
+
+impl TryFrom<proto::Debug> for Config {
     type Error = ConvertProtoConfigError;
 
-    fn try_from(p: ProtoDebug) -> Result<Self, Self::Error> {
+    fn try_from(p: proto::Debug) -> Result<Self, Self::Error> {
         Ok(Config { id: p.id })
     }
 }

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -89,6 +89,12 @@ impl FilterFactory for DropFactory {
 #[derive(Serialize, Deserialize, Debug, schemars::JsonSchema)]
 pub struct Config;
 
+impl From<Config> for proto::Drop {
+    fn from(_config: Config) -> Self {
+        Self {}
+    }
+}
+
 impl TryFrom<proto::Drop> for Config {
     type Error = ConvertProtoConfigError;
 

--- a/src/filters/error.rs
+++ b/src/filters/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     InitializeMetricsFailed(String),
     #[error("Protobuf error: {}", .0)]
     ConvertProtoConfig(ConvertProtoConfigError),
+    #[error("Infallible! This should never occur")]
+    Infallible,
 }
 
 impl From<Error> for ValidationError {
@@ -44,9 +46,27 @@ impl From<Error> for ValidationError {
     }
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(_: std::convert::Infallible) -> Self {
+        Self::Infallible
+    }
+}
+
 impl From<MetricsError> for Error {
     fn from(error: MetricsError) -> Self {
         Error::InitializeMetricsFailed(error.to_string())
+    }
+}
+
+impl From<serde_yaml::Error> for Error {
+    fn from(error: serde_yaml::Error) -> Self {
+        Self::DeserializeFailed(error.to_string())
+    }
+}
+
+impl From<prost::EncodeError> for Error {
+    fn from(error: prost::EncodeError) -> Self {
+        Self::ConvertProtoConfig(ConvertProtoConfigError::new(error, None))
     }
 }
 

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -21,7 +21,7 @@ use tracing::debug;
 use crate::filters::firewall::metrics::Metrics;
 use crate::filters::prelude::*;
 
-use self::quilkin::filters::firewall::v1alpha1::Firewall as ProtoConfig;
+use self::quilkin::filters::firewall::v1alpha1 as proto;
 
 crate::include_proto!("quilkin.filters.firewall.v1alpha1");
 
@@ -56,7 +56,7 @@ impl FilterFactory for FirewallFactory {
     fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
         let (config_json, config) = self
             .require_config(args.config)?
-            .deserialize::<Config, ProtoConfig>(self.name())?;
+            .deserialize::<Config, proto::Firewall>(self.name())?;
 
         let filter = Firewall::new(config, Metrics::new()?);
         Ok(FilterInstance::new(
@@ -146,6 +146,7 @@ impl Filter for Firewall {
         None
     }
 }
+
 #[cfg(test)]
 mod tests {
     use std::net::Ipv4Addr;

--- a/src/filters/load_balancer.rs
+++ b/src/filters/load_balancer.rs
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
+crate::include_proto!("quilkin.filters.load_balancer.v1alpha1");
+
 mod config;
 mod endpoint_chooser;
 
 use crate::filters::{prelude::*, DynFilterFactory};
 
-use config::ProtoConfig;
+pub use config::{Config, Policy};
 use endpoint_chooser::EndpointChooser;
 
-pub use config::{Config, Policy};
+use self::quilkin::filters::load_balancer::v1alpha1 as proto;
 
 pub const NAME: &str = "quilkin.filters.load_balancer.v1alpha1.LoadBalancer";
 
@@ -57,7 +59,7 @@ impl FilterFactory for LoadBalancerFilterFactory {
     fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
         let (config_json, config) = self
             .require_config(args.config)?
-            .deserialize::<Config, ProtoConfig>(self.name())?;
+            .deserialize::<Config, proto::LoadBalancer>(self.name())?;
         let filter = LoadBalancer {
             endpoint_chooser: config.policy.as_endpoint_chooser(),
         };

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -1,8 +1,27 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+crate::include_proto!("quilkin.filters.matches.v1alpha1");
+
 mod config;
 mod metrics;
 
 use crate::{config::ConfigType, filters::prelude::*, metadata::Value};
 
+use self::quilkin::filters::matches::v1alpha1 as proto;
 use crate::filters::r#match::metrics::Metrics;
 pub use config::Config;
 
@@ -138,7 +157,7 @@ impl FilterFactory for MatchFactory {
     fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
         let (config_json, config) = self
             .require_config(args.config)?
-            .deserialize::<Config, config::proto::Match>(self.name())?;
+            .deserialize::<Config, proto::Match>(self.name())?;
 
         let filter = MatchInstance::new(config, Metrics::new()?)?;
         Ok(FilterInstance::new(

--- a/src/filters/match/config.rs
+++ b/src/filters/match/config.rs
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-crate::include_proto!("quilkin.filters.matches.v1alpha1");
-
-pub(crate) use self::quilkin::filters::matches::v1alpha1 as proto;
-
 use serde::{Deserialize, Serialize};
 
+use super::proto;
 use crate::{config::ConfigType, filters::ConvertProtoConfigError};
 
 /// Configuration for the [`factory`][crate::filters::match::factory].

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -90,6 +90,12 @@ impl FilterFactory for PassFactory {
 #[derive(Serialize, Deserialize, Debug, schemars::JsonSchema)]
 pub struct Config;
 
+impl From<Config> for proto::Pass {
+    fn from(_config: Config) -> Self {
+        Self {}
+    }
+}
+
 impl TryFrom<proto::Pass> for Config {
     type Error = ConvertProtoConfigError;
 

--- a/src/prost.rs
+++ b/src/prost.rs
@@ -47,3 +47,41 @@ pub fn value_from_kind(kind: Kind) -> Value {
         ),
     }
 }
+
+pub fn struct_from_yaml(value: Value) -> Option<prost_types::Struct> {
+    match from_yaml(value) {
+        prost_types::Value {
+            kind: Some(Kind::StructValue(r#struct)),
+        } => Some(r#struct),
+        _ => None,
+    }
+}
+
+pub fn from_yaml(value: Value) -> prost_types::Value {
+    prost_types::Value {
+        kind: Some(match value {
+            Value::Null => Kind::NullValue(<_>::default()),
+            Value::Bool(v) => Kind::BoolValue(v),
+            // as_f64 never returns None, so unwrap is safe here.
+            Value::Number(v) => Kind::NumberValue(v.as_f64().unwrap()),
+            Value::String(v) => Kind::StringValue(v),
+            Value::Sequence(v) => Kind::ListValue(prost_types::ListValue {
+                values: v.into_iter().map(from_yaml).collect(),
+            }),
+            Value::Mapping(v) => Kind::StructValue(prost_types::Struct {
+                fields: v
+                    .into_iter()
+                    .filter_map(|(key, value)| {
+                        let key = if let Value::String(value) = key {
+                            value
+                        } else {
+                            return None;
+                        };
+
+                        Some((key, from_yaml(value)))
+                    })
+                    .collect(),
+            }),
+        }),
+    }
+}

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -193,6 +193,15 @@ mod tests {
         #[prost(message, optional, tag = "1")]
         pub value: Option<prost::alloc::string::String>,
     }
+
+    impl From<Append> for ProtoAppend {
+        fn from(append: Append) -> Self {
+            Self {
+                value: append.value,
+            }
+        }
+    }
+
     impl TryFrom<ProtoAppend> for Append {
         type Error = ConvertProtoConfigError;
         fn try_from(p: ProtoAppend) -> std::result::Result<Self, Self::Error> {


### PR DESCRIPTION
This splits out most of the type conversion code from #506 in order to make it easier to review and merge.``