### PR TITLE
Remove allocated check for deleted gameserver events

### DIFF
--- a/src/config/watch/agones.rs
+++ b/src/config/watch/agones.rs
@@ -151,10 +151,6 @@ impl Watcher {
             }
 
             Event::Deleted(server) => {
-                if !server.is_allocated() {
-                    return Ok(());
-                }
-
                 let endpoint = Endpoint::try_from(server)?;
                 tracing::trace!(?endpoint, "Deleting endpoint");
                 self.config.clusters.modify(|clusters| {


### PR DESCRIPTION
This check was wrong and prevents Quilkin from removing stale endpoints unless it gets a restarted event.