### PR TITLE
Add `StaticFilter` trait

### DIFF
--- a/docs/src/filters/writing_custom_filters.md
+++ b/docs/src/filters/writing_custom_filters.md
@@ -1,176 +1,82 @@
 # Writing Custom Filters
 
-Quilkin provides an extensible implementation of [Filters] that allows us to plug in custom implementations to fit our needs.
-This document provides an overview of the API and how we can go about writing our own [Filters].
+> The full source code used in this example can be found
+  in [`examples/`][example].
 
-## API Components
+Quilkin provides an extensible implementation of [Filters] that allows us to
+plug in custom implementations to fit our needs.  This document provides an
+overview of the API and how we can go about writing our own [Filters]. First
+we need to create a type and implement two traits for it.
 
-The following components make up Quilkin's implementation of filters.
-
-### Filter
-
-A [trait][Filter] representing an actual [Filter][built-in-filters] instance in the pipeline.
-
-- An implementation provides a `read` and a `write` method.
-- Both methods are invoked by the proxy when it consults the [filter chain] - their arguments contain information about the packet being processed.
-- `read` is invoked when a packet is received on the local downstream port and is to be sent to an upstream endpoint while `write` is invoked in the opposite direction when a packet is received from an upstream endpoint and is to be sent to a downstream client.
-
-### FilterFactory
-
-A [trait][FilterFactory] representing a type that knows how to create instances of a particular type of [Filter].
-
-- An implementation provides a `name` and `create_filter` method.
-- `create_filter` takes in [configuration][filter configuration] for the filter to create and returns a [FilterInstance] type containing a new instance of its filter type.
-  `name` returns the Filter name - a unique identifier of filters of the created type (e.g quilkin.filters.debug.v1alpha1.Debug).
-
-### FilterRegistry
-
-A [struct][FilterRegistry] representing the set of all filter types known to the proxy.
-It contains all known implementations of [FilterFactory], each identified by their [name][filter-factory-name].
-
-
-These components come together to form the [filter chain].
-- A [FilterRegistry] is populated with the [FilterFactory] for [built-in-filters] and any custom ones we provide.
-- During startup, the initial list of [filter configuration] is retrieved, either from a [static config file][proxy-config] or dynamically from a [management server].
-- Each [filter configuration] is used to invoke the matching (based on the Filter name) [FilterFactory] in the [FilterRegistry] - creating a [Filter] instance.
-- Finally, the created [Filter] instances are piped together to form the [filter chain].
-
-Note that when using dynamic configuration, the process repeats in a similar manner - new filter instances are created according to the updated [filter configuration] and a new [filter chain] is re-created while the old one is dropped.
-
-
-### Creating Custom Filters
-
-To extend Quilkin's code with our own custom filter, we need to do the following:
-
-1. Import the Quilkin crate.
-1. Implement the [Filter] trait with our custom logic, as well as a [FilterFactory] that knows how to create instances of the Filter implementation.
-1. Start the proxy with the custom [FilterFactory] implementation.
-
-> The full source code used in this example can be found [here][example]
-
-#### 1. Import the Quilkin crate
-
-```bash
-# Start with a new crate
-cargo new --bin quilkin-filter-example
-```
-Add Quilkin as a dependency in `Cargo.toml`.
-```toml
-[dependencies]
-quilkin = "0.2.0"
-```
-
-#### 2. Implement the filter traits
-
-It's not terribly important what the filter in this example does so let's write a `Greet` filter that appends `Hello` to every packet in one direction and `Goodbye` to packets in the opposite direction.
-
-We start with the [Filter] implementation
+It's not terribly important what the filter in this example does so let's write
+a `Greet` filter that appends `Hello` to every packet in one direction and
+`Goodbye` to packets in the opposite direction.
 
 ```rust,no_run,noplayground
-# #![allow(unused)]
-# fn main() {
-#
-// src/main.rs
-use quilkin::filters::prelude::*;
-
 struct Greet;
+```
+
+> As a convention within Quilkin: Filter names are singular, they also tend to
+> be a verb, rather than an adjective.
+>
+>  **Examples**
+>  - **Greet** not "Greets"
+>  - **Compress** not "Compressor".
+
+## `Filter`
+
+Represents the actual [Filter][built-in-filters] instance in the pipeline. An
+implementation provides a `read` and a `write` method (both are passthrough
+by default) that accepts a context object and returns a response.
+
+Both methods are invoked by the proxy when it consults the [filter chain]
+`read` is invoked when a packet is received on the local downstream port and
+is to be sent to an upstream endpoint while `write` is invoked in the opposite
+direction when a packet is received from an upstream endpoint and is to be
+sent to a downstream client.
+
+```rust,no_run,noplayground
+# struct Greet;
+use quilkin::filters::prelude::*;
 
 impl Filter for Greet {
     fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
-        ctx.contents.splice(0..0, String::from("Hello ").into_bytes());
+        ctx.contents.extend(b"Hello");
         Some(ctx.into())
     }
     fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
-        ctx.contents.splice(0..0, String::from("Goodbye ").into_bytes());
+        ctx.contents.extend(b"Goodbye");
         Some(ctx.into())
     }
 }
-# }
 ```
 
-Next, we implement a [FilterFactory] for it and give it a name:
+## `StaticFilter`
+
+Represents metadata needed for your [`Filter`], most of it has to with defining
+configuration, for now we can use `()` as we have no configuration currently.
 
 ```rust,no_run,noplayground
-# #![allow(unused)]
-# fn main() {
-#
-# #[derive(Default)]
+# use quilkin::filters::prelude::*;
 # struct Greet;
-# impl Greet {
-#     fn new(_: Config) -> Self {
-#          <_>::default()
-#     }
-# }
 # impl Filter for Greet {}
-# impl StaticFilter for Greet {
-#     const NAME: &'static str = "greet.v1";
-#     type Configuration = Config;
-#     type BinaryConfiguration = prost_types::Struct;
-#
-#     fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
-#         Ok(Greet::new(config.unwrap_or_default()))
-#     }
-# }
-// src/main.rs
-use quilkin::filters::prelude::*;
+impl StaticFilter for Greet {
+    const NAME: &'static str = "greet.v1";
+    type Configuration = ();
+    type BinaryConfiguration = ();
 
-#[derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
-struct Config {
-    greeting: String,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            greeting: "World".into(),
-        }
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Ok(Self)
     }
 }
-
-impl TryFrom<prost_types::Struct> for Config {
-    type Error = Error;
-
-    fn try_from(map: prost_types::Struct) -> Result<Self, Error> {
-        let greeting = map.fields.get("greeting")
-            .and_then(|v| v.kind.clone())
-            .and_then(|kind| {
-                match kind {
-                    prost_types::value::Kind::StringValue(string) => Some(string),
-                    _ => None,
-                }
-            }).ok_or_else(|| {
-                Error::FieldInvalid {
-                    field: "greeting".into(),
-                    reason: "Missing".into()
-                }
-            })?;
-
-        Ok(Self { greeting })
-    }
-}
-
-impl From<Config> for prost_types::Struct {
-    fn from(config: Config) -> Self {
-        Self {
-            fields: <_>::from([
-                ("greeting".into(), prost_types::Value {
-                    kind: Some(prost_types::value::Kind::StringValue(config.greeting))
-                })
-            ])
-        }
-    }
-}
-# }
 ```
 
-> As a convention within Quilkin, Filter names are singular. e.g. `Greet` rather than `Greets`.
-> They also tend to be a verb, rather than an adjective, i.e. `Compress` rather than `Compressor`.
+## Running
 
-#### 3. Start the proxy
-
-We can run the proxy in the exact manner as the default Quilkin binary using the [run][runner::run] function, passing in our custom [FilterFactory].
-Let's add a main function that does that. Quilkin relies on the [Tokio] async runtime, so we need to import that
-crate and wrap our main function with it.
+We can run the proxy in the exact manner as the default Quilkin binary using the
+[run][runner::run] function, passing in our custom [FilterFactory]. Let's add a
+main function that does that. Quilkin relies on the [Tokio] async runtime, so we
+need to import that crate and wrap our main function with it.
 
 Add Tokio as a dependency in `Cargo.toml`.
 
@@ -187,11 +93,12 @@ Add a main function that starts the proxy.
 {{#include ../../../examples/quilkin-filter-example/src/main.rs:run}}
 ```
 
-Now, let's try out the proxy. The following configuration starts our extended version of the proxy at port 7001 and
-forwards all packets to an upstream server at port 4321.
+Now, let's try out the proxy. The following configuration starts our extended
+version of the proxy at port 7001 and forwards all packets to an upstream server
+at port 4321.
 
 ```yaml
-# config.yaml
+# quilkin.yaml
 version: v1alpha1
 proxy:
   port: 7001
@@ -202,124 +109,66 @@ static:
   - address: 127.0.0.1:4321
 ```
 
-- Start the proxy
+Next we to setup our network of services, for this example we're going to use
+the `netcat` tool to spawn a UDP echo server and interactive client for us to
+send packets over the wire.
 
-  ```bash
-  cargo run -- -c config.yaml
-  ```
-
-- Start a UDP listening server on the configured port
-  ```bash
-  nc -lu 127.0.0.1 4321
-  ```
-
-- Start an interactive UDP client that sends packet to the proxy
-  ```bash
-  nc -u 127.0.0.1 7001
-  ```
-
-Whatever we pass to the client should now show up with our modification on the listening server's standard output.
-For example typing `Quilkin` in the client prints `Hello Quilkin` on the server.
-
-#### 4. Working with Filter Configuration
-
-Let's extend the `Greet` filter to require a configuration that contains what greeting to use.
-
-The [Serde] crate is used to describe static YAML configuration in code while [Prost] is used to describe dynamic configuration as [Protobuf] messages when talking to the [management server].
-
-##### Static Configuration
-
-First let's create the config for our static configuration:
-
-###### 1. Add the yaml parsing crates to `Cargo.toml`:
-
-```toml
-  [dependencies]
-  # ...
-  serde = "1.0"
-  serde_yaml = "0.8"
+```bash
+# Start the proxy
+cargo run -- &
+# Start a UDP listening server on the configured port
+nc -lu 127.0.0.1 4321 &
+# Start an interactive UDP client that sends packet to the proxy
+nc -u 127.0.0.1 7001
 ```
 
-###### 2. Define a struct representing the config:
+Whatever we pass to the client should now show up with our modification on the
+listening server's standard output.  For example typing `Quilkin` in the client
+prints `Hello Quilkin` on the server.
+
+## Configuration
+
+Let's extend the `Greet` filter to have a configuration that contains what
+greeting to use.
+
+The [Serde] crate is used to describe static YAML configuration in code while
+[Tonic]/[Prost] is used to describe dynamic configuration as [Protobuf] messages
+when talking to a [management server].
+
+### YAML Configuration
+
+First let's create the type for our configuration:
+
+1. Add the yaml parsing crates to `Cargo.toml`:
+
+```toml
+# [dependencies]
+serde = "1.0"
+serde_yaml = "0.8"
+```
+
+2. Define a struct representing the config:
 
 ```rust,no_run,noplayground,ignore
 // src/main.rs
 {{#include ../../../examples/quilkin-filter-example/src/main.rs:serde_config}}
 ```
 
-###### 3. Update the `Greet` Filter to take in `greeting` as a parameter:
+3. Update the `Greet` Filter to take in `greeting` as a parameter:
 
 ```rust,no_run,noplayground,ignore
 // src/main.rs
 {{#include ../../../examples/quilkin-filter-example/src/main.rs:filter}}
 ```
 
-###### 4. Finally, update `GreetFilterFactory` to extract the greeting from the passed in configuration and forward it onto the `Greet` Filter.
+### Protobuf Configuration
 
-```rust,no_run,noplayground
-// src/main.rs
-# use serde::{Deserialize, Serialize};
-# use quilkin::filters::prelude::*;
-# #[derive(Serialize, Default, Deserialize, Debug, schemars::JsonSchema)]
-# struct Config {
-#     greeting: String,
-# }
-# #[derive(Default)]
-# struct Greet(String);
-# impl Greet {
-#    fn new(_: Config) -> Self { <_>::default() }
-# }
-# impl Filter for Greet { }
-# impl TryFrom<prost_types::Struct> for Config {
-#     type Error = Error;
-#     fn try_from(map: prost_types::Struct) -> Result<Self, Error> {
-#         todo!()
-#     }
-# }
-# impl TryFrom<Config> for prost_types::Struct {
-#     type Error = Error;
-#     fn try_from(map: Config) -> Result<Self, Error> {
-#         todo!()
-#     }
-# }
-impl StaticFilter for Greet {
-#    const NAME: &'static str = "greet.v1";
-#    type Configuration = Config;
-#    type BinaryConfiguration = prost_types::Struct;
-#
-    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
-        Ok(Greet::new(config.unwrap_or_default()))
-    }
-}
-```
+Quilkin comes with out-of-the-box support for xDS management, and as such needs
+to communicate filter configuration over [Protobuf] with management servers and
+clients to synchronise state across the network. So let's add the binary version
+of our `Greet` configuration.
 
-And with these changes we have wired up static configuration for our filter. Try it out with the following config.yaml:
-```yaml
-# config.yaml
-{{#include ../../../examples/quilkin-filter-example/config.yaml:yaml}}
-```
-
-##### Dynamic Configuration
-
-You might have noticed while adding [static configuration support][anchor-static-config], that the [config][CreateFilterArgs::config] argument passed into our [FilterFactory]
-has a [Dynamic][ConfigType::dynamic] variant.
-
-```rust,ignore
-let config = match args.config.unwrap() {
-    ConfigType::Static(config) => {
-        serde_yaml::from_str::<Config>(serde_yaml::to_string(&config).unwrap().as_str())
-         .unwrap()
-    }
-    ConfigType::Dynamic(_) => unimplemented!("dynamic config is not yet supported for this filter"),
-};
-```
-
-The [Dynamic][ConfigType::dynamic] contains the serialized [Protobuf] message received from the [management server] for the [Filter] to create.
-As a result, its contents are entirely opaque to Quilkin and it is represented with the [Prost Any][prost-any] type so the [FilterFactory]
-can interpret its contents however it wishes.
-However, it usually contains a Protobuf equivalent of the filter's static configuration.
-
-###### 1. Add the proto parsing crates to `Cargo.toml`:
+1. Add the proto parsing crates to `Cargo.toml`:
 
 ```toml
 [dependencies]
@@ -329,62 +178,60 @@ prost = "0.7"
 prost-types = "0.7"
 ```
 
-###### 2. Create a [Protobuf] equivalent of the [static configuration][anchor-static-config]:
+2. Create a [Protobuf] equivalent of our YAML configuration.
 
 ```plaintext,no_run,noplayground,ignore
 // src/greet.proto
 {{#include ../../../examples/quilkin-filter-example/src/greet.proto:proto}}
 ```
 
-###### 3. Generate Rust code from the proto file:
+3. Generate Rust code from the proto file:
 
 There are a few ways to generate [Prost] code from proto, we will use the [prost_build] crate in this example.
 
-Add the required crates to `Cargo.toml`:
+Add the following required crates to `Cargo.toml`, and then add a
+[build script][build-script] to generate the following Rust code
+during compilation:
 
 ```toml
-[dependencies]
-# ...
+# [dependencies]
 bytes = "1.0"
 
-[build-dependencies]
+# [build-dependencies]
 prost-build = "0.7"
 ```
-
-Add a [build script][build-script] to generate the Rust code during compilation:
 
 ```rust,no_run,noplayground,ignore
 // src/build.rs
 {{#include ../../../examples/quilkin-filter-example/build.rs:build}}
 ```
 
-To include the generated code, we'll use a convenience macro [include_proto], which imports the generated code, while
-recreating the grpc package name as Rust modules:
+To include the generated code, we'll use [`tonic::include_proto`], then we just
+need to implement [std::convert::TryFrom] for converting the protobuf message to
+equivalvent configuration.
+
 
 ```rust,no_run,noplayground,ignore
 // src/main.rs
 {{#include ../../../examples/quilkin-filter-example/src/main.rs:include_proto}}
-```
-###### 4. Decode the serialized proto message into a config:
 
-If the message contains a Protobuf equivalent of the filter's static configuration, we can
-leverage the [deserialize][ConfigType::deserialize] method to deserialize either a static or dynamic config.
-The function automatically deserializes and converts from the Protobuf type if the input contains a dynamic
-configuration.
-As a result, the function requires that the [std::convert::TryFrom] is implemented from our dynamic
-config type to a static equivalent.
-
-```rust,no_run,noplayground,ignore
-// src/main.rs
 {{#include ../../../examples/quilkin-filter-example/src/main.rs:TryFrom}}
 ```
 
-With our conversion implementation, we can to extract a greeting from any configuration type and
-forward it onto the `Greet` Filter.
+Now, let's update `Greet`'s `StaticFilter` implementation to use the two
+configurations.
 
 ```rust,no_run,noplayground,ignore
 // src/main.rs
 {{#include ../../../examples/quilkin-filter-example/src/main.rs:factory}}
+```
+
+That's it! With these changes we have wired up static configuration for our
+filter. Try it out with the following configuration:
+
+```yaml
+# quilkin.yaml
+{{#include ../../../examples/quilkin-filter-example/config.yaml:yaml}}
 ```
 
 [FilterInstance]: ../../api/quilkin/filters/prelude/struct.FilterInstance.html
@@ -397,19 +244,17 @@ forward it onto the `Greet` Filter.
 [ConfigType::dynamic]: ../../api/quilkin/config/enum.ConfigType.html#variant.Dynamic
 [ConfigType::static]: ../../api/quilkin/config/enum.ConfigType.html#variant.Static
 [ConfigType::deserialize]: ../../api/quilkin/config/enum.ConfigType.html#method.deserialize
-[include_proto]: ../../api/quilkin/macro.include_proto.html
 [std::convert::TryFrom]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
 
-[anchor-dynamic-config]: #dynamic-configuration
-[anchor-static-config]: #static-configuration
 [Filters]: ../filters.md
 [filter chain]: ../filters.md#filters-and-filter-chain
 [built-in-filters]: ../filters.md#built-in-filters
 [filter configuration]: ../filters.md#filter-config
 [proxy-config]: ../proxy-configuration.md
 [management server]: ../xds.md
-[Tokio]: https://docs.rs/tokio/1.5.0/tokio/
-[Prost]: https://docs.rs/prost/0.7.0/prost/
+[tokio]: https://docs.rs/tokio
+[tonic]: https://docs.rs/tonic
+[prost]: https://docs.rs/prost
 [Protobuf]: https://developers.google.com/protocol-buffers
 [Serde]: https://docs.serde.rs/serde_yaml/index.html
 [prost-any]: https://docs.rs/prost-types/0.7.0/prost_types/struct.Any.html

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -15,8 +15,9 @@
  */
 
 // ANCHOR: include_proto
-quilkin::include_proto!("greet");
-use greet::Greet as ProtoGreet;
+mod proto {
+    tonic::include_proto!("greet");
+}
 // ANCHOR_END: include_proto
 use quilkin::filters::prelude::*;
 
@@ -31,13 +32,21 @@ struct Config {
 // ANCHOR_END: serde_config
 
 // ANCHOR: TryFrom
-impl TryFrom<ProtoGreet> for Config {
+impl TryFrom<proto::Greet> for Config {
     type Error = ConvertProtoConfigError;
 
-    fn try_from(p: ProtoGreet) -> Result<Self, Self::Error> {
-        Ok(Config {
+    fn try_from(p: proto::Greet) -> Result<Self, Self::Error> {
+        Ok(Self {
             greeting: p.greeting,
         })
+    }
+}
+
+impl From<Config> for proto::Greet {
+    fn from(config: Config) -> Self {
+        Self {
+            greeting: config.greeting,
+        }
     }
 }
 // ANCHOR_END: TryFrom
@@ -60,28 +69,15 @@ impl Filter for Greet {
 // ANCHOR_END: filter
 
 // ANCHOR: factory
-pub const NAME: &str = "greet.v1";
+use quilkin::filters::StaticFilter;
 
-pub fn factory() -> DynFilterFactory {
-    Box::from(GreetFilterFactory)
-}
+impl StaticFilter for Greet {
+    const NAME: &'static str = "greet.v1";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::Greet;
 
-struct GreetFilterFactory;
-impl FilterFactory for GreetFilterFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let (config_json, config) = self
-            .require_config(args.config)?
-            .deserialize::<Config, ProtoGreet>(self.name())?;
-        let filter: Box<dyn Filter> = Box::new(Greet(config.greeting));
-        Ok(FilterInstance::new(config_json, filter))
+    fn new(config: Option<Self::Configuration>) -> Result<Self, quilkin::filters::Error> {
+        Ok(Self(Self::ensure_config_exists(config)?.greeting))
     }
 }
 // ANCHOR_END: factory
@@ -91,7 +87,7 @@ impl FilterFactory for GreetFilterFactory {
 async fn main() {
     quilkin::run(
         quilkin::Config::builder().build(),
-        vec![self::factory()].into_iter(),
+        vec![Greet::factory()].into_iter(),
     )
     .await
     .unwrap();

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -99,7 +99,7 @@ where
         + Sync
         + Sized;
 
-    /// Instaniates a new [`StaticFilter`] from the given configuration, if any.
+    /// Instantiates a new [`StaticFilter`] from the given configuration, if any.
     /// # Errors
     /// If the provided configuration is invalid.
     fn new(config: Option<Self::Configuration>) -> Result<Self, Error>;

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -216,7 +216,7 @@ mod tests {
     use crate::{
         config,
         endpoint::{Endpoint, Endpoints, UpstreamEndpoints},
-        filters::debug,
+        filters::Debug,
         test_utils::{new_test_chain, TestFilterFactory},
     };
 
@@ -224,12 +224,12 @@ mod tests {
 
     #[test]
     fn from_config() {
-        let provider = debug::factory();
+        let provider = Debug::factory();
 
         // everything is fine
         let filter_configs = &[config::Filter {
             name: provider.name().into(),
-            config: Default::default(),
+            config: Some(serde_yaml::Mapping::default().into()),
         }];
 
         let chain = FilterChain::try_create(filter_configs).unwrap();

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -217,7 +217,7 @@ mod tests {
         config,
         endpoint::{Endpoint, Endpoints, UpstreamEndpoints},
         filters::Debug,
-        test_utils::{new_test_chain, TestFilterFactory},
+        test_utils::{new_test_chain, TestFilter},
     };
 
     use super::*;
@@ -229,7 +229,7 @@ mod tests {
         // everything is fine
         let filter_configs = &[config::Filter {
             name: provider.name().into(),
-            config: Some(serde_yaml::Mapping::default().into()),
+            config: Some(serde_json::Map::default().into()),
         }];
 
         let chain = FilterChain::try_create(filter_configs).unwrap();
@@ -310,12 +310,18 @@ mod tests {
     fn chain_double_test_filter() {
         let chain = FilterChain::new(vec![
             (
-                "TestFilter".into(),
-                TestFilterFactory::create_empty_filter(),
+                TestFilter::NAME.into(),
+                FilterInstance {
+                    config: Arc::new(serde_json::json!(null)),
+                    filter: Box::new(TestFilter),
+                },
             ),
             (
-                "TestFilter".into(),
-                TestFilterFactory::create_empty_filter(),
+                TestFilter::NAME.into(),
+                FilterInstance {
+                    config: Arc::new(serde_json::json!(null)),
+                    filter: Box::new(TestFilter),
+                },
             ),
         ])
         .unwrap();
@@ -368,13 +374,16 @@ mod tests {
 
     #[test]
     fn get_configs() {
-        struct TestFilter2 {}
+        struct TestFilter2;
         impl Filter for TestFilter2 {}
 
         let filter_chain = FilterChain::new(vec![
             (
                 "TestFilter".into(),
-                TestFilterFactory::create_empty_filter(),
+                FilterInstance {
+                    config: Arc::new(serde_json::json!(null)),
+                    filter: Box::new(TestFilter),
+                },
             ),
             (
                 "TestFilter2".into(),
@@ -383,7 +392,7 @@ mod tests {
                         "k1": "v1",
                         "k2": 2
                     })),
-                    filter: Box::new(TestFilter2 {}),
+                    filter: Box::new(TestFilter2),
                 },
             ),
         ])

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -143,7 +143,7 @@ impl StaticFilter for Compress {
     type Configuration = Config;
     type BinaryConfiguration = proto::Compress;
 
-    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
         Ok(Compress::new(
             Self::ensure_config_exists(config)?,
             Metrics::new()?,

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -29,15 +29,8 @@ use metrics::Metrics;
 
 pub use config::{Action, Config, Mode};
 
-pub const NAME: &str = "quilkin.filters.compress.v1alpha1.Compress";
-
-/// Returns a factory for creating compression filters.
-pub fn factory() -> DynFilterFactory {
-    Box::from(CompressFactory::new())
-}
-
 /// Filter for compressing and decompressing packet data
-struct Compress {
+pub struct Compress {
     metrics: Metrics,
     compression_mode: Mode,
     on_read: Action,
@@ -145,44 +138,26 @@ impl Filter for Compress {
     }
 }
 
-struct CompressFactory {}
+impl StaticFilter for Compress {
+    const NAME: &'static str = "quilkin.filters.compress.v1alpha1.Compress";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::Compress;
 
-impl CompressFactory {
-    pub fn new() -> Self {
-        CompressFactory {}
-    }
-}
-
-impl FilterFactory for CompressFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let (config_json, config) = self
-            .require_config(args.config)?
-            .deserialize::<Config, proto::Compress>(self.name())?;
-        let filter = Compress::new(config, Metrics::new()?);
-        Ok(FilterInstance::new(
-            config_json,
-            Box::new(filter) as Box<dyn Filter>,
+    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Ok(Compress::new(
+            Self::ensure_config_exists(config)?,
+            Metrics::new()?,
         ))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
     use tracing_test::traced_test;
 
-    use crate::endpoint::{Endpoint, Endpoints, UpstreamEndpoints};
-    use crate::filters::{
-        compress::{compressor::Snappy, Compressor},
-        CreateFilterArgs, Filter, FilterFactory, ReadContext, WriteContext,
+    use crate::{
+        endpoint::{Endpoint, Endpoints, UpstreamEndpoints},
+        filters::compress::compressor::Snappy,
     };
 
     use super::*;
@@ -275,36 +250,25 @@ mod tests {
 
     #[test]
     fn default_mode_factory() {
-        let factory = CompressFactory::new();
         let config = serde_json::json!({
             "on_read": "DECOMPRESS".to_string(),
             "on_write": "COMPRESS".to_string(),
 
         });
-        let filter = factory
-            .create_filter(CreateFilterArgs::fixed(Some(config)))
-            .expect("should create a filter")
-            .filter;
-        assert_downstream(filter.as_ref());
+        let filter = Compress::from_config(Some(serde_json::from_value(config).unwrap()));
+        assert_downstream(&filter);
     }
 
     #[test]
     fn config_factory() {
-        let factory = CompressFactory::new();
-
         let config = serde_json::json!({
             "mode": "SNAPPY".to_string(),
             "on_read": "DECOMPRESS".to_string(),
             "on_write": "COMPRESS".to_string(),
 
         });
-        let args = CreateFilterArgs::fixed(Some(config));
-
-        let filter = factory
-            .create_filter(args)
-            .expect("should create a filter")
-            .filter;
-        assert_downstream(filter.as_ref());
+        let filter = Compress::from_config(Some(serde_json::from_value(config).unwrap()));
+        assert_downstream(&filter);
     }
 
     #[test]

--- a/src/filters/concatenate_bytes.rs
+++ b/src/filters/concatenate_bytes.rs
@@ -78,7 +78,7 @@ impl StaticFilter for ConcatenateBytes {
     type Configuration = Config;
     type BinaryConfiguration = proto::ConcatenateBytes;
 
-    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
         Ok(ConcatenateBytes::new(Self::ensure_config_exists(config)?))
     }
 }

--- a/src/filters/concatenate_bytes.rs
+++ b/src/filters/concatenate_bytes.rs
@@ -23,18 +23,11 @@ use crate::filters::prelude::*;
 use self::quilkin::filters::concatenate_bytes::v1alpha1 as proto;
 pub use config::{Config, Strategy};
 
-pub const NAME: &str = "quilkin.filters.concatenate_bytes.v1alpha1.ConcatenateBytes";
-
-/// Returns a factory for creating concatenation filters.
-pub fn factory() -> DynFilterFactory {
-    Box::from(ConcatBytesFactory)
-}
-
 /// The `ConcatenateBytes` filter's job is to add a byte packet to either the
 /// beginning or end of each UDP packet that passes through. This is commonly
 /// used to provide an auth token to each packet, so they can be
 /// routed appropriately.
-struct ConcatenateBytes {
+pub struct ConcatenateBytes {
     on_read: Strategy,
     on_write: Strategy,
     bytes: Vec<u8>,
@@ -80,26 +73,12 @@ impl Filter for ConcatenateBytes {
     }
 }
 
-#[derive(Default)]
-struct ConcatBytesFactory;
+impl StaticFilter for ConcatenateBytes {
+    const NAME: &'static str = "quilkin.filters.concatenate_bytes.v1alpha1.ConcatenateBytes";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::ConcatenateBytes;
 
-impl FilterFactory for ConcatBytesFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let (config_json, config) = self
-            .require_config(args.config)?
-            .deserialize::<Config, proto::ConcatenateBytes>(self.name())?;
-        let filter = ConcatenateBytes::new(config);
-        Ok(FilterInstance::new(
-            config_json,
-            Box::new(filter) as Box<dyn Filter>,
-        ))
+    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Ok(ConcatenateBytes::new(Self::ensure_config_exists(config)?))
     }
 }

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -25,6 +25,7 @@ use tracing::info;
 use self::quilkin::filters::debug::v1alpha1 as proto;
 
 /// Debug logs all incoming and outgoing packets
+#[derive(Debug)]
 pub struct Debug {
     config: Config,
 }
@@ -59,7 +60,7 @@ impl StaticFilter for Debug {
     type Configuration = Config;
     type BinaryConfiguration = proto::Debug;
 
-    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
         Ok(Debug::new(config))
     }
 }
@@ -123,7 +124,6 @@ mod tests {
 
     #[test]
     fn from_config_should_error() {
-        let config = serde_json::json!({ "id": {} });
-        Debug::try_from_config(Some(serde_json::from_value(config).unwrap())).unwrap_err();
+        serde_json::from_value::<Config>(serde_json::json!({ "id": {} })).unwrap_err();
     }
 }

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -22,15 +22,10 @@ use serde::{Deserialize, Serialize};
 crate::include_proto!("quilkin.filters.drop.v1alpha1");
 use self::quilkin::filters::drop::v1alpha1 as proto;
 
+pub const NAME: &str = Drop::NAME;
+
 /// Always drops a packet, mostly useful in combination with other filters.
-struct Drop;
-
-pub const NAME: &str = "quilkin.filters.drop.v1alpha1.Drop";
-
-/// Creates a new factory for generating debug filters.
-pub fn factory() -> DynFilterFactory {
-    Box::from(DropFactory::new())
-}
+pub struct Drop;
 
 impl Drop {
     fn new() -> Self {
@@ -50,38 +45,13 @@ impl Filter for Drop {
     }
 }
 
-/// Factory for the Debug
-struct DropFactory;
+impl StaticFilter for Drop {
+    const NAME: &'static str = "quilkin.filters.drop.v1alpha1.Drop";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::Drop;
 
-impl DropFactory {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl FilterFactory for DropFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let config: Option<(_, Config)> = args
-            .config
-            .map(|config| config.deserialize::<Config, proto::Drop>(self.name()))
-            .transpose()?;
-
-        let (config_json, _) = config
-            .map(|(config_json, config)| (config_json, Some(config)))
-            .unwrap_or_else(|| (serde_json::Value::Null, None));
-
-        Ok(FilterInstance::new(
-            config_json,
-            Box::new(Drop::new()) as Box<dyn Filter>,
-        ))
+    fn new(_: Option<Self::Configuration>) -> Result<Self, Error> {
+        Ok(Drop::new())
     }
 }
 

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -50,7 +50,7 @@ impl StaticFilter for Drop {
     type Configuration = Config;
     type BinaryConfiguration = proto::Drop;
 
-    fn new(_: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(_: Option<Self::Configuration>) -> Result<Self, Error> {
         Ok(Drop::new())
     }
 }

--- a/src/filters/factory.rs
+++ b/src/filters/factory.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use crate::{
     config::ConfigType,
-    filters::{Error, Filter},
+    filters::{Error, Filter, StaticFilter},
 };
 
 /// An owned pointer to a dynamic [`FilterFactory`] instance.
@@ -63,10 +63,75 @@ pub trait FilterFactory: Sync + Send {
     /// Returns a filter based on the provided arguments.
     fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error>;
 
+    /// Converts YAML configuration into its Protobuf equivalvent.
+    fn encode_config_to_protobuf(&self, args: serde_json::Value)
+        -> Result<prost_types::Any, Error>;
+
+    /// Converts YAML configuration into its Protobuf equivalvent.
+    fn encode_config_to_json(&self, args: prost_types::Any) -> Result<serde_json::Value, Error>;
+
     /// Returns the [`ConfigType`] from the provided Option, otherwise it returns
     /// Error::MissingConfig if the Option is None.
     fn require_config(&self, config: Option<ConfigType>) -> Result<ConfigType, Error> {
         config.ok_or_else(|| Error::MissingConfig(self.name()))
+    }
+}
+
+impl<F> FilterFactory for std::marker::PhantomData<fn() -> F>
+where
+    F: StaticFilter + 'static,
+    Error: From<<F::Configuration as TryFrom<F::BinaryConfiguration>>::Error>
+        + From<<F::BinaryConfiguration as TryFrom<F::Configuration>>::Error>,
+{
+    fn name(&self) -> &'static str {
+        F::NAME
+    }
+
+    fn config_schema(&self) -> schemars::schema::RootSchema {
+        schemars::schema_for!(F::Configuration)
+    }
+
+    /// Returns a filter based on the provided arguments.
+    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
+        let (config_json, config): (_, Option<F::Configuration>) = if let Some(config) = args.config
+        {
+            config
+                .deserialize::<F::Configuration, F::BinaryConfiguration>(self.name())
+                .map(|(j, c)| (j, Some(c)))?
+        } else {
+            (serde_json::Value::Null, None)
+        };
+
+        Ok(FilterInstance::new(
+            config_json,
+            Box::from(F::new(config)?) as Box<dyn Filter>,
+        ))
+    }
+
+    fn encode_config_to_protobuf(
+        &self,
+        config: serde_json::Value,
+    ) -> Result<prost_types::Any, Error> {
+        let config: F::Configuration = serde_json::from_value(config)?;
+
+        Ok(prost_types::Any {
+            type_url: self.name().into(),
+            value: crate::prost::encode::<F::BinaryConfiguration>(&config.try_into()?)?,
+        })
+    }
+
+    fn encode_config_to_json(&self, config: prost_types::Any) -> Result<serde_json::Value, Error> {
+        if self.name() != config.type_url {
+            return Err(crate::filters::Error::MismatchedTypes {
+                expected: self.name().into(),
+                actual: config.type_url,
+            });
+        }
+
+        let message = <F::BinaryConfiguration as prost::Message>::decode(&*config.value)?;
+        let config = F::Configuration::try_from(message)?;
+
+        Ok(serde_json::to_value(&config)?)
     }
 }
 

--- a/src/filters/factory.rs
+++ b/src/filters/factory.rs
@@ -104,7 +104,7 @@ where
 
         Ok(FilterInstance::new(
             config_json,
-            Box::from(F::new(config)?) as Box<dyn Filter>,
+            Box::from(F::try_from_config(config)?) as Box<dyn Filter>,
         ))
     }
 

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-//! Filter for allowing/blocking traffic by IP and port.
-
 use tracing::debug;
 
 use crate::filters::firewall::metrics::Metrics;
@@ -30,43 +28,8 @@ mod metrics;
 
 pub use config::{Action, Config, PortRange, PortRangeError, Rule};
 
-pub const NAME: &str = "quilkin.filters.firewall.v1alpha1.Firewall";
-
-pub fn factory() -> DynFilterFactory {
-    Box::from(FirewallFactory::new())
-}
-
-struct FirewallFactory {}
-
-impl FirewallFactory {
-    pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl FilterFactory for FirewallFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let (config_json, config) = self
-            .require_config(args.config)?
-            .deserialize::<Config, proto::Firewall>(self.name())?;
-
-        let filter = Firewall::new(config, Metrics::new()?);
-        Ok(FilterInstance::new(
-            config_json,
-            Box::new(filter) as Box<dyn Filter>,
-        ))
-    }
-}
-
-struct Firewall {
+/// Filter for allowing/blocking traffic by IP and port.
+pub struct Firewall {
     metrics: Metrics,
     on_read: Vec<Rule>,
     on_write: Vec<Rule>,
@@ -79,6 +42,19 @@ impl Firewall {
             on_read: config.on_read,
             on_write: config.on_write,
         }
+    }
+}
+
+impl StaticFilter for Firewall {
+    const NAME: &'static str = "quilkin.filters.firewall.v1alpha1.Firewall";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::Firewall;
+
+    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Ok(Firewall::new(
+            Self::ensure_config_exists(config)?,
+            Metrics::new()?,
+        ))
     }
 }
 

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -50,7 +50,7 @@ impl StaticFilter for Firewall {
     type Configuration = Config;
     type BinaryConfiguration = proto::Firewall;
 
-    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
         Ok(Firewall::new(
             Self::ensure_config_exists(config)?,
             Metrics::new()?,

--- a/src/filters/local_rate_limit.rs
+++ b/src/filters/local_rate_limit.rs
@@ -169,7 +169,7 @@ impl StaticFilter for LocalRateLimit {
     type Configuration = Config;
     type BinaryConfiguration = proto::LocalRateLimit;
 
-    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
         Self::new(Self::ensure_config_exists(config)?, Metrics::new()?)
     }
 }

--- a/src/filters/local_rate_limit.rs
+++ b/src/filters/local_rate_limit.rs
@@ -34,13 +34,6 @@ use metrics::Metrics;
 crate::include_proto!("quilkin.filters.local_rate_limit.v1alpha1");
 use self::quilkin::filters::local_rate_limit::v1alpha1 as proto;
 
-pub const NAME: &str = "quilkin.filters.local_rate_limit.v1alpha1.LocalRateLimit";
-
-/// Creates a new factory for generating rate limiting filters.
-pub fn factory() -> DynFilterFactory {
-    Box::from(LocalRateLimitFactory::new())
-}
-
 // TODO: we should make these values configurable and transparent to the filter.
 /// SESSION_TIMEOUT_SECONDS is the default session timeout.
 pub const SESSION_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
@@ -71,7 +64,7 @@ struct Bucket {
 /// applies rate limiting on packets received from a downstream connection (processed
 /// through [`LocalRateLimit::read`]). Packets coming from upstream endpoints
 /// flow through the filter untouched.
-struct LocalRateLimit {
+pub struct LocalRateLimit {
     /// Tracks rate limiting state per source address.
     state: TtlMap<Bucket>,
     /// Filter configuration.
@@ -83,12 +76,19 @@ struct LocalRateLimit {
 impl LocalRateLimit {
     /// new returns a new LocalRateLimit. It spawns a future in the background
     /// that periodically refills the rate limiter's tokens.
-    fn new(config: Config, metrics: Metrics) -> Self {
-        LocalRateLimit {
+    fn new(config: Config, metrics: Metrics) -> Result<Self, Error> {
+        if config.period < 1 {
+            return Err(Error::FieldInvalid {
+                field: "period".into(),
+                reason: "value must be at least 1 second".into(),
+            });
+        }
+
+        Ok(LocalRateLimit {
             state: TtlMap::new(SESSION_TIMEOUT_SECONDS, SESSION_EXPIRY_POLL_INTERVAL),
             config,
             metrics,
-        }
+        })
     }
 
     /// acquire_token is called on behalf of every packet that is eligible
@@ -164,41 +164,13 @@ impl Filter for LocalRateLimit {
     }
 }
 
-/// Creates instances of [`LocalRateLimit`].
-struct LocalRateLimitFactory {}
+impl StaticFilter for LocalRateLimit {
+    const NAME: &'static str = "quilkin.filters.local_rate_limit.v1alpha1.LocalRateLimit";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::LocalRateLimit;
 
-impl LocalRateLimitFactory {
-    pub fn new() -> Self {
-        LocalRateLimitFactory {}
-    }
-}
-
-impl FilterFactory for LocalRateLimitFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let (config_json, config) = self
-            .require_config(args.config)?
-            .deserialize::<Config, proto::LocalRateLimit>(self.name())?;
-
-        if config.period < 1 {
-            Err(Error::FieldInvalid {
-                field: "period".into(),
-                reason: "value must be at least 1 second".into(),
-            })
-        } else {
-            let filter = LocalRateLimit::new(config, Metrics::new()?);
-            Ok(FilterInstance::new(
-                config_json,
-                Box::new(filter) as Box<dyn Filter>,
-            ))
-        }
+    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Self::new(Self::ensure_config_exists(config)?, Metrics::new()?)
     }
 }
 
@@ -245,17 +217,14 @@ mod tests {
     use tokio::time;
 
     use super::*;
-    use crate::config::ConfigType;
-    use crate::endpoint::{Endpoint, EndpointAddress, Endpoints};
-    use crate::filters::local_rate_limit::LocalRateLimitFactory;
-    use crate::filters::{
-        local_rate_limit::{metrics::Metrics, Config, LocalRateLimit},
-        CreateFilterArgs, Filter, FilterFactory, ReadContext,
+    use crate::{
+        config::ConfigType,
+        endpoint::{Endpoint, Endpoints},
+        test_utils::assert_write_no_change,
     };
-    use crate::test_utils::assert_write_no_change;
 
     fn rate_limiter(config: Config) -> LocalRateLimit {
-        LocalRateLimit::new(config, Metrics::new().unwrap())
+        LocalRateLimit::new(config, Metrics::new().unwrap()).unwrap()
     }
 
     fn address_pair() -> (EndpointAddress, EndpointAddress) {
@@ -280,7 +249,7 @@ mod tests {
 
     #[tokio::test]
     async fn config_minimum_period() {
-        let factory = LocalRateLimitFactory::new();
+        let factory = LocalRateLimit::factory();
         let config = "
 max_packets: 10
 period: 0

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -23,14 +23,8 @@ use crate::{config::ConfigType, filters::prelude::*, metadata::Value};
 
 use self::quilkin::filters::matches::v1alpha1 as proto;
 use crate::filters::r#match::metrics::Metrics;
+
 pub use config::Config;
-
-pub const NAME: &str = "quilkin.filters.match.v1alpha1.Match";
-
-/// Creates a new factory for generating match filters.
-pub fn factory() -> DynFilterFactory {
-    Box::from(MatchFactory::new())
-}
 
 struct ConfigInstance {
     metadata_key: String,
@@ -61,19 +55,19 @@ impl ConfigInstance {
     }
 }
 
-struct MatchInstance {
+pub struct Match {
     metrics: Metrics,
     on_read_filters: Option<ConfigInstance>,
     on_write_filters: Option<ConfigInstance>,
 }
 
-impl MatchInstance {
+impl Match {
     fn new(config: Config, metrics: Metrics) -> Result<Self, Error> {
         let on_read_filters = config.on_read.map(ConfigInstance::new).transpose()?;
         let on_write_filters = config.on_write.map(ConfigInstance::new).transpose()?;
 
         if on_read_filters.is_none() && on_write_filters.is_none() {
-            return Err(Error::MissingConfig(NAME));
+            return Err(Error::MissingConfig(Self::NAME));
         }
 
         Ok(Self {
@@ -113,7 +107,7 @@ where
     }
 }
 
-impl Filter for MatchInstance {
+impl Filter for Match {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
     fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
         match_filter(
@@ -137,33 +131,13 @@ impl Filter for MatchInstance {
     }
 }
 
-struct MatchFactory;
+impl StaticFilter for Match {
+    const NAME: &'static str = "quilkin.filters.match.v1alpha1.Match";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::Match;
 
-impl MatchFactory {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl FilterFactory for MatchFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let (config_json, config) = self
-            .require_config(args.config)?
-            .deserialize::<Config, proto::Match>(self.name())?;
-
-        let filter = MatchInstance::new(config, Metrics::new()?)?;
-        Ok(FilterInstance::new(
-            config_json,
-            Box::new(filter) as Box<dyn Filter>,
-        ))
+    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Self::new(Self::ensure_config_exists(config)?, Metrics::new()?)
     }
 }
 
@@ -174,7 +148,7 @@ mod tests {
         filters::{
             r#match::{
                 config::{Branch, DirectionalConfig, Fallthrough, Filter as ConfigFilter},
-                Config, MatchInstance, Metrics,
+                Config, Match, Metrics,
             },
             Filter, ReadContext, WriteContext,
         },
@@ -196,7 +170,7 @@ mod tests {
             }),
             on_write: None,
         };
-        let filter = MatchInstance::new(config, metrics).unwrap();
+        let filter = Match::new(config, metrics).unwrap();
         let endpoint: Endpoint = Default::default();
         let contents = "hello".to_string().into_bytes();
 

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -136,7 +136,7 @@ impl StaticFilter for Match {
     type Configuration = Config;
     type BinaryConfiguration = proto::Match;
 
-    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
         Self::new(Self::ensure_config_exists(config)?, Metrics::new()?)
     }
 }

--- a/src/filters/match/config.rs
+++ b/src/filters/match/config.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use super::proto;
 use crate::{config::ConfigType, filters::ConvertProtoConfigError};
 
-/// Configuration for the [`factory`][crate::filters::match::factory].
+/// Configuration for [`Match`][super::Match].
 #[derive(Debug, Deserialize, Serialize, PartialEq, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -27,6 +27,17 @@ pub struct Config {
     pub on_read: Option<DirectionalConfig>,
     /// Configuration for [`Filter::write`][crate::filters::Filter::write].
     pub on_write: Option<DirectionalConfig>,
+}
+
+impl TryFrom<Config> for proto::Match {
+    type Error = crate::filters::Error;
+
+    fn try_from(config: Config) -> Result<Self, Self::Error> {
+        Ok(Self {
+            on_read: config.on_read.map(TryFrom::try_from).transpose()?,
+            on_write: config.on_write.map(TryFrom::try_from).transpose()?,
+        })
+    }
 }
 
 impl TryFrom<proto::Match> for Config {
@@ -65,6 +76,22 @@ pub struct DirectionalConfig {
     pub fallthrough: Fallthrough,
 }
 
+impl TryFrom<DirectionalConfig> for proto::r#match::Config {
+    type Error = crate::filters::Error;
+
+    fn try_from(config: DirectionalConfig) -> Result<Self, Self::Error> {
+        Ok(Self {
+            metadata_key: Some(config.metadata_key),
+            branches: config
+                .branches
+                .into_iter()
+                .map(TryFrom::try_from)
+                .collect::<Result<_, _>>()?,
+            fallthrough: config.fallthrough.try_into().map(Some)?,
+        })
+    }
+}
+
 impl TryFrom<proto::r#match::Config> for DirectionalConfig {
     type Error = eyre::Report;
 
@@ -96,6 +123,17 @@ pub struct Branch {
     /// The filter to run on successful matches.
     #[serde(flatten)]
     pub filter: Filter,
+}
+
+impl TryFrom<Branch> for proto::r#match::Branch {
+    type Error = crate::filters::Error;
+
+    fn try_from(branch: Branch) -> Result<Self, Self::Error> {
+        Ok(Self {
+            value: Some(branch.value.into()),
+            filter: branch.filter.try_into().map(Some)?,
+        })
+    }
 }
 
 impl TryFrom<proto::r#match::Branch> for Branch {
@@ -218,14 +256,23 @@ impl<'de> Deserialize<'de> for Filter {
     }
 }
 
-/// The behaviour when the none of branches match. Defaults to dropping packets.
-#[derive(Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
-#[serde(transparent)]
-pub struct Fallthrough(pub Filter);
+impl TryFrom<Filter> for proto::r#match::Filter {
+    type Error = crate::filters::Error;
 
-impl Default for Fallthrough {
-    fn default() -> Self {
-        Self(Filter::new(crate::filters::drop::NAME))
+    fn try_from(filter: Filter) -> Result<Self, Self::Error> {
+        Ok(Self {
+            config: match filter.config {
+                Some(ConfigType::Dynamic(any)) => Some(any),
+                Some(ConfigType::Static(value)) => {
+                    crate::filters::FilterRegistry::get_factory(&filter.id)
+                        .ok_or_else(|| crate::filters::Error::NotFound(filter.id.clone()))?
+                        .encode_config_to_protobuf(value)
+                        .map(Some)?
+                }
+                None => None,
+            },
+            id: Some(filter.id),
+        })
     }
 }
 
@@ -241,6 +288,24 @@ impl TryFrom<proto::r#match::Filter> for Filter {
             id,
             config: filter.config.map(ConfigType::Dynamic),
         })
+    }
+}
+
+/// The behaviour when the none of branches match. Defaults to dropping packets.
+#[derive(Debug, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(transparent)]
+pub struct Fallthrough(pub Filter);
+
+impl Default for Fallthrough {
+    fn default() -> Self {
+        Self(Filter::new(crate::filters::drop::NAME))
+    }
+}
+
+impl TryFrom<Fallthrough> for proto::r#match::Filter {
+    type Error = crate::filters::Error;
+    fn try_from(fallthrough: Fallthrough) -> Result<Self, Self::Error> {
+        fallthrough.0.try_into()
     }
 }
 

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -24,14 +24,7 @@ use self::quilkin::filters::pass::v1alpha1 as proto;
 
 /// Allows a packet to pass through, mostly useful in combination with
 /// other filters.
-struct Pass;
-
-pub const NAME: &str = "quilkin.filters.pass.v1alpha1.Pass";
-
-/// Creates a new factory for generating debug filters.
-pub fn factory() -> DynFilterFactory {
-    Box::from(PassFactory::new())
-}
+pub struct Pass;
 
 impl Pass {
     fn new() -> Self {
@@ -51,38 +44,13 @@ impl Filter for Pass {
     }
 }
 
-/// Factory for the Debug
-struct PassFactory;
+impl StaticFilter for Pass {
+    const NAME: &'static str = "quilkin.filters.pass.v1alpha1.Pass";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::Pass;
 
-impl PassFactory {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl FilterFactory for PassFactory {
-    fn name(&self) -> &'static str {
-        NAME
-    }
-
-    fn config_schema(&self) -> schemars::schema::RootSchema {
-        schemars::schema_for!(Config)
-    }
-
-    fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-        let config: Option<(_, Config)> = args
-            .config
-            .map(|config| config.deserialize::<Config, proto::Pass>(self.name()))
-            .transpose()?;
-
-        let (config_json, _) = config
-            .map(|(config_json, config)| (config_json, Some(config)))
-            .unwrap_or_else(|| (serde_json::Value::Null, None));
-
-        Ok(FilterInstance::new(
-            config_json,
-            Box::new(Pass::new()) as Box<dyn Filter>,
-        ))
+    fn new(_config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Ok(Pass::new())
     }
 }
 

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -49,7 +49,7 @@ impl StaticFilter for Pass {
     type Configuration = Config;
     type BinaryConfiguration = proto::Pass;
 
-    fn new(_config: Option<Self::Configuration>) -> Result<Self, Error> {
+    fn try_from_config(_config: Option<Self::Configuration>) -> Result<Self, Error> {
         Ok(Pass::new())
     }
 }

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -50,6 +50,12 @@ impl FilterRegistry {
             Some(filter) => filter,
         }
     }
+
+    /// Returns a [`DynFilterFactory`] for a given `key`. Returning `None` if the
+    /// factory cannot be found.
+    pub fn get_factory(key: &str) -> Option<std::sync::Arc<DynFilterFactory>> {
+        REGISTRY.load().get(key).cloned()
+    }
 }
 
 #[cfg(test)]

--- a/src/filters/set.rs
+++ b/src/filters/set.rs
@@ -16,7 +16,7 @@
 
 use std::{iter::FromIterator, sync::Arc};
 
-use crate::filters::{self, DynFilterFactory};
+use crate::filters::{self, DynFilterFactory, StaticFilter};
 
 #[cfg(doc)]
 use crate::filters::{FilterFactory, FilterRegistry};
@@ -52,17 +52,17 @@ impl FilterSet {
     pub fn default_with(filters: impl IntoIterator<Item = DynFilterFactory>) -> Self {
         Self::with(
             [
-                filters::capture::factory(),
-                filters::compress::factory(),
-                filters::concatenate_bytes::factory(),
-                filters::debug::factory(),
-                filters::drop::factory(),
-                filters::firewall::factory(),
-                filters::load_balancer::factory(),
-                filters::local_rate_limit::factory(),
-                filters::r#match::factory(),
-                filters::pass::factory(),
-                filters::token_router::factory(),
+                filters::Capture::factory(),
+                filters::Compress::factory(),
+                filters::ConcatenateBytes::factory(),
+                filters::Debug::factory(),
+                filters::Drop::factory(),
+                filters::Firewall::factory(),
+                filters::LoadBalancer::factory(),
+                filters::LocalRateLimit::factory(),
+                filters::Match::factory(),
+                filters::Pass::factory(),
+                filters::TokenRouter::factory(),
             ]
             .into_iter()
             .chain(filters),

--- a/src/prost.rs
+++ b/src/prost.rs
@@ -19,6 +19,13 @@
 use prost_types::value::Kind;
 use serde_json::Value;
 
+pub fn encode<M: prost::Message>(message: &M) -> Result<Vec<u8>, prost::EncodeError> {
+    let mut buf = Vec::new();
+    buf.reserve(message.encoded_len());
+    message.encode(&mut buf)?;
+    Ok(buf)
+}
+
 pub fn mapping_from_kind(kind: Kind) -> Option<serde_json::Map<String, serde_json::Value>> {
     match value_from_kind(kind) {
         Value::Object(mapping) => Some(mapping),

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -21,7 +21,7 @@ use tonic::transport::Endpoint as TonicEndpoint;
 use crate::{
     config::{self, Config, ManagementServer, Proxy, Source, ValidationError, ValueInvalidArgs},
     endpoint::Endpoints,
-    filters::chain::Error as FilterChainError,
+    filters::FilterChainError,
     proxy::{
         server::metrics::Metrics as ProxyMetrics, sessions::metrics::Metrics as SessionMetrics,
         Admin as ProxyAdmin, Health, Server,

--- a/src/proxy/config_dump.rs
+++ b/src/proxy/config_dump.rs
@@ -97,7 +97,11 @@ fn create_config_dump_json(
 #[cfg(test)]
 mod tests {
     use super::handle_request;
-    use crate::{cluster::SharedCluster, endpoint::Endpoint, filters::SharedFilterChain};
+    use crate::{
+        cluster::SharedCluster,
+        endpoint::Endpoint,
+        filters::{SharedFilterChain, StaticFilter},
+    };
 
     #[tokio::test]
     async fn test_handle_request() {
@@ -105,7 +109,7 @@ mod tests {
             SharedCluster::new_static_cluster(vec![Endpoint::new(([127, 0, 0, 1], 8080).into())])
                 .unwrap();
         let filter_chain = SharedFilterChain::new(&[crate::config::Filter {
-            name: crate::filters::debug::NAME.into(),
+            name: crate::filters::Debug::NAME.into(),
             config: Some(serde_yaml::from_str("id: hello").unwrap()),
         }])
         .unwrap();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,18 +15,22 @@
  */
 
 /// Common utilities for testing
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::str::from_utf8;
-use std::sync::Arc;
+use std::{
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    str::from_utf8,
+    sync::Arc,
+};
 
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, oneshot, watch};
 
-use crate::config::{Builder as ConfigBuilder, Config};
-use crate::endpoint::{Endpoint, EndpointAddress, Endpoints};
-use crate::filters::{prelude::*, FilterRegistry};
-use crate::metadata::Value;
-use crate::proxy::{Builder, PendingValidation};
+use crate::{
+    config::{Builder as ConfigBuilder, Config},
+    endpoint::{Endpoint, EndpointAddress, Endpoints},
+    filters::{prelude::*, FilterRegistry},
+    metadata::Value,
+    proxy::{Builder, PendingValidation},
+};
 
 pub struct TestFilterFactory;
 
@@ -37,6 +41,17 @@ impl FilterFactory for TestFilterFactory {
 
     fn config_schema(&self) -> schemars::schema::RootSchema {
         schemars::schema_for_value!(serde_json::Value::Null)
+    }
+
+    fn encode_config_to_protobuf(
+        &self,
+        _config: serde_json::Value,
+    ) -> Result<prost_types::Any, Error> {
+        Ok(<_>::default())
+    }
+
+    fn encode_config_to_json(&self, _config: prost_types::Any) -> Result<serde_json::Value, Error> {
+        Ok(serde_json::Value::Null)
     }
 
     fn create_filter(&self, _: CreateFilterArgs) -> Result<FilterInstance, Error> {

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -226,7 +226,7 @@ mod tests {
         type Configuration = Append;
         type BinaryConfiguration = ProtoAppend;
 
-        fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
             let config = Self::ensure_config_exists(config)?;
 
             if config.value.as_ref().unwrap() == "reject" {

--- a/src/xds/listener.rs
+++ b/src/xds/listener.rs
@@ -159,35 +159,35 @@ impl ListenerManager {
 
 #[cfg(test)]
 mod tests {
-    use super::ListenerManager;
-    use crate::filters::prelude::*;
-    use crate::xds::{
-        config::listener::v3::{
-            filter::ConfigType, Filter as LdsFilter, FilterChain as LdsFilterChain, Listener,
-        },
-        service::discovery::v3::{DiscoveryRequest, DiscoveryResponse},
-    };
-
     use std::time::Duration;
 
-    use crate::endpoint::{Endpoint, Endpoints, UpstreamEndpoints};
-    use crate::filters::{
-        ConvertProtoConfigError, DynFilterFactory, FilterRegistry, SharedFilterChain,
-    };
-    use crate::xds::LISTENER_TYPE;
-    use prost::Message;
     use serde::{Deserialize, Serialize};
-    use std::convert::TryFrom;
-    use tokio::sync::mpsc;
     use tokio::time;
+
+    use super::*;
+    use crate::{
+        endpoint::{Endpoint, Endpoints, UpstreamEndpoints},
+        filters::prelude::*,
+        xds::config::listener::v3::{
+            filter::ConfigType, Filter as LdsFilter, FilterChain as LdsFilterChain,
+        },
+    };
 
     // A simple filter that will be used in the following tests.
     // It appends a string to each payload.
     const APPEND_TYPE_URL: &str = "filter.append";
+
     #[derive(Clone, PartialEq, Serialize, Deserialize, schemars::JsonSchema)]
     pub struct Append {
         pub value: Option<prost::alloc::string::String>,
     }
+
+    impl Append {
+        fn load() {
+            FilterRegistry::register([Self::factory()])
+        }
+    }
+
     #[derive(Clone, PartialEq, prost::Message)]
     pub struct ProtoAppend {
         #[prost(message, optional, tag = "1")]
@@ -221,38 +221,22 @@ mod tests {
         }
     }
 
-    fn load_append_filter() {
-        FilterRegistry::register([DynFilterFactory::from(Box::from(AppendFactory))])
-    }
+    impl StaticFilter for Append {
+        const NAME: &'static str = APPEND_TYPE_URL;
+        type Configuration = Append;
+        type BinaryConfiguration = ProtoAppend;
 
-    struct AppendFactory;
+        fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
+            let config = Self::ensure_config_exists(config)?;
 
-    impl FilterFactory for AppendFactory {
-        fn name(&self) -> &'static str {
-            APPEND_TYPE_URL
-        }
-
-        fn config_schema(&self) -> schemars::schema::RootSchema {
-            schemars::schema_for!(Append)
-        }
-
-        fn create_filter(&self, args: CreateFilterArgs) -> Result<FilterInstance, Error> {
-            let (config_json, filter) = args
-                .config
-                .map(|config| config.deserialize::<Append, ProtoAppend>(self.name()))
-                .transpose()?
-                .unwrap();
-            if filter.value.as_ref().unwrap() == "reject" {
-                Err(Error::FieldInvalid {
+            if config.value.as_ref().unwrap() == "reject" {
+                return Err(Error::FieldInvalid {
                     field: "value".into(),
                     reason: "reject requested".into(),
-                })
-            } else {
-                Ok(FilterInstance::new(
-                    config_json,
-                    Box::new(filter) as Box<dyn Filter>,
-                ))
+                });
             }
+
+            Ok(config)
         }
     }
 
@@ -262,7 +246,7 @@ mod tests {
         // LDS filters and it can build up a filter chain from it.
 
         // Prepare a filter registry with the filter factories we need for the test.
-        load_append_filter();
+        Append::load();
         let filter_chain = SharedFilterChain::empty();
         let (discovery_req_tx, mut discovery_req_rx) = mpsc::channel(10);
         let mut manager = ListenerManager::new(filter_chain.clone(), discovery_req_tx);
@@ -353,7 +337,7 @@ mod tests {
         // contains no filter chain.
 
         // Prepare a filter registry with the filter factories we need for the test.
-        load_append_filter();
+        Append::load();
         let filter_chain = SharedFilterChain::empty();
         let (discovery_req_tx, mut discovery_req_rx) = mpsc::channel(10);
         let mut manager = ListenerManager::new(filter_chain.clone(), discovery_req_tx);
@@ -446,7 +430,7 @@ mod tests {
     async fn listener_manager_reject_updates() {
         // Test that the manager returns NACK DiscoveryRequests for updates it failed to process.
 
-        load_append_filter();
+        Append::load();
         let filter_chain = SharedFilterChain::empty();
         let (discovery_req_tx, mut discovery_req_rx) = mpsc::channel(10);
         let mut manager = ListenerManager::new(filter_chain.clone(), discovery_req_tx);
@@ -602,17 +586,11 @@ mod tests {
         );
     }
 
-    #[allow(deprecated)]
     fn create_lds_filter_chain(filters: Vec<LdsFilter>) -> LdsFilterChain {
         LdsFilterChain {
-            filter_chain_match: None,
             filters,
-            use_proxy_proto: None,
-            metadata: None,
-            transport_socket: None,
-            transport_socket_connect_timeout: None,
             name: "test-lds-filter-chain".into(),
-            on_demand_configuration: None,
+            ..<_>::default()
         }
     }
 

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -21,7 +21,7 @@ use tokio::time::{timeout, Duration};
 use quilkin::{
     config::{Builder, Filter},
     endpoint::Endpoint,
-    filters::{capture, token_router},
+    filters::{Capture, StaticFilter, TokenRouter},
     metadata::MetadataView,
     test_utils::TestHelper,
 };
@@ -48,11 +48,11 @@ quilkin.dev:
         .with_static(
             vec![
                 Filter {
-                    name: capture::factory().name().into(),
+                    name: Capture::factory().name().into(),
                     config: serde_yaml::from_str(capture_yaml).unwrap(),
                 },
                 Filter {
-                    name: token_router::factory().name().into(),
+                    name: TokenRouter::factory().name().into(),
                     config: None,
                 },
             ],

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -21,7 +21,7 @@ use tokio::time::{timeout, Duration};
 use quilkin::{
     config::{Builder, Filter},
     endpoint::Endpoint,
-    filters::compress,
+    filters::{Compress, StaticFilter},
     test_utils::TestHelper,
 };
 
@@ -40,7 +40,7 @@ on_write: COMPRESS
         .with_port(server_port)
         .with_static(
             vec![Filter {
-                name: compress::factory().name().into(),
+                name: Compress::factory().name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             vec![Endpoint::new(echo)],
@@ -59,7 +59,7 @@ on_write: DECOMPRESS
         .with_port(client_port)
         .with_static(
             vec![Filter {
-                name: compress::factory().name().into(),
+                name: Compress::factory().name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             vec![Endpoint::new((Ipv4Addr::LOCALHOST, server_port).into())],

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -21,7 +21,7 @@ use tokio::time::{timeout, Duration};
 use quilkin::{
     config::{Builder, Filter},
     endpoint::Endpoint,
-    filters::concatenate_bytes,
+    filters::{ConcatenateBytes, StaticFilter},
     test_utils::TestHelper,
 };
 
@@ -39,7 +39,7 @@ bytes: YWJj #abc
         .with_port(server_port)
         .with_static(
             vec![Filter {
-                name: concatenate_bytes::factory().name().into(),
+                name: ConcatenateBytes::factory().name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             vec![Endpoint::new(echo)],

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -22,7 +22,7 @@ use tokio::time::{timeout, Duration};
 use quilkin::{
     config::{Builder, Filter},
     endpoint::Endpoint,
-    filters::{compress, concatenate_bytes},
+    filters::{Compress, ConcatenateBytes, StaticFilter},
     test_utils::TestHelper,
 };
 
@@ -60,15 +60,15 @@ on_write: DECOMPRESS
         .with_static(
             vec![
                 Filter {
-                    name: concatenate_bytes::factory().name().into(),
+                    name: ConcatenateBytes::factory().name().into(),
                     config: serde_yaml::from_str(yaml_concat_read).unwrap(),
                 },
                 Filter {
-                    name: concatenate_bytes::factory().name().into(),
+                    name: ConcatenateBytes::factory().name().into(),
                     config: serde_yaml::from_str(yaml_concat_write).unwrap(),
                 },
                 Filter {
-                    name: compress::factory().name().into(),
+                    name: Compress::factory().name().into(),
                     config: serde_yaml::from_str(yaml_compress).unwrap(),
                 },
             ],

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -22,7 +22,7 @@ use std::{
 use quilkin::{
     config::{Builder as ConfigBuilder, Filter},
     endpoint::Endpoint,
-    filters::debug,
+    filters::{Debug, StaticFilter},
     test_utils::{load_test_filters, TestHelper},
     Builder as ProxyBuilder,
 };
@@ -100,7 +100,7 @@ async fn debug_filter() {
     let mut t = TestHelper::default();
 
     // handy for grabbing the configuration name
-    let factory = debug::factory();
+    let factory = Debug::factory();
 
     // create an echo server as an endpoint.
     let echo = t.run_echo_server().await;

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-use quilkin::config::{Builder, Filter};
-use quilkin::endpoint::Endpoint;
-use quilkin::filters::firewall;
-use quilkin::test_utils::TestHelper;
+use quilkin::{
+    config::{Builder, Filter},
+    endpoint::Endpoint,
+    filters::{Firewall, StaticFilter},
+    test_utils::TestHelper,
+};
 use std::net::SocketAddr;
 use tokio::sync::oneshot::Receiver;
 use tokio::time::{timeout, Duration};
@@ -104,7 +106,7 @@ async fn test(t: &mut TestHelper, server_port: u16, yaml: &str) -> Receiver<Stri
         .with_port(server_port)
         .with_static(
             vec![Filter {
-                name: firewall::factory().name().into(),
+                name: Firewall::factory().name().into(),
                 config: serde_yaml::from_str(yaml.as_str()).unwrap(),
             }],
             vec![Endpoint::new(echo)],

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -20,7 +20,7 @@ use std::sync::{Arc, Mutex};
 use quilkin::{
     config::{Builder as ConfigBuilder, Filter},
     endpoint::Endpoint,
-    filters::load_balancer,
+    filters::{LoadBalancer, StaticFilter},
     test_utils::TestHelper,
 };
 
@@ -49,7 +49,7 @@ policy: ROUND_ROBIN
         .with_port(server_port)
         .with_static(
             vec![Filter {
-                name: load_balancer::factory().name().into(),
+                name: LoadBalancer::factory().name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             echo_addresses

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -21,7 +21,7 @@ use tokio::time::{timeout, Duration};
 use quilkin::{
     config::{Builder as ConfigBuilder, Filter},
     endpoint::Endpoint,
-    filters::local_rate_limit,
+    filters::{LocalRateLimit, StaticFilter},
     test_utils::TestHelper,
 };
 
@@ -40,7 +40,7 @@ period: 1
         .with_port(server_port)
         .with_static(
             vec![Filter {
-                name: local_rate_limit::factory().name().into(),
+                name: LocalRateLimit::factory().name().into(),
                 config: serde_yaml::from_str(yaml).unwrap(),
             }],
             vec![Endpoint::new(echo)],

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -21,7 +21,7 @@ use tokio::time::{timeout, Duration};
 use quilkin::{
     config::{Builder, Filter},
     endpoint::Endpoint,
-    filters::{capture, r#match},
+    filters::{Capture, Match, StaticFilter},
     test_utils::TestHelper,
 };
 
@@ -62,11 +62,11 @@ on_read:
         .with_static(
             vec![
                 Filter {
-                    name: capture::NAME.into(),
+                    name: Capture::NAME.into(),
                     config: serde_yaml::from_str(capture_yaml).unwrap(),
                 },
                 Filter {
-                    name: r#match::NAME.into(),
+                    name: Match::NAME.into(),
                     config: serde_yaml::from_str(matches_yaml).unwrap(),
                 },
             ],

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -21,7 +21,7 @@ use tokio::time::{timeout, Duration};
 use quilkin::{
     config::{Builder, Filter},
     endpoint::Endpoint,
-    filters::{capture, token_router},
+    filters::{Capture, StaticFilter, TokenRouter},
     metadata::MetadataView,
     test_utils::TestHelper,
 };
@@ -49,11 +49,11 @@ quilkin.dev:
         .with_static(
             vec![
                 Filter {
-                    name: capture::factory().name().into(),
+                    name: Capture::factory().name().into(),
                     config: serde_yaml::from_str(capture_yaml).unwrap(),
                 },
                 Filter {
-                    name: token_router::factory().name().into(),
+                    name: TokenRouter::factory().name().into(),
                     config: None,
                 },
             ],


### PR DESCRIPTION
This PR is borne out of initially an effort to pull the `yaml_to_protobuf` changes to `FilterFactory` from #506 into a separate PR, and also add a `protobuf_to_yaml` method. However adding another new method was pretty tedious, and when thinking more holistically about the problem of converting configuration back and forth from YAML and Protobuf, I realised that we needed a more generic solution that would allow us to statically only define the types and have the same dynamic behaviour.

This thought process led me to this PR which adds a new `StaticFilter` trait which does exactly that. Now if you're writing a filter in Rust you no longer have to define a `FilterFactory` to construct it, you only implement `StaticFilter` and `Filter`, and then Quilkin will automatically *at compile-time* generate a virtual table safe version of `StaticFilter` (still called `FilterFactory` for the sake of not changing everything all at once).

This new trait design effectively eliminates all boilerplate needed when defining your own filter. For example; this is entire definition for the `Compress` as a filter (excluding the actual `Filter` impl). As shown, nearly everything is defined statically with types and constants, the only behaviour needed to be implemented is converting from an `Option<Self::Configuration>` into a `Self`.

```rust
impl StaticFilter for Compress {
    const NAME: &'static str = "quilkin.filters.compress.v1alpha1.Compress";
    type Configuration = Config;
    type BinaryConfiguration = proto::Compress;

    fn new(config: Option<Self::Configuration>) -> Result<Self, Error> {
        Ok(Compress::new(
            Self::ensure_config_exists(config)?,
            Metrics::new()?,
        ))
    }
}
```

It's hard to understate how much this single abstraction saves in terms of time and effort. The seperation provides two key things, the most obvious of which is mostly type-based API that is verified at compile-time for getting access to a filter and its configuration. The second benefit is that having a seperate trait allows us to split the dynamic dispatch `FilterFactory` functionality, this means that changes to `FilterFactory` have no affect on `StaticFilter` definitions. This is how this PR is able to add two safely add new `FilterFactory` methods which allow you to dynamically transcode the configuration format, and for it to still be net negative in terms of code added.

### Breaking Changes
- Filter modules no longer expose their name through a module level constant, instead preferring `StaticFilter::NAME`.
- Filter modules no longer expose a `factory` free function, use `StaticFilter::factory` to achieve the same effect.