### PR TITLE
Allow gameservers to not have port

### DIFF
--- a/src/config/watch/agones/crd.rs
+++ b/src/config/watch/agones/crd.rs
@@ -270,7 +270,7 @@ impl TryFrom<GameServer> for Endpoint {
             .ports
             .as_ref()
             .and_then(|ports| ports.first().map(|status| status.port))
-            .ok_or_else(|| tonic::Status::internal("No port found for game server"))?;
+            .unwrap_or_default();
         let filter_metadata = crate::endpoint::Metadata { tokens };
         Ok(Self::with_metadata((address, port).into(), filter_metadata))
     }


### PR DESCRIPTION
When gameservers are deleted, their port is removed. This fixes it so that the gameserver will have a port of zero instead of returning an error.
