### PR TITLE
Resubscribe to resources after disconnect, fix test flakiness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ tracing-subscriber = { version = "0.3.9", features = ["json", "env-filter"] }
 tryhard = "0.4.0"
 uuid = { version = "1", default-features = false, features = ["v4"] }
 enum-map = "=2.1.0"
-notify = "5.0.0-pre.15"
+notify = "=5.0.0-pre.15"
 serde_stacker = "0.1.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/config/watch/fs.rs
+++ b/src/config/watch/fs.rs
@@ -66,10 +66,10 @@ mod tests {
         let dest = Arc::new(crate::Config::default());
         let tmp_dir = tempdir::TempDir::new("path").unwrap();
         let file_path = tmp_dir.into_path().join("config.yaml");
-        tokio::spawn(watch(dest.clone(), file_path.clone()));
         tokio::fs::write(&file_path, serde_yaml::to_string(&source).unwrap())
             .await
             .unwrap();
+        let _handle = tokio::spawn(watch(dest.clone(), file_path.clone()));
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         source.clusters.modify(|clusters| {
@@ -83,8 +83,11 @@ mod tests {
                 ));
         });
 
-        std::fs::write(&file_path, serde_yaml::to_string(&source).unwrap()).unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::fs::write(&file_path, serde_yaml::to_string(&source).unwrap())
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         assert_eq!(source, dest);
     }


### PR DESCRIPTION
Previously we were reconnecting to the stream, but we weren't resubscribing to resources, so now the stream tracks what resources it's requested in the past and makes fresh discovery requests on reconnect.