### PR TITLE
Agones GameServer + Quilkin sidecar test

### DIFF
--- a/agones/src/pod.rs
+++ b/agones/src/pod.rs
@@ -17,7 +17,7 @@
 #[cfg(test)]
 mod tests {
     use k8s_openapi::{
-        api::core::v1::{Container, Pod, PodSpec},
+        api::core::v1::{Pod, PodSpec},
         apimachinery::pkg::apis::meta::v1::ObjectMeta,
     };
     use kube::{
@@ -28,7 +28,7 @@ mod tests {
     use std::time::Duration;
     use tokio::time::timeout;
 
-    use crate::Client;
+    use crate::{quilkin_container, Client};
 
     #[tokio::test]
     async fn create_quilkin_pod() {
@@ -41,11 +41,7 @@ mod tests {
                 ..Default::default()
             },
             spec: Some(PodSpec {
-                containers: vec![Container {
-                    name: "quilkin".into(),
-                    image: Some(client.quilkin_image.clone()),
-                    ..Default::default()
-                }],
+                containers: vec![quilkin_container(&client, None)],
                 ..Default::default()
             }),
             status: None,

--- a/build/Makefile
+++ b/build/Makefile
@@ -185,7 +185,7 @@ run-test-agones:
 	docker run --rm $(DOCKER_RUN_ARGS) $(common_rust_args) $(kube_mount_args) -w /workspace/agones \
 		--entrypoint=kubectl $(BUILD_IMAGE_TAG) get ns
 	docker run --rm $(DOCKER_RUN_ARGS) $(common_rust_args) $(kube_mount_args) -w /workspace/agones \
-			-e "IMAGE_TAG=${IMAGE_TAG}" --entrypoint=cargo $(BUILD_IMAGE_TAG) test $(ARGS)
+			-e "RUST_BACKTRACE=1" -e "IMAGE_TAG=${IMAGE_TAG}" --entrypoint=cargo $(BUILD_IMAGE_TAG) test $(ARGS)
 
 # Convenience target to build and push quilkin images to a repository.
 # Use `REPOSITORY` arg to specify the repository to push to.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Implements an integration test wherein we use Quilkin as a sidecar to an
Agones GameServer container.

Also includes some updates to the test harnesses:
* Function to create a common Quilkin container
* Fixed odd (?) bug where k8s client would sometimes close at the end of tests, failing subsequent other tests.
* Convenience function for grabbing the address of a GameServer so you  can send packets to it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #510

**Special notes for your reviewer**:

