### PR TITLE
Add short poll to xDS clients as workaround, improve xDS tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ uuid = { version = "1", default-features = false, features = ["v4"] }
 enum-map = "=2.1.0"
 notify = "=5.0.0-pre.15"
 serde_stacker = "0.1.5"
+tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,7 @@ impl Config {
                 return;
             }
 
-            tracing::trace!(endpoints = ?cluster.endpoints().map(|e| e.address.to_string()).collect::<Vec<_>>(), "applying new endpoints");
+            tracing::trace!(endpoints = %serde_json::to_value(&cluster).unwrap(), "applying new endpoints");
             self.clusters.modify(|clusters| {
                 clusters.insert(cluster.clone());
             });

--- a/src/config/watch/agones.rs
+++ b/src/config/watch/agones.rs
@@ -132,10 +132,11 @@ impl Watcher {
                 }
 
                 let endpoint = Endpoint::try_from(server)?;
-                tracing::trace!(?endpoint, "Adding endpoint");
+                tracing::trace!(endpoint=%serde_json::to_value(&endpoint).unwrap(), "Adding endpoint");
                 self.config.clusters.modify(|clusters| {
                     clusters.default_cluster_mut().insert(endpoint.clone());
                 });
+                tracing::trace!(clusters=%serde_json::to_value(&self.config.clusters.load()).unwrap(), "current clusters");
             }
 
             Event::Restarted(servers) => {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -125,7 +125,12 @@ impl Proxy {
 
             stream.send(ResourceType::Endpoint, &[]).await?;
             stream.send(ResourceType::Listener, &[]).await?;
-            Some(stream)
+            Some(tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                    stream.send(ResourceType::Endpoint, &[]).await.unwrap();
+                }
+            }))
         } else {
             None
         };
@@ -243,7 +248,7 @@ impl Proxy {
     ) {
         let clusters = args.config.clusters.load();
 
-        tracing::trace!(?clusters, "Clusters available");
+        tracing::trace!(clusters=%serde_json::to_value(&clusters).unwrap(), "Clusters available");
 
         let endpoints: Vec<_> = clusters.endpoints().collect();
         if endpoints.is_empty() {

--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -19,7 +19,7 @@ use std::{pin::Pin, sync::Arc};
 use cached::Cached;
 use futures::Stream;
 use tokio_stream::StreamExt;
-use tracing::Instrument;
+use tracing_futures::Instrument;
 
 use crate::{
     config::Config,
@@ -53,10 +53,18 @@ pub struct ControlPlane {
     watchers: Arc<crate::xds::resource::ResourceMap<Watchers>>,
 }
 
-#[derive(Default)]
 struct Watchers {
-    channels: parking_lot::Mutex<Vec<tokio::sync::watch::Sender<()>>>,
+    sender: tokio::sync::watch::Sender<()>,
     version: std::sync::atomic::AtomicU64,
+}
+
+impl Default for Watchers {
+    fn default() -> Self {
+        Self {
+            sender: tokio::sync::watch::channel(()).0,
+            version: <_>::default(),
+        }
+    }
 }
 
 impl ControlPlane {
@@ -98,19 +106,8 @@ impl ControlPlane {
         watchers
             .version
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let mut channels = watchers.channels.lock();
-        tracing::trace!(%resource_type, watchers = channels.len(), "pushing update");
-        let mut i = 0;
-        while i < channels.len() {
-            if channels[i].send(()).is_err() {
-                tracing::trace!("removing channel");
-                channels.swap_remove(i);
-                i = i.saturating_sub(1);
-            } else {
-                tracing::trace!("sending channel update");
-                i += 1;
-            }
-        }
+        tracing::trace!(%resource_type, watchers=watchers.sender.receiver_count(), "pushing update");
+        let _ = watchers.sender.send(());
     }
 
     fn discovery_response(
@@ -165,26 +162,24 @@ impl ControlPlane {
 
         let node = message.node.clone().unwrap();
         let resource_type: ResourceType = message.type_url.parse()?;
-        tracing::trace!(id = %node.id, %resource_type, "new request");
+        tracing::trace!(id = %node.id, %resource_type, "initial request");
         metrics::DISCOVERY_REQUESTS
             .with_label_values(&[&*node.id, resource_type.type_url()])
             .inc();
-        let (tx, rx) = tokio::sync::watch::channel(());
-        self.watchers[resource_type].channels.lock().push(tx);
+        let mut rx = self.watchers[resource_type].sender.subscribe();
         let mut pending_acks = cached::TimedCache::with_lifespan(1);
         let this = Self::clone(self);
         let response = this.discovery_response(&node.id, resource_type, &message.resource_names)?;
         pending_acks.cache_set(response.nonce.clone(), ());
 
+        let id = node.id.clone();
         Ok(Box::pin(async_stream::try_stream! {
             yield response;
-            tokio::pin!(rx);
-            tokio::pin!(streaming);
 
             loop {
                 tokio::select! {
                     _ = rx.changed() => {
-                        yield this.discovery_response(&node.id, resource_type, &message.resource_names).map(|response| {
+                        yield this.discovery_response(&id, resource_type, &message.resource_names).map(|response| {
                             pending_acks.cache_set(response.nonce.clone(), ());
                             response
                         })?;
@@ -199,7 +194,7 @@ impl ControlPlane {
                             }
                         };
 
-                        let id = new_message.node.as_ref().map(|node| &*node.id).unwrap_or_default();
+                        let id = new_message.node.as_ref().map(|node| &*node.id).unwrap_or(&*id);
                         let resource_type = match new_message.type_url.parse::<ResourceType>() {
                             Ok(value) => value,
                             Err(error) => {
@@ -208,32 +203,33 @@ impl ControlPlane {
                             }
                         };
 
-                        tracing::trace!(%id, %resource_type, "new request");
+                        tracing::trace!("new request");
                         metrics::DISCOVERY_REQUESTS.with_label_values(&[id, resource_type.type_url()]).inc();
 
                         if let Some(error) = &new_message.error_detail {
                             metrics::NACKS.with_label_values(&[id, resource_type.type_url()]).inc();
-                            tracing::error!(%id, %resource_type, nonce = %new_message.response_nonce, ?error, "NACK");
+                            tracing::error!(nonce = %new_message.response_nonce, ?error, "NACK");
                             // Currently just resend previous discovery response.
                         } else if uuid::Uuid::parse_str(&new_message.response_nonce).is_ok() {
                             if pending_acks.cache_get(&new_message.response_nonce).is_some() {
-                                tracing::info!(%id, %resource_type, nonce = %new_message.response_nonce, "ACK");
+                                tracing::info!(nonce = %new_message.response_nonce, "ACK");
                                 continue
                             } else {
-                                tracing::trace!(%id, %resource_type, nonce = %new_message.response_nonce, "Unknown nonce: could not be found in cache");
+                                tracing::trace!(nonce = %new_message.response_nonce, "Unknown nonce: could not be found in cache");
                                 continue
                             }
                         }
 
-                        yield this.discovery_response(&node.id, resource_type, &message.resource_names).map(|response| {
+                        yield this.discovery_response(id, resource_type, &message.resource_names).map(|response| {
                             pending_acks.cache_set(response.nonce.clone(), ());
                             response
-                        })?;
+                        }).unwrap();
                     }
                 }
-
             }
-        }))
+
+            tracing::info!("terminating stream");
+        }.instrument(tracing::info_span!("xds_stream", %node.id, %resource_type))))
     }
 }
 


### PR DESCRIPTION
Currently for some reason the management server is not sending back to active clients changes because there is seemingly no receivers. This is a temporary workaround to have the client constantly polling for new changes so that will stay up to date, while we work on addressing the management's bi-directional communication.


This also improves some of the tracing for the xds stream to place relevant information in a span.