### PR TITLE
Replace serde_yaml with serde_json internally

### DIFF
--- a/src/cluster/shared.rs
+++ b/src/cluster/shared.rs
@@ -100,7 +100,9 @@ mod tests {
     async fn dynamic_cluster_manager_process_cluster_update() {
         let shared_cluster = SharedCluster::empty().unwrap();
 
-        fn mapping(entries: &[(&str, &str)]) -> serde_yaml::Mapping {
+        fn mapping(
+            entries: &[(&str, &str)],
+        ) -> serde_json::Map<std::string::String, serde_json::Value> {
             entries
                 .iter()
                 .map(|(k, v)| ((*k).into(), (*v).into()))

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,13 +161,11 @@ impl Source {
 #[serde(deny_unknown_fields)]
 pub struct Filter {
     pub name: String,
-    pub config: Option<serde_yaml::Value>,
+    pub config: Option<serde_json::Value>,
 }
 
 #[cfg(test)]
 mod tests {
-    use serde_yaml::Value;
-
     use super::*;
 
     use crate::endpoint::Metadata;
@@ -262,17 +260,13 @@ static:
 
         let filter = config.source.get_static_filters().unwrap().get(0).unwrap();
         assert_eq!("quilkin.core.v1.rate-limiter", filter.name);
-        let config = filter.config.as_ref().unwrap();
-        let filter_config = config.as_mapping().unwrap();
-
-        let key = Value::from("map");
+        let filter_config = filter.config.as_ref().unwrap();
         assert_eq!(
             "of arbitrary key value pairs",
-            filter_config.get(&key).unwrap().as_str().unwrap()
+            filter_config.get("map").unwrap()
         );
 
-        let key = Value::from("could");
-        let could = filter_config.get(&key).unwrap().as_sequence().unwrap();
+        let could = filter_config.get("could").unwrap().as_array().unwrap();
         assert_eq!("also", could.get(0).unwrap().as_str().unwrap());
         assert_eq!("be", could.get(1).unwrap().as_str().unwrap());
         assert_eq!(27, could.get(2).unwrap().as_i64().unwrap());

--- a/src/config/config_type.rs
+++ b/src/config/config_type.rs
@@ -26,7 +26,7 @@ use crate::filters::{ConvertProtoConfigError, Error};
 pub enum ConfigType {
     /// Static configuration from YAML.
     #[schemars(with = "serde_json::Value")]
-    Static(serde_yaml::Value),
+    Static(serde_json::Value),
     /// Dynamic configuration from Protobuf.
     #[schemars(skip)]
     Dynamic(prost_types::Any),
@@ -102,7 +102,7 @@ impl<'de> serde::Deserialize<'de> for ConfigType {
     where
         D: serde::Deserializer<'de>,
     {
-        serde_yaml::Value::deserialize(de).map(ConfigType::Static)
+        serde_json::Value::deserialize(de).map(ConfigType::Static)
     }
 }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -27,7 +27,7 @@ pub use address::EndpointAddress;
 type EndpointMetadata = crate::metadata::MetadataView<Metadata>;
 
 /// A destination endpoint with any associated metadata.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, PartialOrd, Eq)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct Endpoint {

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -141,7 +141,7 @@ mod tests {
         let config = serde_json::json!({
             "metadataKey": TOKEN_KEY.to_string(),
             "suffix": {
-                "size": 3 as i64,
+                "size": 3_i64,
                 "remove": true,
             }
         });
@@ -159,7 +159,7 @@ mod tests {
 
         let config = serde_json::json!({
             "suffix": {
-                "size": 3 as i64,
+                "size": 3_i64,
             }
         });
 

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -116,8 +116,6 @@ impl FilterFactory for CaptureFactory {
 mod tests {
     use std::sync::Arc;
 
-    use serde_yaml::{Mapping, Value as YamlValue};
-
     use crate::{
         endpoint::{Endpoint, Endpoints},
         filters::metadata::CAPTURED_BYTES,
@@ -139,25 +137,17 @@ mod tests {
     #[test]
     fn factory_valid_config_all() {
         let factory = CaptureFactory::new();
-        let mut map = Mapping::new();
-        map.insert(
-            YamlValue::String("metadataKey".into()),
-            YamlValue::String(TOKEN_KEY.into()),
-        );
-        map.insert(
-            YamlValue::String("suffix".into()),
-            YamlValue::Mapping({
-                let mut map = Mapping::new();
 
-                map.insert("size".into(), YamlValue::Number(3.into()));
-                map.insert("remove".into(), YamlValue::Bool(true));
-
-                map
-            }),
-        );
+        let config = serde_json::json!({
+            "metadataKey": TOKEN_KEY.to_string(),
+            "suffix": {
+                "size": 3 as i64,
+                "remove": true,
+            }
+        });
 
         let filter = factory
-            .create_filter(CreateFilterArgs::fixed(Some(YamlValue::Mapping(map))))
+            .create_filter(CreateFilterArgs::fixed(Some(config)))
             .unwrap()
             .filter;
         assert_end_strategy(filter.as_ref(), TOKEN_KEY, true);
@@ -166,18 +156,15 @@ mod tests {
     #[test]
     fn factory_valid_config_defaults() {
         let factory = CaptureFactory::new();
-        let mut map = Mapping::new();
-        map.insert("suffix".into(), {
-            let mut map = Mapping::new();
-            map.insert(
-                YamlValue::String("size".into()),
-                YamlValue::Number(3.into()),
-            );
-            map.into()
+
+        let config = serde_json::json!({
+            "suffix": {
+                "size": 3 as i64,
+            }
         });
 
         let filter = factory
-            .create_filter(CreateFilterArgs::fixed(Some(YamlValue::Mapping(map))))
+            .create_filter(CreateFilterArgs::fixed(Some(config)))
             .unwrap()
             .filter;
         assert_end_strategy(filter.as_ref(), CAPTURED_BYTES, false);
@@ -186,13 +173,12 @@ mod tests {
     #[test]
     fn factory_invalid_config() {
         let factory = CaptureFactory::new();
-        let mut map = Mapping::new();
-        map.insert(
-            YamlValue::String("size".into()),
-            YamlValue::String("WRONG".into()),
-        );
-
-        let result = factory.create_filter(CreateFilterArgs::fixed(Some(YamlValue::Mapping(map))));
+        let config = serde_json::json!({
+            "suffix": {
+                "size": "WRONG",
+            }
+        });
+        let result = factory.create_filter(CreateFilterArgs::fixed(Some(config)));
         assert!(result.is_err(), "Should be an error");
     }
 

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -177,8 +177,6 @@ impl FilterFactory for CompressFactory {
 #[cfg(test)]
 mod tests {
     use std::convert::TryFrom;
-
-    use serde_yaml::{Mapping, Value};
     use tracing_test::traced_test;
 
     use crate::endpoint::{Endpoint, Endpoints, UpstreamEndpoints};
@@ -278,17 +276,13 @@ mod tests {
     #[test]
     fn default_mode_factory() {
         let factory = CompressFactory::new();
-        let mut map = Mapping::new();
-        map.insert(
-            Value::String("on_read".into()),
-            Value::String("DECOMPRESS".into()),
-        );
-        map.insert(
-            Value::String("on_write".into()),
-            Value::String("COMPRESS".into()),
-        );
+        let config = serde_json::json!({
+            "on_read": "DECOMPRESS".to_string(),
+            "on_write": "COMPRESS".to_string(),
+
+        });
         let filter = factory
-            .create_filter(CreateFilterArgs::fixed(Some(Value::Mapping(map))))
+            .create_filter(CreateFilterArgs::fixed(Some(config)))
             .expect("should create a filter")
             .filter;
         assert_downstream(filter.as_ref());
@@ -297,17 +291,13 @@ mod tests {
     #[test]
     fn config_factory() {
         let factory = CompressFactory::new();
-        let mut map = Mapping::new();
-        map.insert(Value::String("mode".into()), Value::String("SNAPPY".into()));
-        map.insert(
-            Value::String("on_read".into()),
-            Value::String("DECOMPRESS".into()),
-        );
-        map.insert(
-            Value::String("on_write".into()),
-            Value::String("COMPRESS".into()),
-        );
-        let config = Value::Mapping(map);
+
+        let config = serde_json::json!({
+            "mode": "SNAPPY".to_string(),
+            "on_read": "DECOMPRESS".to_string(),
+            "on_write": "COMPRESS".to_string(),
+
+        });
         let args = CreateFilterArgs::fixed(Some(config));
 
         let filter = factory

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -127,8 +127,6 @@ impl TryFrom<proto::Debug> for Config {
 #[cfg(test)]
 mod tests {
     use crate::test_utils::{assert_filter_read_no_change, assert_write_no_change};
-    use serde_yaml::Mapping;
-    use serde_yaml::Value;
     use tracing_test::traced_test;
 
     use super::*;
@@ -152,34 +150,37 @@ mod tests {
 
     #[test]
     fn from_config_with_id() {
-        let mut map = Mapping::new();
         let factory = DebugFactory::new();
+        let config = serde_json::json!({
+            "id": "name".to_string(),
+        });
 
-        map.insert(Value::from("id"), Value::from("name"));
         assert!(factory
-            .create_filter(CreateFilterArgs::fixed(Some(Value::Mapping(map)),))
+            .create_filter(CreateFilterArgs::fixed(Some(config)))
             .is_ok());
     }
 
     #[test]
     fn from_config_without_id() {
-        let mut map = Mapping::new();
         let factory = DebugFactory::new();
+        let config = serde_json::json!({
+            "id": "name",
+        });
 
-        map.insert(Value::from("id"), Value::from("name"));
         assert!(factory
-            .create_filter(CreateFilterArgs::fixed(Some(Value::Mapping(map)),))
+            .create_filter(CreateFilterArgs::fixed(Some(config)))
             .is_ok());
     }
 
     #[test]
     fn from_config_should_error() {
-        let mut map = Mapping::new();
         let factory = DebugFactory::new();
 
-        map.insert(Value::from("id"), Value::Sequence(vec![]));
+        let config = serde_json::json!({
+            "id": {},
+        });
         assert!(factory
-            .create_filter(CreateFilterArgs::fixed(Some(Value::Mapping(map))))
+            .create_filter(CreateFilterArgs::fixed(Some(config)))
             .is_err());
     }
 }

--- a/src/filters/factory.rs
+++ b/src/filters/factory.rs
@@ -84,7 +84,7 @@ impl CreateFilterArgs {
 
     /// Creates a new instance of [`CreateFilterArgs`] using a
     /// fixed [`ConfigType`].
-    pub fn fixed(config: Option<serde_yaml::Value>) -> CreateFilterArgs {
+    pub fn fixed(config: Option<serde_json::Value>) -> CreateFilterArgs {
         Self::new(config.map(ConfigType::Static))
     }
 

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -191,8 +191,6 @@ mod tests {
     use std::ops::Deref;
     use std::sync::Arc;
 
-    use serde_yaml::Mapping;
-
     use crate::endpoint::{Endpoint, Endpoints, Metadata};
     use crate::metadata::Value;
     use crate::test_utils::assert_write_no_change;
@@ -245,16 +243,12 @@ mod tests {
     #[test]
     fn factory_custom_tokens() {
         let factory = TokenRouterFactory::new();
-        let mut map = Mapping::new();
-        map.insert(
-            serde_yaml::Value::String("metadataKey".into()),
-            serde_yaml::Value::String(TOKEN_KEY.into()),
-        );
+        let config = serde_json::json!({
+            "metadataKey": TOKEN_KEY.to_string(),
+        });
 
         let filter = factory
-            .create_filter(CreateFilterArgs::fixed(Some(serde_yaml::Value::Mapping(
-                map,
-            ))))
+            .create_filter(CreateFilterArgs::fixed(Some(config)))
             .unwrap()
             .filter;
         let mut ctx = new_ctx();
@@ -268,10 +262,10 @@ mod tests {
     #[test]
     fn factory_empty_config() {
         let factory = TokenRouterFactory::new();
-        let map = Mapping::new();
+        let map = serde_json::Map::new();
 
         let filter = factory
-            .create_filter(CreateFilterArgs::fixed(Some(serde_yaml::Value::Mapping(
+            .create_filter(CreateFilterArgs::fixed(Some(serde_json::Value::Object(
                 map,
             ))))
             .unwrap()

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -173,9 +173,7 @@ impl TryFrom<prost_types::Value> for Value {
 /// Represents a view into the metadata object attached to another object. `T`
 /// represents metadata known to Quilkin under `quilkin.dev` (available under
 /// the [`KEY`] constant.)
-#[derive(
-    Default, Debug, serde::Deserialize, serde::Serialize, PartialEq, Clone, PartialOrd, Eq,
-)]
+#[derive(Default, Debug, serde::Deserialize, serde::Serialize, PartialEq, Clone, Eq)]
 #[non_exhaustive]
 pub struct MetadataView<T> {
     /// Known Quilkin metadata.
@@ -183,11 +181,14 @@ pub struct MetadataView<T> {
     pub known: T,
     /// User created metadata.
     #[serde(flatten)]
-    pub unknown: serde_yaml::Mapping,
+    pub unknown: serde_json::Map<String, serde_json::Value>,
 }
 
 impl<T> MetadataView<T> {
-    pub fn with_unknown(known: impl Into<T>, unknown: serde_yaml::Mapping) -> Self {
+    pub fn with_unknown(
+        known: impl Into<T>,
+        unknown: serde_json::Map<String, serde_json::Value>,
+    ) -> Self {
         Self {
             known: known.into(),
             unknown,
@@ -214,10 +215,12 @@ impl<T: Into<prost_types::Struct>> From<MetadataView<T>> for ProtoMetadata {
     fn from(metadata: MetadataView<T>) -> Self {
         let mut filter_metadata = HashMap::new();
         filter_metadata.insert(String::from("quilkin.dev"), metadata.known.into());
-        filter_metadata.extend(metadata.unknown.into_iter().filter_map(|(k, v)| {
-            k.as_str()
-                .and_then(|k| crate::prost::struct_from_yaml(v).map(|v| (k.into(), v)))
-        }));
+        filter_metadata.extend(
+            metadata
+                .unknown
+                .into_iter()
+                .filter_map(|(k, v)| crate::prost::struct_from_json(v).map(|v| (k, v))),
+        );
 
         Self {
             filter_metadata,

--- a/src/xds/cluster.rs
+++ b/src/xds/cluster.rs
@@ -782,7 +782,7 @@ mod tests {
 
         assert_eq!(dyn_metadata.len(), 1);
 
-        let value = dyn_metadata.get("key-a".into()).unwrap();
+        let value = dyn_metadata.get("key-a").unwrap();
         assert_eq!(
             value,
             &serde_json::Value::Object([("one".into(), "two".into())].into_iter().collect())

--- a/src/xds/cluster.rs
+++ b/src/xds/cluster.rs
@@ -782,14 +782,10 @@ mod tests {
 
         assert_eq!(dyn_metadata.len(), 1);
 
-        let value = dyn_metadata.get(&String::from("key-a").into()).unwrap();
+        let value = dyn_metadata.get("key-a".into()).unwrap();
         assert_eq!(
             value,
-            &serde_yaml::Value::from(
-                [("one".into(), "two".into())]
-                    .into_iter()
-                    .collect::<serde_yaml::Mapping>()
-            )
+            &serde_json::Value::Object([("one".into(), "two".into())].into_iter().collect())
         );
     }
 

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -19,8 +19,6 @@ use std::{
     sync::Arc,
 };
 
-use serde_yaml::{Mapping, Value};
-
 use quilkin::{
     config::{Builder as ConfigBuilder, Filter},
     endpoint::Endpoint,
@@ -108,8 +106,9 @@ async fn debug_filter() {
     let echo = t.run_echo_server().await;
 
     // filter config
-    let mut map = Mapping::new();
-    map.insert(Value::from("id"), Value::from("server"));
+    let config = serde_json::json!({
+    "id":  "server",
+    });
     // create server configuration
     let server_port = 12247;
     let server_config = ConfigBuilder::empty()
@@ -117,15 +116,17 @@ async fn debug_filter() {
         .with_static(
             vec![Filter {
                 name: factory.name().into(),
-                config: Some(serde_yaml::Value::Mapping(map)),
+                config: Some(config),
             }],
             vec![Endpoint::new(echo)],
         )
         .build();
     t.run_server_with_config(server_config);
 
-    let mut map = Mapping::new();
-    map.insert(Value::from("id"), Value::from("client"));
+    let config = serde_json::json!({
+    "id":  "client",
+    });
+
     // create a local client
     let client_port = 12248;
     let client_config = ConfigBuilder::empty()
@@ -133,7 +134,7 @@ async fn debug_filter() {
         .with_static(
             vec![Filter {
                 name: factory.name().into(),
-                config: Some(serde_yaml::Value::Mapping(map)),
+                config: Some(config),
             }],
             vec![Endpoint::new(
                 SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port).into(),


### PR DESCRIPTION
We replaced `serde_yaml` with `serde_json` to simplify writing tests and conversion to protobuf 


**Which issue(s) this PR fixes**:
https://github.com/googleforgames/quilkin/issues/507
