### PR TITLE
Port Reuse: Would love some help - unit tests only pass most of the time.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = "1.0.79"
 serde_regex = "1.1.0"
 serde_yaml = "0.8.21"
+socket2 = "0.4.4"
 snap = "1.0.5"
 stable-eyre = "0.2.2"
 thiserror = "1.0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ socket2 = "0.4.4"
 snap = "1.0.5"
 stable-eyre = "0.2.2"
 thiserror = "1.0.30"
-tokio = { version = "1.17", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
+tokio = { version = "1.18.2", features = ["rt-multi-thread", "signal", "test-util", "parking_lot"] }
 tokio-stream = "0.1.8"
 tonic = "0.6.1"
 tracing = {version = "0.1.31" }

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -442,6 +442,7 @@ mod tests {
         time::{timeout, Duration},
     };
 
+    use crate::test_utils::create_socket;
     use crate::{
         cluster::SharedCluster,
         config,
@@ -590,7 +591,7 @@ mod tests {
     async fn spawn_downstream_receive_workers() {
         let t = TestHelper::default();
 
-        let socket = t.create_socket().await;
+        let socket = create_socket().await;
         let addr = socket.local_addr().unwrap();
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
         let mut endpoint = t.open_socket_and_recv_single_packet().await;
@@ -618,7 +619,7 @@ mod tests {
 
         Server::spawn_downstream_receive_workers(vec![config]);
 
-        let socket = t.create_socket().await;
+        let socket = create_socket().await;
         socket.send_to(msg.as_bytes(), &addr).await.unwrap();
         timeout(Duration::from_secs(1), endpoint.packet_rx.changed())
             .await
@@ -657,7 +658,7 @@ mod tests {
             .await
             .unwrap();
 
-        let socket = t.create_socket().await;
+        let socket = create_socket().await;
         socket.send_to(msg.as_bytes(), &local_addr).await.unwrap();
 
         timeout(Duration::from_secs(1), endpoint.packet_rx.changed())

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-pub(super) mod metrics;
-
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 
 use prometheus::HistogramTimer;
 use tokio::net::UdpSocket;
 use tokio::sync::{mpsc, watch};
-use tokio::task::JoinHandle;
 use tokio::time::Duration;
 
 use metrics::Metrics as ProxyMetrics;
 
+use crate::utils::net;
 use crate::{
     cluster::SharedCluster,
     config::Config,
@@ -42,6 +40,8 @@ use crate::{
     utils::debug,
     Result,
 };
+
+pub(super) mod metrics;
 
 /// Server is the UDP server main implementation
 pub struct Server {
@@ -65,7 +65,6 @@ impl TryFrom<Config> for Server {
 struct RunRecvFromArgs {
     cluster: SharedCluster,
     filter_chain: SharedFilterChain,
-    socket: Arc<UdpSocket>,
     session_manager: SessionManager,
     session_ttl: Duration,
     send_packets: mpsc::Sender<UpstreamPacket>,
@@ -85,8 +84,8 @@ struct DownstreamPacket {
 struct DownstreamReceiveWorkerConfig {
     /// ID of the worker.
     worker_id: usize,
-    /// Channel from which the worker picks up the downstream packets.
-    packet_rx: mpsc::Receiver<DownstreamPacket>,
+    /// Socket with reused port from which the worker receives packets.
+    socket: UdpSocket,
     /// Configuration required to process a received downstream packet.
     receive_config: ProcessDownstreamReceiveConfig,
     /// The worker task exits when a value is received from this shutdown channel.
@@ -120,7 +119,7 @@ impl Server {
             "Starting"
         );
 
-        let socket = Arc::new(Server::bind(self.config.proxy.port).await?);
+        let socket = Arc::new(self.bind().await?);
         let session_manager = SessionManager::new(shutdown_rx.clone());
         let (send_packets, receive_packets) = mpsc::channel::<UpstreamPacket>(1024);
 
@@ -134,28 +133,21 @@ impl Server {
         }
 
         self.run_receive_packet(socket.clone(), receive_packets);
-        let recv_loop = self.run_recv_from(RunRecvFromArgs {
+        self.run_recv_from(RunRecvFromArgs {
             cluster,
             filter_chain,
-            socket,
             session_manager,
             session_ttl,
             send_packets,
             shutdown_rx: shutdown_rx.clone(),
-        });
+        })
+        .await?;
+        tracing::info!("Quilkin is ready");
 
-        tracing::info!("Quilkin is ready.");
-
-        tokio::select! {
-            join_result = recv_loop => {
-                join_result
-                    .map_err(|error| eyre::eyre!(error))
-                    .and_then(|inner| inner)
-            }
-            _ = shutdown_rx.changed() => {
-                Ok(())
-            }
-        }
+        shutdown_rx
+            .changed()
+            .await
+            .map_err(|error| eyre::eyre!(error))
     }
 
     fn create_resource_managers(
@@ -187,7 +179,7 @@ impl Server {
     /// This function also spawns the set of worker tasks responsible for consuming packets
     /// off the aforementioned queue and processing them through the filter chain and session
     /// pipeline.
-    fn run_recv_from(&self, args: RunRecvFromArgs) -> JoinHandle<Result<()>> {
+    async fn run_recv_from(&self, args: RunRecvFromArgs) -> Result<()> {
         let session_manager = args.session_manager;
         let proxy_metrics = self.proxy_metrics.clone();
         let session_metrics = self.session_metrics.clone();
@@ -196,16 +188,14 @@ impl Server {
         // consume packets off.
         let num_workers = num_cpus::get();
 
-        // Contains channel Senders for each worker task.
-        let mut packet_txs = vec![];
+        // TOXO: is this config setup still necessary? Maybe?
         // Contains config for each worker task.
         let mut worker_configs = vec![];
         for worker_id in 0..num_workers {
-            let (packet_tx, packet_rx) = mpsc::channel(num_workers);
-            packet_txs.push(packet_tx);
+            let socket = self.bind().await?;
             worker_configs.push(DownstreamReceiveWorkerConfig {
                 worker_id,
-                packet_rx,
+                socket,
                 shutdown_rx: args.shutdown_rx.clone(),
                 receive_config: ProcessDownstreamReceiveConfig {
                     proxy_metrics: proxy_metrics.clone(),
@@ -222,51 +212,7 @@ impl Server {
         // Start the worker tasks that pick up received packets from their queue
         // and processes them.
         Self::spawn_downstream_receive_workers(worker_configs);
-
-        // Start the background task to receive downstream packets from the socket
-        // and place them onto the worker tasks' queue for processing.
-        let socket = args.socket;
-        tokio::spawn(async move {
-            // Index to round-robin over workers to process packets.
-            let mut next_worker = 0;
-            let num_workers = num_workers;
-
-            // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
-            // packet, which is the maximum value of 16 a bit integer.
-            let mut buf = vec![0; 1 << 16];
-            loop {
-                match socket.recv_from(&mut buf).await {
-                    Ok((size, recv_addr)) => {
-                        let timer = proxy_metrics.read_processing_time_seconds.start_timer();
-                        let packet_tx = &mut packet_txs[next_worker % num_workers];
-                        next_worker += 1;
-
-                        if packet_tx
-                            .send(DownstreamPacket {
-                                source: recv_addr.into(),
-                                contents: (&buf[..size]).to_vec(),
-                                timer,
-                            })
-                            .await
-                            .is_err()
-                        {
-                            // We cannot recover from this error since
-                            // it implies that the receiver has been dropped.
-                            let error = eyre::eyre!(
-                                "Failed to send received packet over channel to worker"
-                            );
-                            tracing::error!(%error);
-                            return Err(error);
-                        }
-                    }
-                    Err(error) => {
-                        let error = eyre::eyre!(error).wrap_err("Error processing receive socket");
-                        tracing::error!(%error);
-                        return Err(error);
-                    }
-                }
-            }
-        })
+        Ok(())
     }
 
     // For each worker config provided, spawn a background task that sits in a
@@ -275,27 +221,44 @@ impl Server {
     fn spawn_downstream_receive_workers(worker_configs: Vec<DownstreamReceiveWorkerConfig>) {
         for DownstreamReceiveWorkerConfig {
             worker_id,
-            mut packet_rx,
+            socket,
             mut shutdown_rx,
             receive_config,
         } in worker_configs
         {
             tokio::spawn(async move {
+                // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
+                // packet, which is the maximum value of 16 a bit integer.
+                let mut buf = vec![0; 1 << 16];
                 loop {
+                    tracing::debug!(
+                        id = worker_id,
+                        addr = ?socket.local_addr(),
+                        "Awaiting packet"
+                    );
                     tokio::select! {
-                      packet = packet_rx.recv() => {
-                        match packet {
-                          Some(packet) => Self::process_downstream_received_packet(packet, &receive_config).await,
-                          None => {
-                            tracing::debug!(id = worker_id, "work sender channel was closed.");
-                            return;
-                          }
+                        recv = socket.recv_from(&mut buf) => {
+                            let timer = receive_config.proxy_metrics.read_processing_time_seconds.start_timer();
+                            match recv {
+                                Ok((size, source)) => {
+                                    tracing::debug!(id = worker_id, size = size, source = %source, "Received packet");
+                                    let packet = DownstreamPacket {
+                                        source: source.into(),
+                                        contents: (&buf[..size]).to_vec(),
+                                        timer,
+                                    };
+                                    Self::process_downstream_received_packet(packet, &receive_config).await
+                                },
+                                Err(error) => {
+                                    tracing::error!(%error);
+                                    return;
+                                }
+                            }
                         }
-                      }
-                      _ = shutdown_rx.changed() => {
-                        tracing::debug!(id = worker_id, "received shutdown signal.");
-                        return;
-                      }
+                        _ = shutdown_rx.changed() => {
+                            tracing::debug!(id = worker_id, "Received shutdown signal");
+                            return;
+                        }
                     }
                 }
             });
@@ -462,24 +425,21 @@ impl Server {
         });
     }
 
-    /// bind binds the local configured port
-    async fn bind(port: u16) -> Result<UdpSocket> {
-        let addr = SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port);
-        UdpSocket::bind(addr)
-            .await
-            .map_err(|error| eyre::eyre!(error))
+    /// binds the local configured port with port and address reuse applied.
+    async fn bind(&self) -> Result<UdpSocket> {
+        let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, self.config.proxy.port);
+        net::socket_with_reuse(addr.into())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::net::Ipv4Addr;
 
     use prometheus::{Histogram, HistogramOpts};
     use tokio::{
         sync::mpsc,
-        time::{self, timeout, Duration},
+        time::{timeout, Duration},
     };
 
     use crate::{
@@ -487,8 +447,11 @@ mod tests {
         config,
         endpoint::Endpoint,
         filters::SharedFilterChain,
-        proxy::sessions::UpstreamPacket,
-        test_utils::{config_with_dummy_endpoint, load_test_filters, new_test_chain, TestHelper},
+        proxy::{
+            server::metrics::Metrics as ProxyMetrics, sessions::metrics::Metrics as SessionMetrics,
+            sessions::UpstreamPacket,
+        },
+        test_utils::{config_with_dummy_endpoint, get_local_addr, load_test_filters, TestHelper},
     };
 
     use super::*;
@@ -498,11 +461,11 @@ mod tests {
         let mut t = TestHelper::default();
 
         let endpoint1 = t.open_socket_and_recv_single_packet().await;
-        let endpoint2 = t.open_socket_and_recv_single_packet().await;
+        let mut endpoint2 = t.open_socket_and_recv_single_packet().await;
 
-        let local_addr = (Ipv4Addr::UNSPECIFIED, 12358);
+        let local_addr = get_local_addr();
         let config = Server::builder()
-            .port(local_addr.1)
+            .port(local_addr.port())
             .endpoints(vec![
                 Endpoint::new(endpoint1.socket.local_addr().unwrap().into()),
                 Endpoint::new(endpoint2.socket.local_addr().unwrap().into()),
@@ -512,22 +475,38 @@ mod tests {
         t.run_server_with_config(config);
 
         let msg = "hello";
-        endpoint1
-            .socket
-            .send_to(msg.as_bytes(), &local_addr)
+        tryhard::retry_fn(|| {
+            let mut rx = endpoint1.packet_rx.clone();
+
+            async move {
+                // Use a standard socket in test utils as we only want to bind sockets to unused ports.
+                let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).await.unwrap();
+                tracing::debug!(dest = %local_addr, source = %socket.local_addr().unwrap(), "Sending Packet");
+                socket.send_to(msg.as_bytes(), &local_addr).await.unwrap();
+                timeout(Duration::from_millis(100), rx.changed()).await
+            }
+        }).retries(10)
+        .fixed_backoff(Duration::from_secs(1))
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(msg, *endpoint1.packet_rx.borrow());
+        timeout(Duration::from_secs(1), endpoint2.packet_rx.changed())
             .await
+            .expect("should get a packet")
             .unwrap();
-        assert_eq!(msg, endpoint1.packet_rx.await.unwrap());
-        assert_eq!(msg, endpoint2.packet_rx.await.unwrap());
+        assert_eq!(msg, *endpoint2.packet_rx.borrow());
     }
 
     #[tokio::test]
     async fn run_client() {
+        // pretty_print();
         let mut t = TestHelper::default();
 
         let endpoint = t.open_socket_and_recv_single_packet().await;
 
-        let local_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 12357));
+        let local_addr = get_local_addr();
         let config = Server::builder()
             .port(local_addr.port())
             .endpoints(vec![Endpoint::new(
@@ -538,12 +517,29 @@ mod tests {
         t.run_server_with_config(config);
 
         let msg = "hello";
-        endpoint
-            .socket
-            .send_to(msg.as_bytes(), &local_addr)
-            .await
-            .unwrap();
-        assert_eq!(msg, endpoint.packet_rx.await.unwrap());
+        let mut i = 0;
+        tryhard::retry_fn(|| {
+            let mut rx = endpoint.packet_rx.clone();
+            if i > 0 {
+                println!("--- RETRYING --- {i}");
+            }
+            i += i;
+
+            async move {
+                // Use a standard socket in test utils as we only want to bind sockets to unused ports.
+                let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).await.unwrap();
+                tracing::debug!(dest = %local_addr, source = %socket.local_addr().unwrap(), "Sending Packet");
+                socket.send_to(msg.as_bytes(), &local_addr).await.unwrap();
+                timeout(Duration::from_millis(100), rx.changed()).await
+            }
+        })
+        .retries(10)
+        .fixed_backoff(Duration::from_secs(1))
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(msg, *endpoint.packet_rx.borrow());
     }
 
     #[tokio::test]
@@ -551,8 +547,8 @@ mod tests {
         let mut t = TestHelper::default();
 
         load_test_filters();
-        let endpoint = t.open_socket_and_recv_single_packet().await;
-        let local_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 12367);
+        let mut endpoint = t.open_socket_and_recv_single_packet().await;
+        let local_addr = get_local_addr();
         let config = Server::builder()
             .port(local_addr.port())
             .filters(vec![config::Filter {
@@ -575,162 +571,54 @@ mod tests {
 
         // since we don't know what the session ephemeral port is, we'll just
         // search for the filter strings.
-        let result = endpoint.packet_rx.await.unwrap();
+        timeout(Duration::from_secs(1), endpoint.packet_rx.changed())
+            .await
+            .expect("should receive a packet")
+            .unwrap();
+        let result = &*endpoint.packet_rx.borrow();
         assert!(result.contains(msg), "'{}' not found in '{}'", msg, result);
         assert!(result.contains(":odr:"), ":odr: not found in '{}'", result);
     }
 
     #[tokio::test]
-    async fn bind() {
-        let socket = Server::bind(12345).await.unwrap();
-        let addr = socket.local_addr().unwrap();
-
-        let expected = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 12345);
-        assert_eq!(expected, addr)
-    }
-
-    #[tokio::test]
     async fn spawn_downstream_receive_workers() {
-        time::pause();
+        let t = TestHelper::default();
 
-        struct Result {
-            msg: String,
-            addr: SocketAddr,
-        }
-        struct Expected {
-            session_len: usize,
-        }
-
-        async fn test(
-            name: String,
-            filter_chain: SharedFilterChain,
-            expected: Expected,
-            shutdown_rx: watch::Receiver<()>,
-        ) -> Result {
-            let t = TestHelper::default();
-
-            tracing::info!(%name, "Test");
-            let msg = "hello".to_string();
-            let endpoint = t.open_socket_and_recv_single_packet().await;
-
-            let socket = t.create_socket().await;
-            let mut receive_addr = socket.local_addr().unwrap();
-            // need to switch to 127.0.0.1, as the request comes locally
-            receive_addr.set_ip("127.0.0.1".parse().unwrap());
-
-            let session_manager = SessionManager::new(shutdown_rx.clone());
-            let (send_packets, mut recv_packets) = mpsc::channel::<UpstreamPacket>(1);
-
-            let time_increment = 10;
-            time::advance(Duration::from_secs(time_increment)).await;
-
-            let endpoint_address = endpoint.socket.local_addr().unwrap().into();
-
-            let num_workers = 2;
-            let mut packet_txs = Vec::with_capacity(num_workers);
-            let mut worker_configs = Vec::with_capacity(num_workers);
-
-            let cluster =
-                SharedCluster::new_static_cluster(vec![Endpoint::new(endpoint_address)]).unwrap();
-            let proxy_metrics = ProxyMetrics::new().unwrap();
-
-            for worker_id in 0..num_workers {
-                let (packet_tx, packet_rx) = mpsc::channel(num_workers);
-                packet_txs.push(packet_tx);
-
-                let proxy_metrics = proxy_metrics.clone();
-                let session_metrics = SessionMetrics::new().unwrap();
-
-                worker_configs.push(DownstreamReceiveWorkerConfig {
-                    worker_id,
-                    packet_rx,
-                    shutdown_rx: shutdown_rx.clone(),
-                    receive_config: ProcessDownstreamReceiveConfig {
-                        proxy_metrics: proxy_metrics.clone(),
-                        session_metrics,
-                        cluster: cluster.clone(),
-                        filter_chain: filter_chain.clone(),
-                        session_manager: session_manager.clone(),
-                        session_ttl: Duration::from_secs(10),
-                        send_packets: send_packets.clone(),
-                    },
-                })
-            }
-
-            Server::spawn_downstream_receive_workers(worker_configs);
-
-            for packet_tx in packet_txs {
-                packet_tx
-                    .send(DownstreamPacket {
-                        source: receive_addr.into(),
-                        contents: msg.as_bytes().to_vec(),
-                        timer: proxy_metrics.read_processing_time_seconds.start_timer(),
-                    })
-                    .await
-                    .unwrap();
-            }
-
-            socket.send_to(msg.as_bytes(), &receive_addr).await.unwrap();
-
-            let result = endpoint.packet_rx.await.unwrap();
-            recv_packets.close();
-
-            let map = session_manager.get_sessions().await;
-            assert_eq!(expected.session_len, map.len());
-            let build_key = (
-                receive_addr.into(),
-                endpoint.socket.local_addr().unwrap().into(),
-            )
-                .into();
-            assert!(map.contains_key(&build_key));
-            let session = map.get(&build_key).unwrap();
-            let now_secs = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-            let diff = session.expiration() - now_secs;
-            assert!((5..11).contains(&diff));
-
-            assert_eq!(
-                num_workers as u64,
-                proxy_metrics
-                    .read_processing_time_seconds
-                    .get_sample_count(),
-                "One packet is sent for each worker, and we should have a sample for each"
-            );
-
-            Result {
-                msg: result,
-                addr: receive_addr,
-            }
-        }
-
+        let socket = t.create_socket().await;
+        let addr = socket.local_addr().unwrap();
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
-        let chain = SharedFilterChain::empty();
-        let result = test(
-            "no filter".to_string(),
-            chain,
-            Expected { session_len: 1 },
-            shutdown_rx.clone(),
-        )
-        .await;
-        assert_eq!("hello", result.msg);
+        let mut endpoint = t.open_socket_and_recv_single_packet().await;
+        let (send_packets, _) = mpsc::channel::<UpstreamPacket>(1);
+        let msg = "hello";
 
-        let chain = new_test_chain();
-        let result = test(
-            "test filter".to_string(),
-            chain,
-            Expected { session_len: 1 },
-            shutdown_rx.clone(),
-        )
-        .await;
+        // we'll test a single DownstreamReceiveWorkerConfig
+        let config = DownstreamReceiveWorkerConfig {
+            worker_id: 1,
+            socket,
+            receive_config: ProcessDownstreamReceiveConfig {
+                proxy_metrics: ProxyMetrics::new().unwrap(),
+                session_metrics: SessionMetrics::new().unwrap(),
+                cluster: SharedCluster::new_static_cluster(vec![Endpoint::new(
+                    endpoint.socket.local_addr().unwrap().into(),
+                )])
+                .unwrap(),
+                filter_chain: SharedFilterChain::empty(),
+                session_manager: SessionManager::new(shutdown_rx.clone()),
+                session_ttl: Duration::from_secs(10),
+                send_packets,
+            },
+            shutdown_rx,
+        };
 
-        assert_eq!(
-            format!("hello:odr:127.0.0.1:{}", result.addr.port(),),
-            result.msg
-        );
+        Server::spawn_downstream_receive_workers(vec![config]);
 
-        time::resume();
+        let socket = t.create_socket().await;
+        socket.send_to(msg.as_bytes(), &addr).await.unwrap();
+        timeout(Duration::from_secs(1), endpoint.packet_rx.changed())
+            .await
+            .expect("should receive a packet")
+            .unwrap();
+        assert_eq!(msg, *endpoint.packet_rx.borrow());
     }
 
     #[tokio::test]
@@ -739,37 +627,38 @@ mod tests {
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
 
         let msg = "hello";
-        let endpoint = t.open_socket_and_recv_single_packet().await;
-        let socket = t.create_socket().await;
+        let mut endpoint = t.open_socket_and_recv_single_packet().await;
         let session_manager = SessionManager::new(shutdown_rx.clone());
         let (send_packets, mut recv_packets) = mpsc::channel::<UpstreamPacket>(1);
+        let local_addr = get_local_addr();
+        let mut config = config_with_dummy_endpoint().build().unwrap();
+        config.proxy.port = local_addr.port();
 
-        let config = config_with_dummy_endpoint().build().unwrap();
         let server = Server::try_from(config).unwrap();
 
-        server.run_recv_from(RunRecvFromArgs {
-            cluster: SharedCluster::new_static_cluster(vec![Endpoint::new(
-                endpoint.socket.local_addr().unwrap().into(),
-            )])
-            .unwrap(),
-            filter_chain: SharedFilterChain::empty(),
-            socket: socket.clone(),
-            session_manager: session_manager.clone(),
-            session_ttl: Duration::from_secs(10),
-            send_packets,
-            shutdown_rx,
-        });
+        server
+            .run_recv_from(RunRecvFromArgs {
+                cluster: SharedCluster::new_static_cluster(vec![Endpoint::new(
+                    endpoint.socket.local_addr().unwrap().into(),
+                )])
+                .unwrap(),
+                filter_chain: SharedFilterChain::empty(),
+                session_manager: session_manager.clone(),
+                session_ttl: Duration::from_secs(10),
+                send_packets,
+                shutdown_rx,
+            })
+            .await
+            .unwrap();
 
-        let addr = socket.local_addr().unwrap();
-        socket.send_to(msg.as_bytes(), &addr).await.unwrap();
+        let socket = t.create_socket().await;
+        socket.send_to(msg.as_bytes(), &local_addr).await.unwrap();
 
-        assert_eq!(
-            msg,
-            timeout(Duration::from_millis(500), endpoint.packet_rx)
-                .await
-                .expect("should get a packet")
-                .unwrap()
-        );
+        timeout(Duration::from_secs(1), endpoint.packet_rx.changed())
+            .await
+            .expect("should receive a packet")
+            .unwrap();
+        assert_eq!(msg, *endpoint.packet_rx.borrow());
         recv_packets.close();
     }
 
@@ -783,7 +672,7 @@ mod tests {
 
         // without a filter
         let (send_packet, recv_packet) = mpsc::channel::<UpstreamPacket>(1);
-        let endpoint = t.open_socket_and_recv_single_packet().await;
+        let mut endpoint = t.open_socket_and_recv_single_packet().await;
         if send_packet
             .send(UpstreamPacket::new(
                 endpoint.socket.local_addr().unwrap().into(),
@@ -798,7 +687,11 @@ mod tests {
         let config = config_with_dummy_endpoint().build().unwrap();
         let server = Server::try_from(config).unwrap();
         server.run_receive_packet(endpoint.socket, recv_packet);
-        assert_eq!(msg, endpoint.packet_rx.await.unwrap());
+        timeout(Duration::from_secs(1), endpoint.packet_rx.changed())
+            .await
+            .expect("should receive a packet")
+            .unwrap();
+        assert_eq!(msg, *endpoint.packet_rx.borrow());
         assert_eq!(
             1_u64,
             histogram.get_sample_count(),

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -442,7 +442,6 @@ mod tests {
         time::{timeout, Duration},
     };
 
-    use crate::test_utils::create_socket;
     use crate::{
         cluster::SharedCluster,
         config,
@@ -452,7 +451,10 @@ mod tests {
             server::metrics::Metrics as ProxyMetrics, sessions::metrics::Metrics as SessionMetrics,
             sessions::UpstreamPacket,
         },
-        test_utils::{config_with_dummy_endpoint, get_local_addr, load_test_filters, TestHelper},
+        test_utils::{
+            available_addr, config_with_dummy_endpoint, create_socket, load_test_filters,
+            TestHelper,
+        },
     };
 
     use super::*;
@@ -464,7 +466,7 @@ mod tests {
         let endpoint1 = t.open_socket_and_recv_single_packet().await;
         let mut endpoint2 = t.open_socket_and_recv_single_packet().await;
 
-        let local_addr = get_local_addr();
+        let local_addr = available_addr().await;
         let config = Server::builder()
             .port(local_addr.port())
             .endpoints(vec![
@@ -507,7 +509,7 @@ mod tests {
 
         let endpoint = t.open_socket_and_recv_single_packet().await;
 
-        let local_addr = get_local_addr();
+        let local_addr = available_addr().await;
         let config = Server::builder()
             .port(local_addr.port())
             .endpoints(vec![Endpoint::new(
@@ -549,7 +551,7 @@ mod tests {
 
         load_test_filters();
         let endpoint = t.open_socket_and_recv_single_packet().await;
-        let local_addr = get_local_addr();
+        let local_addr = available_addr().await;
         let config = Server::builder()
             .port(local_addr.port())
             .filters(vec![config::Filter {
@@ -637,7 +639,7 @@ mod tests {
         let mut endpoint = t.open_socket_and_recv_single_packet().await;
         let session_manager = SessionManager::new(shutdown_rx.clone());
         let (send_packets, mut recv_packets) = mpsc::channel::<UpstreamPacket>(1);
-        let local_addr = get_local_addr();
+        let local_addr = available_addr().await;
         let mut config = config_with_dummy_endpoint().build().unwrap();
         config.proxy.port = local_addr.port();
 

--- a/src/proxy/sessions/session.rs
+++ b/src/proxy/sessions/session.rs
@@ -359,7 +359,7 @@ mod tests {
     use prometheus::{Histogram, HistogramOpts};
     use tokio::time::timeout;
 
-    use crate::test_utils::{new_test_chain, TestHelper};
+    use crate::test_utils::{create_socket, new_test_chain, TestHelper};
 
     use crate::endpoint::{Endpoint, EndpointAddress};
     use crate::filters::SharedFilterChain;
@@ -368,8 +368,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_new() {
-        let t = TestHelper::default();
-        let socket = t.create_socket().await;
+        let socket = create_socket().await;
         let addr: EndpointAddress = socket.local_addr().unwrap().into();
         let endpoint = Endpoint::new(addr.clone());
         let (send_packet, mut recv_packet) = mpsc::channel::<UpstreamPacket>(5);

--- a/src/proxy/sessions/session_manager.rs
+++ b/src/proxy/sessions/session_manager.rs
@@ -72,7 +72,7 @@ impl SessionManager {
                         break;
                     }
                     _ = interval.tick() => {
-                        tracing::debug!("Attempting to Prune Sessions");
+                        tracing::debug!("Pruning Sessions");
                         Self::prune_sessions(&mut sessions).await;
 
                     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,3 +15,4 @@
  */
 
 pub(crate) mod debug;
+pub(crate) mod net;

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::Result;
+use socket2::{Protocol, Socket, Type};
+use std::net::SocketAddr;
+use tokio::net::UdpSocket;
+
+/// returns a UdpSocket with address and port reuse.
+pub fn socket_with_reuse(addr: SocketAddr) -> Result<UdpSocket> {
+    let sock = Socket::new(
+        match addr {
+            SocketAddr::V4(_) => socket2::Domain::IPV4,
+            SocketAddr::V6(_) => socket2::Domain::IPV6,
+        },
+        Type::DGRAM,
+        Some(Protocol::UDP),
+    )?;
+    sock.set_reuse_address(true)?;
+    sock.set_reuse_port(true)?;
+    sock.set_nonblocking(true)?;
+    sock.bind(&addr.into())?;
+
+    UdpSocket::from_std(sock.into()).map_err(|error| eyre::eyre!(error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    #[tokio::test]
+    async fn socket_with_reuse() {
+        let expected = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 12345);
+        let socket = super::socket_with_reuse(expected.into()).unwrap();
+        let addr = socket.local_addr().unwrap();
+
+        assert_eq!(SocketAddr::V4(expected), socket.local_addr().unwrap());
+
+        // should be able to do it a second time, since we are reusing the address.
+        let socket = super::socket_with_reuse(expected.into()).unwrap();
+        let addr2 = socket.local_addr().unwrap();
+        assert_eq!(addr, addr2);
+    }
+}

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -70,18 +70,16 @@ async fn token_router() {
     let msg = b"helloabc";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    assert_eq!(
-        "helloabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!("helloabc", *recv_chan.borrow());
 
     // send an invalid packet
     let msg = b"helloxyz";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    let result = timeout(Duration::from_secs(3), recv_chan.recv()).await;
+    let result = timeout(Duration::from_secs(3), recv_chan.changed()).await;
     assert!(result.is_err(), "should not have received a packet");
 }

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -16,7 +16,7 @@
 
 use tokio::time::{timeout, Duration};
 
-use quilkin::test_utils::get_local_addr;
+use quilkin::test_utils::available_addr;
 use quilkin::{
     config::Filter,
     endpoint::Endpoint,
@@ -30,7 +30,7 @@ async fn client_and_server() {
     let echo = t.run_echo_server().await;
 
     // create server configuration as
-    let server_addr = get_local_addr();
+    let server_addr = available_addr().await;
     let yaml = "
 on_read: DECOMPRESS
 on_write: COMPRESS
@@ -48,7 +48,7 @@ on_write: COMPRESS
     t.run_server_with_config(server_config);
 
     // create a local client
-    let client_addr = get_local_addr();
+    let client_addr = available_addr().await;
     let yaml = "
 on_read: COMPRESS
 on_write: DECOMPRESS

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -76,9 +76,9 @@ on_write: DECOMPRESS
     tracing::info!(address = %local_addr, "Sending hello");
     tx.send_to(b"hello", &local_addr).await.unwrap();
 
-    let expected = timeout(Duration::from_secs(5), rx.recv())
+    timeout(Duration::from_secs(5), rx.changed())
         .await
         .expect("should have received a packet")
         .unwrap();
-    assert_eq!("hello", expected);
+    assert_eq!("hello", *rx.borrow());
 }

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -52,11 +52,9 @@ bytes: YWJj #abc
     let local_addr = (Ipv4Addr::LOCALHOST, server_port);
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
-    assert_eq!(
-        "helloabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("helloabc", *recv_chan.borrow());
 }

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -82,11 +82,9 @@ on_write: DECOMPRESS
     let local_addr = (Ipv4Addr::LOCALHOST, server_port);
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
-    assert_eq!(
-        "helloxyzabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("helloxyzabc", *recv_chan.borrow());
 }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -15,6 +15,8 @@
  */
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::time::Duration;
+use tokio::time::timeout;
 
 use quilkin::{
     config::Filter,
@@ -71,7 +73,10 @@ async fn test_filter() {
     tracing::info!(address = %local_addr, "Sending hello");
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
-    let result = recv_chan.recv().await.unwrap();
+    let result = timeout(Duration::from_secs(5), recv_chan.recv())
+        .await
+        .unwrap()
+        .unwrap();
     // since we don't know the ephemeral ip addresses in use, we'll search for
     // substrings for the results we expect that the TestFilter will inject in
     // the round-tripped packets.

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -16,6 +16,8 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::time::timeout;
 
 use quilkin::{
     config::Filter,
@@ -61,7 +63,11 @@ policy: ROUND_ROBIN
 
     for addr in echo_addresses {
         socket.send_to(b"hello", &server_addr).await.unwrap();
-        assert_eq!(recv_chan.recv().await.unwrap(), "hello");
+        timeout(Duration::from_secs(5), recv_chan.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!("hello", *recv_chan.borrow());
 
         assert_eq!(
             addr,

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -56,13 +56,17 @@ period: 1
     }
 
     for _ in 0..2 {
-        assert_eq!(recv_chan.recv().await.unwrap(), "hello");
+        timeout(Duration::from_secs(5), recv_chan.changed())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!("hello", *recv_chan.borrow());
     }
 
     // Allow enough time to have received any response.
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Check that we do not get any response.
-    assert!(timeout(Duration::from_secs(1), recv_chan.recv())
+    assert!(timeout(Duration::from_secs(1), recv_chan.changed())
         .await
         .is_err());
 }

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -82,47 +82,39 @@ on_read:
     let msg = b"helloabc";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    assert_eq!(
-        "helloxyz",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("helloxyz", *recv_chan.borrow());
 
     // send an xyz packet
     let msg = b"helloxyz";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    assert_eq!(
-        "helloabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("helloabc", *recv_chan.borrow());
 
     // fallthrough packet
     let msg = b"hellodef";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    assert_eq!(
-        "hellodef",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("hellodef", *recv_chan.borrow());
 
     // second fallthrough packet
     let msg = b"hellofgh";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    assert_eq!(
-        "hellodef",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("hellodef", *recv_chan.borrow());
 }

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -56,7 +56,7 @@ async fn metrics_server() {
     tracing::info!(address = %local_addr, "Sending hello");
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
-    let _ = recv_chan.recv().await.unwrap();
+    let _ = recv_chan.changed().await.unwrap();
     let client = hyper::Client::new();
 
     let resp = client

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
 use tokio::time::timeout;
 use tokio::time::Duration;
 
+use quilkin::test_utils::{get_local_addr, pretty_print};
 use quilkin::{endpoint::Endpoint, test_utils::TestHelper};
 
 #[tokio::test]
 async fn echo() {
+    pretty_print();
+
     let mut t = TestHelper::default();
 
     // create two echo servers as endpoints
@@ -30,31 +31,19 @@ async fn echo() {
     let server2 = t.run_echo_server().await;
 
     // create server configuration
-    let server_port = 12345;
+    let local_addr = get_local_addr();
     let server_config = quilkin::Server::builder()
-        .port(server_port)
+        .port(local_addr.port())
         .endpoints(vec![Endpoint::new(server1), Endpoint::new(server2)])
         .build()
         .unwrap();
 
     t.run_server_with_config(server_config);
 
-    // create a local client
-    let client_port = 12344;
-    let client_config = quilkin::Server::builder()
-        .port(client_port)
-        .endpoints(vec![Endpoint::new(
-            (IpAddr::V4(Ipv4Addr::LOCALHOST), server_port).into(),
-        )])
-        .build()
-        .unwrap();
-    t.run_server_with_config(client_config);
-
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
     // game_client
-    let local_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, client_port));
     socket.send_to(b"hello", &local_addr).await.unwrap();
 
     timeout(Duration::from_secs(5), recv_chan.changed())
@@ -71,6 +60,5 @@ async fn echo() {
     // should only be two returned items
     assert!(timeout(Duration::from_secs(2), recv_chan.changed())
         .await
-        .unwrap()
         .is_err());
 }

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -18,7 +18,7 @@ use std::str::from_utf8;
 use tokio::time::timeout;
 use tokio::time::Duration;
 
-use quilkin::test_utils::{get_local_addr, pretty_print};
+use quilkin::test_utils::{available_addr, pretty_print};
 use quilkin::{endpoint::Endpoint, test_utils::TestHelper};
 
 #[tokio::test]
@@ -37,7 +37,7 @@ async fn echo() {
     let server2 = t.run_echo_server().await;
 
     // create server configuration
-    let local_addr = get_local_addr();
+    let local_addr = available_addr().await;
     let server_config = quilkin::Server::builder()
         .port(local_addr.port())
         .endpoints(vec![Endpoint::new(server1), Endpoint::new(server2)])

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -71,18 +71,16 @@ quilkin.dev:
     let msg = b"helloabc";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    assert_eq!(
-        "hello",
-        timeout(Duration::from_secs(5), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    timeout(Duration::from_secs(5), recv_chan.changed())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+    assert_eq!("hello", *recv_chan.borrow());
 
     // send an invalid packet
     let msg = b"helloxyz";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    let result = timeout(Duration::from_secs(3), recv_chan.recv()).await;
+    let result = timeout(Duration::from_secs(3), recv_chan.changed()).await;
     assert!(result.is_err(), "should not have received a packet");
 }

--- a/tests/xds.rs
+++ b/tests/xds.rs
@@ -201,11 +201,8 @@ management_servers:
                     // If we time out, it could mean that we haven't applied any cluster update yet so we
                     // are dropping packets. In which case we can simply retry later.
                     // If its for any other reason, our assertion will fail later or we will time out.
-                    if let Ok(response) = time::timeout(Duration::from_millis(500), response_rx.recv()).await {
-                        let response = response.unwrap();
-                        if expected_response == response {
-                            break;
-                        }
+                    if time::timeout(Duration::from_millis(500), response_rx.changed()).await.is_ok() && expected_response == *response_rx.borrow() {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Draft pull request, in hopes that someone else will see something that I am missing. I'd love an extra pair of eyes, because I'm at a bit of a loss here. 😞

Please excuse the mess, work in progress code.

## Context

I believe I've implemented the basics of #410, but on my unit tests, it's passing ~90% of the time, but 10% of the time, Quilkin isn't erroring when it says it's receiving UDP packets, but when the test sends them, nothing happens and I'm very confused.

I'm also wondering if I'm missing some kind of low level kernel socket setting or understanding of how this works, and (hopefully) missed something obvious that someone else will see.

I've yet to try the integration tests.

## Where to look

* net.rs - new `net` module for creating sockets with SO_REUSEADDRESS and SO_REUSEPORT
* server.rs - `spawn_downstream_receive_workers` - this is where the logic to receive packets is being managed.

## How to reproduce

Many of the tests fail in `server.rs` intermittently, but I've been debugging in`tests::run_client` - since it's the simplest test of the of the proxy with a singular packet only going from local to a single endpoint address.

To run: `cargo test --lib run_client`

## Things I have tried

My original thought was "oh, this is a race condition where we're sending the packet before the proxy comes up and is receiving connections" - there are a few ways we could tackle that, but there are several layers of async coroutines within the system, I ended up going with the tried and true approach of polling until something works. So I implemented retry logic via `tryhard` (and changing some of `test_utils` to accommodate that).

So in `run_client` I have it setup to retry 10 times with a delay of second between each attempt to sending a packet and recieve a response. Unfortunately even with the retries, it seems like intermittently, the proxy is not actively accepting packets -- and I'm not sure where it gets stuck (See logs below to see that packets don't get received by Quilkin). 

To make a note - when the test passes, it passes on the first packet that is sent. When it fails, it fails on the first packet and every retry thereafter. I've never seen a retry actually pass the test.

## Relevant logs

### Passing `run_client` unit test

You can see each of the workers come up, await for packets, accept them and process them. Working as expected (happens most of the time).

```
Testing started at 1:58 PM ...
    Finished test [unoptimized + debuginfo] target(s) in 0.11s
     Running unittests (target/debug/deps/quilkin-258efebca14997ce)
  2022-04-19T20:58:52.801777Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:49937, source: 0.0.0.0:37577
    at src/proxy/server.rs:526

  2022-04-19T20:58:52.802458Z  INFO quilkin::proxy::server: Starting, port: 49937, proxy_id: "test"
    at src/proxy/server.rs:103

  2022-04-19T20:58:52.802831Z  INFO quilkin::proxy::server: Quilkin is ready
    at src/proxy/server.rs:131

  2022-04-19T20:58:52.802906Z DEBUG quilkin::proxy::server: Awaiting packet, id: 0, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.802956Z DEBUG quilkin::proxy::server: Awaiting packet, id: 1, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.802991Z DEBUG quilkin::proxy::server: Awaiting packet, id: 2, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.803024Z DEBUG quilkin::proxy::server: Awaiting packet, id: 3, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.803057Z DEBUG quilkin::proxy::server: Awaiting packet, id: 4, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.803090Z DEBUG quilkin::proxy::server: Awaiting packet, id: 5, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.803122Z DEBUG quilkin::proxy::server: Awaiting packet, id: 6, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.803155Z DEBUG quilkin::proxy::server: Awaiting packet, id: 7, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.803305Z DEBUG quilkin::proxy::sessions::session_manager: Pruning Sessions
    at src/proxy/sessions/session_manager.rs:75

  2022-04-19T20:58:52.803385Z DEBUG quilkin::proxy::server: Received packet, id: 3, size: 5, source: 127.0.0.1:37577
    at src/proxy/server.rs:238

  2022-04-19T20:58:52.803506Z DEBUG quilkin::proxy::sessions::session: Session created, source: 127.0.0.1:37577, dest: Endpoint { address: EndpointAddress { host: Ip(0.0.0.0), port: Some(37577) }, metadata: MetadataView { known: Metadata { tokens: {} }, unknown: {} } }
    at src/proxy/sessions/session.rs:156

  2022-04-19T20:58:52.803607Z DEBUG quilkin::proxy::sessions::session: Awaiting incoming packet, source: 127.0.0.1:37577, dest: Endpoint { address: EndpointAddress { host: Ip(0.0.0.0), port: Some(37577) }, metadata: MetadataView { known: Metadata { tokens: {} }, unknown: {} } }
    at src/proxy/sessions/session.rs:181

  2022-04-19T20:58:52.803712Z DEBUG quilkin::proxy::server: Awaiting packet, id: 3, addr: Ok(0.0.0.0:49937)
    at src/proxy/server.rs:228

  2022-04-19T20:58:52.803988Z DEBUG quilkin::proxy::sessions::session: Session closed, source: 127.0.0.1:37577, dest_address: 0.0.0.0:37577
    at src/proxy/sessions/session.rs:341


Process finished with exit code 0
```

### Failing `run_client` unit test

Here you can see the socket comes up and is awaiting connections, but even with 10 retries (each "Sending Packet" debug log) with a second between, the packets are never recieved. I am very much at a loss as to why.

```

Testing started at 1:07 PM ...
    Finished test [unoptimized + debuginfo] target(s) in 0.13s
     Running unittests (target/debug/deps/quilkin-258efebca14997ce)
  2022-04-19T20:07:45.643367Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:45.644091Z  INFO quilkin::proxy::server: Starting, port: 37292, proxy_id: "test"
    at src/proxy/server.rs:103

  2022-04-19T20:07:45.644484Z  INFO quilkin::proxy::server: Quilkin is ready
    at src/proxy/server.rs:131

  2022-04-19T20:07:45.644580Z DEBUG quilkin::proxy::server: Awaiting packet, id: 0, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.644631Z DEBUG quilkin::proxy::server: Awaiting packet, id: 1, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.644667Z DEBUG quilkin::proxy::server: Awaiting packet, id: 2, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.644702Z DEBUG quilkin::proxy::server: Awaiting packet, id: 3, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.644736Z DEBUG quilkin::proxy::server: Awaiting packet, id: 4, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.644770Z DEBUG quilkin::proxy::server: Awaiting packet, id: 5, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.644804Z DEBUG quilkin::proxy::server: Awaiting packet, id: 6, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.644838Z DEBUG quilkin::proxy::server: Awaiting packet, id: 7, addr: Ok(0.0.0.0:37292)
    at src/proxy/server.rs:228

  2022-04-19T20:07:45.645043Z DEBUG quilkin::proxy::sessions::session_manager: Pruning Sessions
    at src/proxy/sessions/session_manager.rs:75

  2022-04-19T20:07:46.747649Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:47.849316Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:48.950998Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:50.053756Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:51.156530Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:52.258570Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:53.360224Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:54.462921Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:55.565932Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:56.669490Z DEBUG quilkin::proxy::server::tests: Sending Packet, dest: 0.0.0.0:37292, source: 0.0.0.0:35604
    at src/proxy/server.rs:526

  2022-04-19T20:07:56.770633Z ERROR quilkin::proxy::health: Panic has occurred. Moving to Unhealthy, panic_info: panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', src/proxy/server.rs:534:10
    at src/proxy/health.rs:37


called `Result::unwrap()` on an `Err` value: Elapsed(())
thread 'proxy::server::tests::run_client' panicked at 'called `Result::unwrap()` on an `Err` value: Elapsed(())', src/proxy/server.rs:534:10
...
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: test failed, to rerun pass '-p quilkin --lib'

Process finished with exit code 101

```

If anyone has any ideas, I would love some input! 