### PR TITLE
Add Build Images to CI results

### DIFF
--- a/build/ci/github-bot/go.mod
+++ b/build/ci/github-bot/go.mod
@@ -14,13 +14,41 @@
 
 module github-bot
 
-go 1.16
+go 1.19
 
 require (
 	github.com/GoogleCloudPlatform/cloud-build-notifiers/lib/notifiers v0.0.0-20210219212036-163c92a64b27
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/google/go-github/v35 v35.2.0
 	golang.org/x/oauth2 v0.0.0-20210201163806-010130855d6c
-	golang.org/x/tools v0.1.1 // indirect
 	google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384
+)
+
+require (
+	cloud.google.com/go v0.76.0 // indirect
+	cloud.google.com/go/storage v1.13.0 // indirect
+	github.com/antlr/antlr4 v0.0.0-20210203043838-a60c32d36933 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/cel-go v0.7.1 // indirect
+	github.com/google/go-cmp v0.5.5 // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
+	github.com/jstemmer/go-junit-report v0.9.1 // indirect
+	github.com/stoewer/go-strcase v1.2.0 // indirect
+	go.opencensus.io v0.22.6 // indirect
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
+	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	golang.org/x/tools v0.1.1 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/api v0.39.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/grpc v1.36.1 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/client-go v11.0.0+incompatible // indirect
 )

--- a/build/ci/github-bot/go.sum
+++ b/build/ci/github-bot/go.sum
@@ -164,7 +164,6 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -212,7 +211,6 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.1 h1:Kvvh58BN8Y9/lBi7hTekvtMpm07eUZ0ck5pRHpsMWrY=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -248,7 +246,6 @@ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4 h1:b0LrWgu8+q7z4J+0Y3Umo5q1dL7NXBkKBWkaVkAq17E=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -273,7 +270,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -307,7 +303,6 @@ golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4 h1:EZ2mChiOa8udjfp6rRmswTbtZN/QzUQp4ptM4rnjHvc=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
@@ -370,7 +365,6 @@ golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=

--- a/build/ci/github-bot/main.go
+++ b/build/ci/github-bot/main.go
@@ -107,6 +107,10 @@ func (g *githubNotifier) SendNotification(ctx context.Context, build *cloudbuild
 
 	// if builds fail, exit, as it's our fault, and there is no point in retrying.
 	body := new(bytes.Buffer)
+
+	// hack to allow backticks in multiline strings
+	build.Substitutions["_DELIM"] = "`"
+
 	if build.Status == cloudbuild.Build_SUCCESS {
 		if err := g.successTemplate.Execute(body, build); err != nil {
 			log.Errorf("Error executing success template: %v, in build %s", err, build.Id)
@@ -135,7 +139,7 @@ func (g *githubNotifier) SendNotification(ctx context.Context, build *cloudbuild
 func (g *githubNotifier) clearBotComments(ctx context.Context, pr int) error {
 	comments, _, err := g.client.Issues.ListComments(ctx, owner, repo, pr, &github.IssueListCommentsOptions{})
 	if err != nil {
-		log.Errorf("Error retrieving comment history: %v on PR with id: %s", err, pr)
+		log.Errorf("Error retrieving comment history: %v on PR with id: %d", err, pr)
 		return nil
 	}
 
@@ -154,6 +158,11 @@ const successTemplate = `
 
 _Build Id: {{ .Id }}_
 
+The following development images have been built, and will exist for the next 30 days:
+{{ range .Artifacts.Images }}
+* [{{ . }}](https://{{ . }})
+{{ end }}
+
 To build this version:
 ` + "```" + `
 git fetch git@github.com:googleforgames/quilkin.git pull/{{ $pr }}/head:pr_{{ $pr }} && git checkout pr_{{ $pr }}
@@ -161,6 +170,10 @@ cargo build
 ` + "```"
 
 const failureTemplate = `
+{{ $sha := .Substitutions.SHORT_SHA }}
+{{ $delim := .Substitutions._DELIM }}
+{{ $repo := .Substitutions._REPOSITORY }}
+
 **Build Failed :sob:**
 
 _Build Id: {{ .Id }}_
@@ -170,5 +183,9 @@ Status: {{ .StatusDetail }}
  - [Cloud Build view]({{.LogUrl}})
  - [Cloud Build log download](https://storage.googleapis.com/quilkin-build-logs/log-{{ .Id }}.txt)
 
-To get permission to view the Cloud Build view, join the [quilkin-discuss](https://groups.google.com/forum/#!forum/quilkin-discuss) Google Group. 
+To get permission to view the Cloud Build view, join the [quilkin-discuss](https://groups.google.com/forum/#!forum/quilkin-discuss) Google Group.
+
+Filter with the Git Commit {{ $delim }}{{ $sha }}{{ $delim }} within [{{ $repo }}/quilkin](https://{{ $repo }}/quilkin) to see if a development image is available from this build, and can be used for debugging purposes.
+
+Development images are retained for at least 30 days.
 `

--- a/build/ci/github-bot/main.go
+++ b/build/ci/github-bot/main.go
@@ -159,8 +159,8 @@ const successTemplate = `
 _Build Id: {{ .Id }}_
 
 The following development images have been built, and will exist for the next 30 days:
-{{ range .Artifacts.Images }}
-* [{{ . }}](https://{{ . }})
+{{ range .Results.Images }}
+* [{{ .Name }}](https://{{ .Name }})
 {{ end }}
 
 To build this version:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -86,4 +86,7 @@ timeout: 7200s
 substitutions:
   _BUILD_IMAGE_TAG: us-docker.pkg.dev/${PROJECT_ID}/ci/build-image
   _REPOSITORY: us-docker.pkg.dev/${PROJECT_ID}/ci/
+artifacts:
+  images:
+    - ${_REPOSITORY}quilkin
 logsBucket: "gs://quilkin-build-logs"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Added the image artifacts to successful builds.

Since Cloud Build doesn't track pushed images on failure (and the image may/may not exist depending on where it failed) I can only provide directions on how to search for the image after the fact.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #593

**Special notes for your reviewer**:

Also updated the Go version, and now the CI container registry is public, so one can search for development images.

If you can think of any other improvements, please suggest them!
