### PR TITLE
`connect()` Sessions socket to Endpoint address

### DIFF
--- a/src/proxy/sessions/error.rs
+++ b/src/proxy/sessions/error.rs
@@ -20,6 +20,7 @@ use std::fmt::{self, Display, Formatter};
 pub enum Error {
     BindUdpSocket(tokio::io::Error),
     UpdateSessionExpiration(String),
+    ToSocketAddr(eyre::Report),
 }
 
 impl Display for Error {
@@ -30,6 +31,9 @@ impl Display for Error {
             }
             Error::UpdateSessionExpiration(reason) => {
                 write!(f, "failed to update session expiration time: {}", reason)
+            }
+            Error::ToSocketAddr(reason) => {
+                write!(f, "failed to convert endpoint to address: {}", reason)
             }
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Since a Session is only ever going to send data to the Endpoint, we can `connect()` the socket to that address, rather than need to pass the endpoint address to every `send()` request.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

Cleanup with working on #410 

**Special notes for your reviewer**:

N/A