### PR TITLE
Tools for Agones e2e testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 #
 
 [workspace]
-members = [".", "./macros"]
+members = [".", "./macros", "./agones"]
 
 [package]
 name = "quilkin"

--- a/agones/.gitignore
+++ b/agones/.gitignore
@@ -1,0 +1,52 @@
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+### Terraform template
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+

--- a/agones/Cargo.toml
+++ b/agones/Cargo.toml
@@ -1,0 +1,30 @@
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+[package]
+name = "agones"
+authors = ["Mark Mandel <markmandel@google.com>"]
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "End to end integration tests to be run against a Kubernetes cluster with Agones installed"
+readme = "README.md"
+
+[dependencies]
+k8s-openapi = { version = "0.15.0", features = ["v1_22"] }
+kube = { version = "0.73.1", features = ["runtime", "derive"] }
+quilkin = { path = "../" }
+tokio = { version = "1.19.2", features = ["sync", "parking_lot"] }

--- a/agones/README.md
+++ b/agones/README.md
@@ -1,0 +1,46 @@
+# Agones Integration Tests
+
+This folder containers the integration tests for Quilkin and Agones integration.
+
+## Requirements
+
+* A Kubernetes cluster with [Agones](https://agones.dev) installed
+* Local authentication to the cluster via `kubectl`
+
+## Running Tests
+
+To run the tests, run `cargo test` in this folder. This will run the e2e to tests with the default Quilkin image.
+
+When writing new tests for new features, you will want to specify a development image hosted on a container 
+registry to test against. This can be done through the `QUILKIN_IMAGE` environment variable like so:
+
+```shell
+QUILKIN_IMAGE=us-docker.pkg.dev/my-project-name/dev/quilkin:0.4.0-dev cargo test
+```
+
+## Creating a Agones GKE cluster with Terraform
+
+The following is a convenience tool for setting up a cluster for end-to-end testing.
+
+This requires:
+
+* [Google Cloud CLI](https://cloud.google.com/sdk/gcloud)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+* [Terraform](https://www.terraform.io/downloads)
+
+You can also use `make shell` from the [build](../build) folder, which will give you a shell environment with all
+the tools needed.
+
+By default, the provided Terraform script creates a cluster in zone "us-west1-c", but this can be overwritten in the 
+variables. See [main.tf](./main.tf) for details.
+
+```
+terraform init
+gcloud auth application-default login
+terraform apply -var project="<YOUR_GCP_ProjectID>"
+gcloud container clusters get-credentials --zone us-west1-c agones
+```
+
+## Licence
+
+Apache 2.0

--- a/agones/README.md
+++ b/agones/README.md
@@ -4,8 +4,8 @@ This folder containers the integration tests for Quilkin and Agones integration.
 
 ## Requirements
 
-* A Kubernetes cluster with [Agones](https://agones.dev) installed
-* Local authentication to the cluster via `kubectl`
+* A Kubernetes cluster with [Agones](https://agones.dev) installed.
+* Local authentication to the cluster via `kubectl`.
 
 ## Running Tests
 
@@ -18,7 +18,21 @@ registry to test against. This can be done through the `QUILKIN_IMAGE` environme
 QUILKIN_IMAGE=us-docker.pkg.dev/my-project-name/dev/quilkin:0.4.0-dev cargo test
 ```
 
-## Creating a Agones GKE cluster with Terraform
+## Creating an Agones Minikube Cluster
+
+If you want to test locally, you can use a tool such a [minikube](https://github.com/kubernetes/minikube) to create 
+a cluster, and install Agones on it.
+
+Because of the virtualisation layers that are required with various drivers of Minikube,  only certain combinations of 
+OS's and drivers can provide direct UDP connectivity, therefore it's worth following the 
+[Agones documentation on setting up Minikube](https://agones.dev/site/docs/installation/creating-cluster/minikube/) 
+to set up a known working combination.
+
+Then follow either the YAML or Helm install options in the 
+[Agones installation documentation](https://agones.dev/site/docs/installation/install-agones/) depoending on your 
+preference.
+
+## Creating an Agones GKE Cluster with Terraform
 
 The following is a convenience tool for setting up a cluster for end-to-end testing.
 

--- a/agones/main.tf
+++ b/agones/main.tf
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      version = "~> 3.88"
+    }
+  }
+}
+
+variable "name" {
+  description = "The name of the GKE cluster"
+  type        = string
+  default     = "agones"
+}
+
+variable "zone" {
+  description = "The Google Cloud Zone to place the GKE cluster"
+  type        = string
+  default     = "us-west1-c"
+}
+
+variable "project" {
+  description = "The Google Cloud project name"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "The GCE machine type to use for the nodes"
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "node_count" {
+  default     = "4"
+  description = "This is the number of gameserver nodes. The Agones module will automatically create an additional two node pools with 1 node each for 'agones-system' and 'agones-metrics'"
+  type        = number
+}
+
+// Create a GKE cluster with the appropriate structure
+module "agones_cluster" {
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.23.0"
+
+  cluster = {
+    "name"             = var.name
+    "zone"             = var.zone
+    "initialNodeCount" = var.node_count
+    "project"          = var.project
+  }
+}
+
+// Install Agones via Helm
+module "helm_agones" {
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm3/?ref=release-1.23.0"
+
+  agones_version         = "1.23.0"
+  values_file            = ""
+  chart                  = "agones"
+  host                   = module.agones_cluster.host
+  token                  = module.agones_cluster.token
+  cluster_ca_certificate = module.agones_cluster.cluster_ca_certificate
+}

--- a/agones/src/lib.rs
+++ b/agones/src/lib.rs
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::{
+    collections::BTreeMap,
+    env,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use k8s_openapi::{api::core::v1::Namespace, apimachinery::pkg::apis::meta::v1::ObjectMeta};
+use kube::{
+    api::{DeleteParams, ListParams, PostParams},
+    Api, ResourceExt,
+};
+use tokio::sync::OnceCell;
+
+mod pod;
+
+#[allow(dead_code)]
+static CLIENT: OnceCell<Client> = OnceCell::const_new();
+#[allow(dead_code)]
+const QUILKIN_IMAGE: &str = "QUILKIN_IMAGE";
+
+pub struct Client {
+    /// The Kubernetes client
+    pub kubernetes: kube::Client,
+    /// The namespace the tests will happen in
+    pub namespace: String,
+    /// The name and tag of the Quilkin image being tested
+    pub quilkin_image: String,
+}
+
+impl Client {
+    /// Thread safe way to create a Client once and only once across multiple tests.
+    /// Executes the setup required:
+    /// * Creates a test namespace for this test
+    /// * Removes previous test namespaces
+    /// * Retrieves the QUILKIN_IMAGE to test from env vars, and defaults it if not available.
+    pub async fn new() -> &'static Client {
+        CLIENT
+            .get_or_init(|| async {
+                let client = kube::Client::try_default()
+                    .await
+                    .expect("Kubernetes client to be created");
+
+                Client {
+                    kubernetes: client.clone(),
+                    namespace: setup_namespace(client).await,
+                    quilkin_image: env::var_os(QUILKIN_IMAGE)
+                        .unwrap_or_else(|| "us-docker.pkg.dev/quilkin/release/quilkin:0.3.0".into())
+                        .into_string()
+                        .unwrap(),
+                }
+            })
+            .await
+    }
+}
+
+/// Deletes old quilkin test namespaces, and then create
+/// a new namespace based on EPOCH time, and return its string value.
+#[allow(dead_code)]
+async fn setup_namespace(client: kube::Client) -> String {
+    let namespaces: Api<Namespace> = Api::all(client.clone());
+
+    let lp = ListParams::default().labels("owner=quilkin-test");
+    let nss = namespaces.list(&lp).await.unwrap();
+    let dp = DeleteParams::default();
+    for ns in nss {
+        let name = ns.name();
+        if let Err(err) = namespaces.delete(name.as_str(), &dp).await {
+            println!("Failure attempting to deleted namespace: {:?}, {err}", name);
+        }
+    }
+
+    let name = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .to_string();
+
+    let metadata = ObjectMeta {
+        name: Some(name),
+        labels: Some(BTreeMap::from([("owner".into(), "quilkin-test".into())])),
+        ..Default::default()
+    };
+    let test_namespace = Namespace {
+        metadata,
+        spec: None,
+        status: None,
+    };
+
+    let pp = PostParams::default();
+    namespaces
+        .create(&pp, &test_namespace)
+        .await
+        .expect("namespace to be created");
+
+    test_namespace.name()
+}

--- a/agones/src/pod.rs
+++ b/agones/src/pod.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#[cfg(test)]
+mod tests {
+    use k8s_openapi::{
+        api::core::v1::{Container, Pod, PodSpec},
+        apimachinery::pkg::apis::meta::v1::ObjectMeta,
+    };
+    use kube::{
+        api::PostParams,
+        runtime::wait::{await_condition, conditions},
+        Api, ResourceExt,
+    };
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    use crate::Client;
+
+    #[tokio::test]
+    async fn create_quilkin_pod() {
+        let client = Client::new().await;
+
+        let pods: Api<Pod> = Api::namespaced(client.kubernetes.clone(), client.namespace.as_str());
+        let pod = Pod {
+            metadata: ObjectMeta {
+                generate_name: Some("quilkin-".into()),
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "quilkin".into(),
+                    image: Some(client.quilkin_image.clone()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            status: None,
+        };
+
+        // create the pod
+        let pp = PostParams::default();
+        let pod = pods.create(&pp, &pod).await.unwrap();
+
+        // now wait for it be become ready.
+        let name = pod.name();
+        let running = await_condition(pods, name.as_str(), conditions::is_pod_running());
+        timeout(Duration::from_secs(30), running)
+            .await
+            .expect("Pod should be running")
+            .unwrap();
+    }
+}

--- a/build/Makefile
+++ b/build/Makefile
@@ -31,6 +31,13 @@ package_version := $(shell grep version -m 1 $(project_path)/Cargo.toml | awk '{
 common_rust_args := -v $(project_path):/workspace -w /workspace \
 					-v $(CARGO_HOME)/registry:/usr/local/cargo/registry
 
+KUBECONFIG ?= ~/.kube/config
+kubeconfig_path := $(dir $(KUBECONFIG))
+helm_config := ~/.config/helm
+helm_cache := ~/.cache/helm
+
+kube_mount_args := -v $(kubeconfig_path):/root/.kube -v $(helm_config):/root/.config/helm -v $(helm_cache):/root/.cache/helm
+
 #   _____                    _
 #  |_   _|_ _ _ __ __ _  ___| |_ ___
 #    | |/ _` | '__/ _` |/ _ \ __/ __|
@@ -76,6 +83,19 @@ test-docs: ensure-build-image
 			cp -r /workspace/target/doc /tmp/docs/api && \
 			rm /tmp/docs/book/print.html && \
 			htmltest -c /workspace/docs/htmltest.yaml /tmp/docs'
+
+# Run e2e tests against an Agones Kubernetes cluster
+# Not part of `test` as it requires a Kubernetes cluster to be provisioned and running.
+# Use QUILKIN_IMAGE to specify which container image to use in the tests
+test-agones: ensure-kube-dirs ensure-build-image
+test-agones: QUILKIN_IMAGE ?= us-docker.pkg.dev/quilkin/release/quilkin:0.3.0
+test-agones:
+	docker run --rm $(common_rust_args) -w /workspace/agones  \
+    		--entrypoint=cargo $(BUILD_IMAGE_TAG) clippy --tests -- -D warnings
+	docker run --rm $(common_rust_args) -w /workspace/agones \
+		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
+	docker run --rm $(common_rust_args) $(kube_mount_args) -w /workspace/agones -e "QUILKIN_IMAGE=${QUILKIN_IMAGE}" \
+    		--entrypoint=cargo $(BUILD_IMAGE_TAG) test
 
 # Build all binaries, images and related artifacts
 build: binary-archive build-image
@@ -133,13 +153,19 @@ docs: ensure-build-image
 			cargo watch -s "cargo doc --workspace --no-deps && cd docs && mdbook build --dest-dir /tmp/docs/book"'
 
 # Start an interactive shell inside the build image
-# Useful for testing, or adhoc cargo commands
-shell: ensure-build-image
+# Useful for testing, or adhoc cargo, gcloud, kubectl or terraform commands
+shell: ensure-kube-dirs ensure-build-image
+	-mkdir -p $(build_path)/.gcloud
 	docker run --rm -it $(common_rust_args) \
-		--entrypoint=bash $(BUILD_IMAGE_TAG)
+		-v $(build_path)/.config/gcloud:/root/.config/gcloud $(kube_mount_args) \
+		 --entrypoint=bash $(BUILD_IMAGE_TAG)
 
 ensure-build-image: ensure-cargo-registry
 	docker build $(BUILD_IMAGE_ARG) --build-arg RUST_TOOLCHAIN=$(rust_toolchain) --tag=$(BUILD_IMAGE_TAG) $(build_path)/build-image/
 
 ensure-cargo-registry:
 	-mkdir -p $(CARGO_HOME)/registry
+
+ensure-kube-dirs:
+	-mkdir -p ~/.config/helm
+	-mkdir -p ~/.kube

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -26,16 +26,36 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 # Install packages
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y jq wget zip build-essential libssl-dev pkg-config python3-pip g++-mingw-w64-x86-64 && \
-    pip3 install live-server
+    apt-get install -y jq wget zip build-essential libssl-dev pkg-config python3-pip bash-completion g++-mingw-w64-x86-64 && \
+    pip3 install live-server && \
+    echo "source /etc/bash_completion" >> /root/.bashrc
+
+# install gcloud
+# Credit: https://cloud.google.com/sdk/docs/install#deb
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && apt-get update -y && \
+    apt-get install google-cloud-cli google-cloud-cli-gke-gcloud-auth-plugin kubectl -y && \
+    echo "source /usr/share/google-cloud-sdk/completion.bash.inc" >> /root/.bashrc && \
+    echo "source <(kubectl completion bash)" >> /root/.bashrc
+
+# install tarrafrm
+# Credit: https://learn.hashicorp.com/tutorials/terraform/install-cli
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
+    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
+    apt-get update -y && apt-get install terraform -y && \
+    terraform -install-autocomplete
+
+# install helm
+# Credit: https://helm.sh/docs/intro/install/
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && \
+    echo "source <(helm completion bash)" >> /root/.bashrc
 
 # Install htmltest
 WORKDIR /tmp
-RUN wget -O htmltest.tar.gz https://github.com/wjdp/htmltest/releases/download/v0.16.0/htmltest_0.16.0_linux_amd64.tar.gz && \
+RUN wget --quiet -O htmltest.tar.gz https://github.com/wjdp/htmltest/releases/download/v0.16.0/htmltest_0.16.0_linux_amd64.tar.gz && \
      tar -xf htmltest.tar.gz && mv ./htmltest /usr/local/bin/ && rm htmltest.tar.gz
 
 # Install Rust
-RUN wget https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \
+RUN wget --quiet https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \
     chmod +x rustup-init && \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_TOOLCHAIN && \
     rm rustup-init && \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Provides a suite of tools for setting up and running e2e integration tests of Quilkin on Agones.

This includes:
* `agones` module with setup functionality and a simple e2e test
* Convenience terraform script for Agones GKE cluster
* Documentation of setup and usage
* Update build image to include convenience tooling (which is also
eventually needed for integration with CI)
* Make target for running Agones integration tests through the build
image.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #510

**Special notes for your reviewer**:

Not sure if a module name of `agones` is a good name? But couldn't come up with anything better. Suggestions welcome.

Once we work out/if to share GameServer CRD definitions somehow, I can also do a sidecar with Quilkin test as well.