### PR TITLE
Improve build-image incremental workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,19 +34,12 @@
 /sdks
 /src
 /tests
-target/debug
-target/release
-target/**.d
-target/*/*/build
-target/*/*/deps
-target/*/*/incremental
-target/criterion
-target/doc
-target/tmp
+/target
 
 # windows files
 *.exe
 *.rlib
 
+!target/build-image/x86_64-unknown-linux-gnu/release/quilkin
 !dependencies-src.zip
 !image/quilkin.yaml

--- a/build/Makefile
+++ b/build/Makefile
@@ -41,7 +41,8 @@ IMAGE_TAG ?= ${REPOSITORY}quilkin:$(package_version)
 MINIKUBE_PROFILE ?= quilkin
 
 common_rust_args := -v $(project_path):/workspace -w /workspace \
-					-v $(CARGO_HOME)/registry:/usr/local/cargo/registry
+					-v $(CARGO_HOME)/registry:/usr/local/cargo/registry \
+					-e "CARGO_TARGET_DIR=/workspace/target/build-image"
 
 KUBECONFIG ?= ~/.kube/config
 kubeconfig_path := $(dir $(KUBECONFIG))
@@ -101,37 +102,34 @@ test-docs: ensure-build-image
 # Build all binaries, images and related artifacts
 build: binary-archive build-image
 
-# Build all debug and release binaries
-build-all-binaries: ensure-build-image build-linux-binary build-macos-binary
+# Build all binaries
+build-all-binaries: ensure-build-image build-linux-binary build-macos-binary build-windows-binary
 
-# Build an archive all debug and release binaries
+# Build an archive all binaries
 binary-archive: ensure-build-image build-all-binaries
-	docker run --rm $(common_rust_args) \
-			--entrypoint=bash $(BUILD_IMAGE_TAG) -c 'zip quilkin-$(package_version).zip ./target/*/*/quilkin ./target/*/*/quilkin.exe'
+	docker run --rm $(common_rust_args) -w /workspace/target/build-image \
+			--entrypoint=bash $(BUILD_IMAGE_TAG) -c 'zip ../../quilkin-$(package_version).zip ./*/*/quilkin ./*/*/quilkin.exe'
 
-# Build release and debug binaries for x86_64-unknown-linux-gnu
+# Build binary for x86_64-unknown-linux-gnu
 build-linux-binary: ensure-build-image
-	docker run --rm $(common_rust_args) \
-		--entrypoint=cargo $(BUILD_IMAGE_TAG) build --target x86_64-unknown-linux-gnu
 	docker run --rm $(common_rust_args) \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) build --target x86_64-unknown-linux-gnu --release
 
-# Build release and debug binaries for x86_64-pc-windows-gnu
+# Build binary for x86_64-pc-windows-gnu
 build-windows-binary: ensure-build-image
-	docker run --rm $(common_rust_args) \
-		--entrypoint=cargo $(BUILD_IMAGE_TAG) build --target x86_64-pc-windows-gnu
 	docker run --rm $(common_rust_args) \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) build --target x86_64-pc-windows-gnu --release
 
-# Build release and debug binaries for x86_64-apple-darwin
+# Build binary for x86_64-apple-darwin
 build-macos-binary:
 	docker run --rm -v $(project_path):/workspace -w /workspace \
 		-v $(CARGO_HOME)/registry:/root/.cargo/registry \
+		-e "CARGO_TARGET_DIR=/workspace/target/build-image" \
 		-e "CC=o64-clang" -e "CXX=o64-clang++" \
         joseluisq/rust-linux-darwin-builder:$(rust_toolchain) \
-        	sh -c "rustup target add x86_64-apple-darwin && cargo build --target x86_64-apple-darwin && cargo build --release --target x86_64-apple-darwin"
+        	sh -c "rustup target add x86_64-apple-darwin && cargo build --release --target x86_64-apple-darwin"
 
-# Build release and debug container images.
+# Build container image.
 # Use either `REPOSITORY` to specify a container repository (defaults to blank/none), or use `IMAGE_TAG` argument to specify
 # the entire image name and tag. Defaults to `quilkin:${version}-${git-sha}`.
 build-image: ensure-build-image build-linux-binary
@@ -140,8 +138,7 @@ build-image:
 		--entrypoint=bash $(BUILD_IMAGE_TAG) -c 'cargo about generate license.html.hbs > license.html'
 	docker run --rm $(common_rust_args) \
 		--entrypoint=bash $(BUILD_IMAGE_TAG) -c './image/archive_dependencies.sh'
-	docker build -t $(IMAGE_TAG)-debug --build-arg PROFILE=debug -f $(project_path)/image/Dockerfile $(project_path)
-	docker build -t $(IMAGE_TAG) --build-arg PROFILE=release -f $(project_path)/image/Dockerfile $(project_path)
+	docker build -t $(IMAGE_TAG) -f $(project_path)/image/Dockerfile $(project_path)
 
 # Builds Quilkin, pushes it to a repository (use REPOSITORY arg to set value)
 # and then runs the Agones integration tests. See targets `build-images` and `push` for more options and details.
@@ -172,7 +169,6 @@ push:
 ifndef SKIP_BUILD_IMAGE
 push: build-image
 endif
-	docker push $(IMAGE_TAG)-debug
 	docker push $(IMAGE_TAG)
 
 # Convenience target to build and push quilkin images into a minikube instance

--- a/build/Makefile
+++ b/build/Makefile
@@ -39,10 +39,10 @@ endif
 REPOSITORY ?= ""
 IMAGE_TAG ?= ${REPOSITORY}quilkin:$(package_version)
 MINIKUBE_PROFILE ?= quilkin
-
+CARGO_TARGET_DIR ?= /workspace/target/build-image
 common_rust_args := -v $(project_path):/workspace -w /workspace \
 					-v $(CARGO_HOME)/registry:/usr/local/cargo/registry \
-					-e "CARGO_TARGET_DIR=/workspace/target/build-image"
+					-e "CARGO_TARGET_DIR=$(CARGO_TARGET_DIR)"
 
 KUBECONFIG ?= ~/.kube/config
 kubeconfig_path := $(dir $(KUBECONFIG))
@@ -93,9 +93,9 @@ test-docs: ensure-build-image
 	docker run --rm $(common_rust_args) \
 		--entrypoint=bash $(BUILD_IMAGE_TAG) -c \
 			'export RUSTDOCFLAGS="-Dwarnings" && mkdir /tmp/docs && \
-			mkdir -p ./target/doc; \
+			mkdir -p "$(CARGO_TARGET_DIR)/doc"; \
 			cargo doc --workspace --no-deps && cd docs && mdbook build --dest-dir /tmp/docs/book && \
-			cp -r /workspace/target/doc /tmp/docs/api && \
+			cp -r "$(CARGO_TARGET_DIR)/doc" /tmp/docs/api && \
 			rm /tmp/docs/book/print.html && \
 			htmltest -c /workspace/docs/htmltest.yaml /tmp/docs'
 
@@ -107,7 +107,7 @@ build-all-binaries: ensure-build-image build-linux-binary build-macos-binary bui
 
 # Build an archive all binaries
 binary-archive: ensure-build-image build-all-binaries
-	docker run --rm $(common_rust_args) -w /workspace/target/build-image \
+	docker run --rm $(common_rust_args) -w $(CARGO_TARGET_DIR) \
 			--entrypoint=bash $(BUILD_IMAGE_TAG) -c 'zip ../../quilkin-$(package_version).zip ./*/*/quilkin ./*/*/quilkin.exe'
 
 # Build binary for x86_64-unknown-linux-gnu
@@ -124,7 +124,7 @@ build-windows-binary: ensure-build-image
 build-macos-binary:
 	docker run --rm -v $(project_path):/workspace -w /workspace \
 		-v $(CARGO_HOME)/registry:/root/.cargo/registry \
-		-e "CARGO_TARGET_DIR=/workspace/target/build-image" \
+		-e "CARGO_TARGET_DIR=$(CARGO_TARGET_DIR)" \
 		-e "CC=o64-clang" -e "CXX=o64-clang++" \
         joseluisq/rust-linux-darwin-builder:$(rust_toolchain) \
         	sh -c "rustup target add x86_64-apple-darwin && cargo build --release --target x86_64-apple-darwin"
@@ -192,7 +192,7 @@ docs: ensure-build-image
 	docker run -it --rm $(common_rust_args) -p 3000:3000 \
 		--entrypoint=bash $(BUILD_IMAGE_TAG) -c \
 			'mkdir /tmp/docs && (live-server -p 3000 /tmp/docs &) && \
-			mkdir -p ./target/doc; ln -s $$(pwd)/target/doc /tmp/docs/api && \
+			mkdir -p "$(CARGO_TARGET_DIR)/doc"; ln -s "$(CARGO_TARGET_DIR)/doc" /tmp/docs/api && \
 			cargo watch -s "cargo doc --workspace --no-deps && cd docs && mdbook build --dest-dir /tmp/docs/book"'
 
 # Start an interactive shell inside the build image

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -53,16 +53,7 @@ steps:
     args:
       - '-c'
       - 'timeout --signal=INT --preserve-status 5s docker run --rm ${_REPOSITORY}quilkin:$(make version)'
-    id: test-quilkin-debug
-    waitFor:
-      - build
-  - name: gcr.io/cloud-builders/docker
-    dir: ./build
-    entrypoint: bash
-    args:
-      - '-c'
-      - 'timeout --signal=INT --preserve-status 5s docker run --rm ${_REPOSITORY}quilkin:$(make version)-debug'
-    id: test-quilkin-release
+    id: test-quilkin-image
     waitFor:
       - build
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -12,20 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG PROFILE
-
 FROM gcr.io/distroless/cc:nonroot as base
 WORKDIR /
 COPY ./license.html .
 COPY ./dependencies-src.zip .
 COPY --chown=nonroot:nonroot ./image/quilkin.yaml /etc/quilkin/quilkin.yaml
+COPY ./target/build-image/x86_64-unknown-linux-gnu/release/quilkin .
 
-FROM base as release
-COPY ./target/x86_64-unknown-linux-gnu/release/quilkin .
-
-FROM base as debug
-COPY ./target/x86_64-unknown-linux-gnu/debug/quilkin .
-
-FROM $PROFILE
 USER nonroot:nonroot
 ENTRYPOINT ["/quilkin", "--config", "/etc/quilkin/quilkin.yaml", "run"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Several improvements to workflows that flow through the build-image to improve build and iteration times.

This includes:

## Removal of debug images

We don't need this anymore, so no reason to build it for each architecture.

## Use `build-image` target directory

I realised that when mixing the `build-image` workflow with local rust tools, that going between them, they would invalidate each other's incremental cache, since it was fingerprinted on absolute directories - drastically expanding build times between iterations.

Moving to a specific target directory for `build-image` usage drastically improves both the incremental build times of images, and every other workflow through `build-image`, such as e2e testing. (`make test-agones` can be used iteratively now).

## More aggressive docker ignore

We only use a few files for the Docker image, so let's ignore everything else. Took the docker context down from 1GB+ to < 50MB.

On a linux machine all this brings incremental builds down from 10's of minutes to a minute or less, since only what has changed is compiled and pushed as we can now take advantage of rust incremental build and docker image caching.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #553

**Special notes for your reviewer**:

I know what the impact is on a Linux environment, would be good to know how it improves things on a Mac and Windows environment where there is an extra layer of virtualisation.
