### PR TITLE
Implemented Port reuse for downstream connection.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = "1.0.79"
 serde_regex = "1.1.0"
 serde_yaml = "0.8.21"
+socket2 = "0.4.4"
 snap = "1.0.5"
 stable-eyre = "0.2.2"
 thiserror = "1.0.30"

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-pub use session::{Session, SessionArgs, SessionKey, UpstreamPacket};
+pub use session::{Session, SessionArgs, SessionKey};
 pub use session_manager::SESSION_TIMEOUT_SECONDS;
 
 pub(crate) mod error;

--- a/src/proxy/sessions/session_manager.rs
+++ b/src/proxy/sessions/session_manager.rs
@@ -110,12 +110,9 @@ impl SessionManager {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::ops::Add;
-    use std::sync::Arc;
-    use std::time::Duration;
+    use std::{collections::HashMap, ops::Add, sync::Arc, time::Duration};
 
-    use tokio::sync::{mpsc, watch, RwLock};
+    use tokio::sync::{watch, RwLock};
 
     use crate::{
         endpoint::{Endpoint, EndpointAddress},
@@ -124,9 +121,9 @@ mod tests {
             server::metrics::Metrics as ProxyMetrics,
             sessions::{
                 metrics::Metrics, session::SessionArgs, session_manager::Sessions, SessionKey,
-                UpstreamPacket,
             },
         },
+        test_utils::create_socket,
     };
 
     use super::SessionManager;
@@ -142,8 +139,8 @@ mod tests {
     async fn run_prune_sessions() {
         let sessions = Arc::new(RwLock::new(HashMap::new()));
         let (from, to) = address_pair();
-        let (send, _recv) = mpsc::channel::<UpstreamPacket>(1);
         let (_shutdown_tx, shutdown_rx) = watch::channel(());
+        let socket = Arc::new(create_socket().await);
 
         let endpoint = Endpoint::new(to.clone());
 
@@ -164,8 +161,8 @@ mod tests {
                 proxy_metrics: ProxyMetrics::new().unwrap(),
                 filter_chain: SharedFilterChain::empty(),
                 source: from,
+                downstream_socket: socket,
                 dest: endpoint.clone(),
-                sender: send,
                 ttl,
             };
             sessions.insert(key.clone(), session_args.into_session().await.unwrap());
@@ -205,8 +202,8 @@ mod tests {
     async fn prune_sessions() {
         let mut sessions: Sessions = Arc::new(RwLock::new(HashMap::new()));
         let (from, to) = address_pair();
-        let (send, _recv) = mpsc::channel::<UpstreamPacket>(1);
         let endpoint = Endpoint::new(to.clone());
+        let socket = Arc::new(create_socket().await);
 
         let key = SessionKey::from((from.clone(), to.clone()));
         let ttl = Duration::from_secs(1);
@@ -218,8 +215,8 @@ mod tests {
                 proxy_metrics: ProxyMetrics::new().unwrap(),
                 filter_chain: SharedFilterChain::empty(),
                 source: from,
+                downstream_socket: socket,
                 dest: endpoint.clone(),
-                sender: send,
                 ttl,
             };
             sessions.insert(key.clone(), session_args.into_session().await.unwrap());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,3 +15,4 @@
  */
 
 pub(crate) mod debug;
+pub(crate) mod net;

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use crate::Result;
+use socket2::{Protocol, Socket, Type};
+use std::{io, net::SocketAddr};
+use tokio::net::UdpSocket;
+
+/// returns a UdpSocket with address and port reuse.
+pub fn socket_with_reuse(addr: SocketAddr) -> Result<UdpSocket> {
+    let sock = Socket::new(
+        match addr {
+            SocketAddr::V4(_) => socket2::Domain::IPV4,
+            SocketAddr::V6(_) => socket2::Domain::IPV6,
+        },
+        Type::DGRAM,
+        Some(Protocol::UDP),
+    )?;
+    enable_reuse(&sock)?;
+    sock.set_nonblocking(true)?;
+    sock.bind(&addr.into())?;
+
+    UdpSocket::from_std(sock.into()).map_err(|error| eyre::eyre!(error))
+}
+
+#[cfg(not(target_family = "windows"))]
+fn enable_reuse(sock: &Socket) -> io::Result<()> {
+    sock.set_reuse_port(true)?;
+    Ok(())
+}
+
+#[cfg(target_family = "windows")]
+fn enable_reuse(sock: &Socket) -> io::Result<()> {
+    sock.set_reuse_address(true)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::available_addr;
+
+    #[tokio::test]
+    async fn socket_with_reuse() {
+        let expected = available_addr().await;
+        let socket = super::socket_with_reuse(expected).unwrap();
+        let addr = socket.local_addr().unwrap();
+
+        assert_eq!(expected, socket.local_addr().unwrap());
+
+        // should be able to do it a second time, since we are reusing the address.
+        let socket = super::socket_with_reuse(expected).unwrap();
+        let addr2 = socket.local_addr().unwrap();
+        assert_eq!(addr, addr2);
+    }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Implemented the use of SO_REUSEPORT for *nix systems and SO_REUSEADDR for Windows systems.

This removes a lot of the code needed for channel coordination that was previously in place, and simplifies much of the architecture, as well as improving performance.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

Closes #410

**Special notes for your reviewer**:

I noted that in [this example](https://github.com/fujita/tokio-reuseport/blob/master/greeter-reuseport/src/main.rs) they started multiple actual threads, but since [Tokio starts a thread for async processing for each cpu anyway, this seemed like redundant work](https://github.com/tokio-rs/tokio/discussions/3858#discussioncomment-869878), so I just stuck with `tokio::spawn` for each worker.