### PR TITLE
Fix metrics namespace not always being present

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,7 +34,8 @@ pub const WRITE_DIRECTION_LABEL: &str = "write";
 /// Returns the [prometheus::Registry] containing all the metrics
 /// registered in Quilkin.
 pub fn registry() -> &'static Registry {
-    static REGISTRY: Lazy<Registry> = Lazy::new(|| Registry::new_custom(Some("quilkin".into()), None).unwrap());
+    static REGISTRY: Lazy<Registry> =
+        Lazy::new(|| Registry::new_custom(Some("quilkin".into()), None).unwrap());
 
     &*REGISTRY
 }
@@ -103,8 +104,7 @@ pub(crate) static PACKETS_DROPPED: Lazy<IntCounterVec> = Lazy::new(|| {
 /// Create a generic metrics options.
 /// Use [filter_opts] instead if the intended target is a filter.
 pub fn opts(name: &str, subsystem: &str, description: &str) -> Opts {
-    Opts::new(name, description)
-        .subsystem(subsystem)
+    Opts::new(name, description).subsystem(subsystem)
 }
 
 pub fn histogram_opts(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,7 +34,7 @@ pub const WRITE_DIRECTION_LABEL: &str = "write";
 /// Returns the [prometheus::Registry] containing all the metrics
 /// registered in Quilkin.
 pub fn registry() -> &'static Registry {
-    static REGISTRY: Lazy<Registry> = Lazy::new(Registry::default);
+    static REGISTRY: Lazy<Registry> = Lazy::new(|| Registry::new_custom(Some("quilkin".into()), None).unwrap());
 
     &*REGISTRY
 }
@@ -104,7 +104,6 @@ pub(crate) static PACKETS_DROPPED: Lazy<IntCounterVec> = Lazy::new(|| {
 /// Use [filter_opts] instead if the intended target is a filter.
 pub fn opts(name: &str, subsystem: &str, description: &str) -> Opts {
     Opts::new(name, description)
-        .namespace("quilkin")
         .subsystem(subsystem)
 }
 


### PR DESCRIPTION
Some metrics were missing the quilkin prefix, this fixes it so that can't happen.