### PR TITLE
Use base64 when logging token, add fmt::Display impl for metadata::Value

### DIFF
--- a/src/config/watch/agones/crd.rs
+++ b/src/config/watch/agones/crd.rs
@@ -55,7 +55,7 @@ impl<'de> serde::Deserialize<'de> for GameServer {
 
         serde_json::from_value::<Inner>(value.clone())
             .map_err(|error| {
-                tracing::trace!(%error, ?value, "gameserver failed");
+                tracing::trace!(%error, %value, "gameserver failed");
                 Error::custom(error)
             })
             .map(

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -67,7 +67,7 @@ impl Filter for Capture {
             .insert(self.is_present_key.clone(), Value::Bool(capture.is_some()));
 
         if let Some(value) = capture {
-            tracing::trace!(key=&**self.metadata_key, value=?value, "captured value");
+            tracing::trace!(key=&**self.metadata_key, %value, "captured value");
             ctx.metadata.insert(self.metadata_key.clone(), value);
             Some(ctx.into())
         } else {

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -101,7 +101,7 @@ where
 
             match config.branches.iter().find(|(key, _)| key == value) {
                 Some((value, instance)) => {
-                    tracing::trace!(key=&*config.metadata_key, value=?value, filter=&*instance.0, "Matched against branch");
+                    tracing::trace!(key=&*config.metadata_key, %value, filter=&*instance.0, "Matched against branch");
                     metrics.packets_matched_total.inc();
                     (and_then)(ctx, &instance.1)
                 }

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -85,7 +85,10 @@ impl Filter for TokenRouter {
 
                     if ctx.endpoints.is_empty() {
                         let token: &[u8] = &**token;
-                        tracing::trace!(?token, "No endpoint matched token");
+                        tracing::trace!(
+                            token = &*base64::encode(token),
+                            "No endpoint matched token"
+                        );
                         self.metrics.packets_dropped_no_endpoint_match.inc();
                         None
                     } else {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -69,6 +69,32 @@ impl Value {
     }
 }
 
+impl std::fmt::Display for Value {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            Self::Bool(value) => value.fmt(f),
+            Self::Number(value) => value.fmt(f),
+            Self::String(value) => value.fmt(f),
+            Self::Bytes(value) => base64::encode(value).fmt(f),
+            Self::List(values) => {
+                write!(f, "[")?;
+                let mut first = true;
+                for value in values {
+                    if first {
+                        first = false;
+                    } else {
+                        write!(f, ",")?;
+                    }
+
+                    value.fmt(f)?;
+                }
+
+                write!(f, "]")
+            }
+        }
+    }
+}
+
 /// Convenience macro for generating From<T> implementations.
 macro_rules! from_value {
     (($name:ident) { $($typ:ty => $ex:expr),+ $(,)? }) => {


### PR DESCRIPTION
These just make it easier to see values in the logs, particularly values that are a bag of bytes.