### PR TITLE
Add multi-stage dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,20 +19,15 @@
 *.md
 *.png
 *.sh
-*.toml
 *.yaml
 *.zip
 *.iml
 .*
-/agones
 /benches
 /build
 /docs
 /examples
-/macros
-/proto
 /sdks
-/src
 /tests
 /target
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1.61.0 AS chef
+WORKDIR app
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+COPY rust-toolchain.toml rust-toolchain.toml
+# Build dependencies - this is the caching Docker layer!
+RUN cargo chef cook -p quilkin --release --recipe-path recipe.json
+# Build application
+COPY . .
+RUN cargo build --release --bin quilkin
+
+# We do not need the Rust toolchain to run the binary!
+FROM debian:bookworm-slim AS runtime
+WORKDIR app
+COPY --from=builder /app/target/release/quilkin /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/quilkin"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM lukemathwalker/cargo-chef:latest-rust-1.61.0 AS chef
+COPY rust-toolchain.toml rust-toolchain.toml
+RUN rustup check
 WORKDIR app
 
 FROM chef AS planner
@@ -7,7 +9,6 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-COPY rust-toolchain.toml rust-toolchain.toml
 # Build dependencies - this is the caching Docker layer!
 RUN cargo chef cook -p quilkin --release --recipe-path recipe.json
 # Build application
@@ -18,4 +19,4 @@ RUN cargo build --release --bin quilkin
 FROM debian:bookworm-slim AS runtime
 WORKDIR app
 COPY --from=builder /app/target/release/quilkin /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/quilkin"]
+ENTRYPOINT ["/usr/local/bin/quilkin", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.61.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.63.0 AS chef
 COPY rust-toolchain.toml rust-toolchain.toml
 RUN rustup check
 WORKDIR app
@@ -19,4 +19,4 @@ RUN cargo build --release --bin quilkin
 FROM debian:bookworm-slim AS runtime
 WORKDIR app
 COPY --from=builder /app/target/release/quilkin /usr/local/bin
-ENTRYPOINT ["/usr/local/bin/quilkin", "run"]
+ENTRYPOINT ["quilkin"]


### PR DESCRIPTION
Fixes #553 at least for me. This is much faster on both macOS and Windows (it also removes the WSL requirement on Windows as you can now build with `docker build .`), and thanks to `cargo-chef`, it has much better caching. This doesn't touch the CI infra, as I figured it would be better to build up the support needed first.

@markmandel is there anything else we need to include in the image other than the binary?