### PR TITLE
Fixes for CI failure on `quilkin run #574`

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,6 +46,33 @@ steps:
     args:
       - build
     id: build
+
+  #
+  # Run the built images for 5 seconds in a few standard configurations, to test basic common scenarios
+  #
+
+  # Default file config
+  - name: gcr.io/cloud-builders/docker
+    dir: ./build
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'timeout --signal=INT --preserve-status 5s docker run --rm ${_REPOSITORY}quilkin:$(make version)'
+    id: test-quilkin-image-default-config-file
+    waitFor:
+      - build
+
+  # Command line configuration
+  - name: gcr.io/cloud-builders/docker
+    dir: ./build
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'timeout --signal=INT --preserve-status 5s docker run -v /tmp:/etc/quilkin/ --entrypoint=/quilkin --rm ${_REPOSITORY}quilkin:$(make version) run --to="127.0.0.1:0"'
+    id: test-quilkin-image-command-line
+    waitFor:
+      - build
+
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:

--- a/docs/src/using.md
+++ b/docs/src/using.md
@@ -12,15 +12,16 @@ The release binary can be downloaded from the
 
 ## Container Image
 
-For each release, there are both a release and debug container image built and
-hosted on Google Cloud [Artifact Registry](https://cloud.google.com/artifact-registry)
-listed for each [release](https://github.com/googleforgames/quilkin/releases).
+For each [release](https://github.com/googleforgames/quilkin/releases), there is a container image built and
+hosted on Google Cloud [Artifact Registry](https://cloud.google.com/artifact-registry).
 
 The production release can be found under the tag: 
 
 ```
 us-docker.pkg.dev/quilkin/release/quilkin:{version}
 ```
+
+Which can be browsed as [us-docker.pkg.dev/quilkin/release/quilkin](https://us-docker.pkg.dev/quilkin/release/quilkin).
 
 ## Command-Line Interface
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,16 +91,12 @@ impl Cli {
         );
 
         let config = Arc::new(Self::read_config(self.config)?);
-        let _admin_task = if self.no_admin {
+        if self.no_admin {
             config.admin.remove();
-            None
-        } else {
-            if let Some(address) = self.admin_address {
-                config
-                    .admin
-                    .store(Arc::new(crate::config::Admin { address }));
-            }
-            Some(tokio::spawn(crate::admin::server(config.clone())))
+        } else if let Some(address) = self.admin_address {
+            config
+                .admin
+                .store(Arc::new(crate::config::Admin { address }));
         };
 
         let (shutdown_tx, shutdown_rx) = watch::channel::<()>(());

--- a/src/config.rs
+++ b/src/config.rs
@@ -570,4 +570,10 @@ dynamic:
             assert!(format!("{error:?}").contains("unknown field"));
         }
     }
+
+    #[test]
+    fn config_default() {
+        let config = Config::default();
+        assert!(config.admin.is_some());
+    }
 }

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -116,10 +116,10 @@ impl<T: Clone + Default> Slot<T> {
     }
 }
 
-impl<T> Default for Slot<T> {
+impl<T: Default> Default for Slot<T> {
     fn default() -> Self {
         Self {
-            inner: <_>::default(),
+            inner: Arc::new(ArcSwapOption::new(Some(Default::default()))),
             watcher: <_>::default(),
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

This includes several fixes, tweaks and small improvements to #574 that will get it through CI:

* Fix bug in `Slot impl Default` that would cause the default Admin config to be `None`.
* Fix double creation of Admin server
* Return cloudbuild timeout tests for easier CI debugging, and add one for command line config.
* Fixes and small additions to the "using" documentation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Sometimes the easiest way to provide feedback is a PR on a PR 😃
