### PR TITLE
Add ready probe endpoint

### DIFF
--- a/src/admin/health.rs
+++ b/src/admin/health.rs
@@ -57,9 +57,9 @@ impl Health {
 
 #[cfg(test)]
 mod tests {
-    use crate::proxy::health::Health;
+    use super::*;
+
     use hyper::StatusCode;
-    use std::panic;
 
     #[test]
     fn panic_hook() {
@@ -68,7 +68,7 @@ mod tests {
         let response = health.check_healthy();
         assert_eq!(response.status(), StatusCode::OK);
 
-        let _ = panic::catch_unwind(|| {
+        let _ = std::panic::catch_unwind(|| {
             panic!("oh no!");
         });
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-mod health;
 mod sessions;
 
-pub(crate) use health::Health;
 pub use sessions::SessionKey;
 
 use std::{


### PR DESCRIPTION
Adds a k8s ready probe endpoint to check when a Quilkin instance is ready to receive traffic, which currently maps to whether it has any endpoints available to forward traffic to.

Closes #590

