### PR TITLE
Clarify packet direction in traces, use base64 for bytes_to_string

### DIFF
--- a/src/utils/debug.rs
+++ b/src/utils/debug.rs
@@ -20,7 +20,5 @@
 /// Attempt to convert a packet into a string, if it is one, otherwise return some human
 /// readable details about the packet.
 pub(crate) fn bytes_to_string(bytes: &[u8]) -> String {
-    std::str::from_utf8(bytes)
-        .map(str::to_string)
-        .unwrap_or_else(|_| format!("<raw bytes :: len: {}>", bytes.len()))
+    base64::encode(bytes)
 }


### PR DESCRIPTION
This improves the traces from sending and receiving packets to clarify the direction, and also moves `bytes_to_string` to output base64 instead of trying to read the data as a string.