### PR TITLE
Use htmltest binary not build from source

### DIFF
--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -29,19 +29,10 @@ RUN set -eux && \
     apt-get install -y jq wget zip build-essential libssl-dev pkg-config python3-pip && \
     pip3 install live-server
 
-# Install Go
-WORKDIR /usr/local
-ENV GO_VERSION=1.17.2
-RUN wget -q https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz && \
-    tar -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz
-ENV PATH /usr/local/go/bin:$PATH
-
 # Install htmltest
 WORKDIR /tmp
-# TODO (markmandel): replace with official release once a 0.16.0 release is created.
-RUN git clone --depth=5 https://github.com/wjdp/htmltest.git && \
-    cd htmltest && ./build.sh && cp ./bin/htmltest /usr/local/bin/ && \
-    rm -r /tmp/htmltest
+RUN wget -O htmltest.tar.gz https://github.com/wjdp/htmltest/releases/download/v0.16.0/htmltest_0.16.0_linux_amd64.tar.gz && \
+     tar -xf htmltest.tar.gz && mv ./htmltest /usr/local/bin/ && rm htmltest.tar.gz
 
 # Install Rust
 RUN wget https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

We just got a new release of htmltest, so we no longer need to build the binary from source.  Shrinks the time to build the build image by quite a bit, as we don't have as much work to do.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A