### PR TITLE
Add ASN maxmind database integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,13 +50,18 @@ cached = "0.34.0"
 chrono = "0.4.20"
 clap = { version = "3.1.2", features = ["cargo", "derive", "env"] }
 dashmap = "4.0.2"
+dirs2 = "3.0.1"
 either = "1.6.1"
+enum-map = "=2.1.0"
 eyre = "0.6.7"
 futures = "0.3.21"
-hyper = "0.14.17"
+hyper = {version = "0.14.17", features = ["http2"] }
+hyper-rustls = { version = "0.23.0", features = ["http2", "webpki-roots"] }
 ipnetwork = "0.18.0"
 k8s-openapi = { version = "0.15.0", features = ["v1_22", "schemars"] }
 kube = { version = "0.73.0", features = ["derive", "runtime", "rustls-tls", "client"], default-features = false }
+maxminddb = "0.23.0"
+notify = "=5.0.0-pre.15"
 num_cpus = "1.13.0"
 once_cell = "1.9.0"
 parking_lot = "0.12"
@@ -65,13 +70,14 @@ prost = "=0.9.0"
 prost-types = "=0.9.0"
 rand = "0.8.5"
 regex = "1.5.4"
-schemars = { version = "0.8.8", features = ["chrono", "bytes"] }
+schemars = { version = "0.8.8", features = ["chrono", "bytes", "url"] }
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = "1.0.79"
 serde_regex = "1.1.0"
+serde_stacker = "0.1.5"
 serde_yaml = "0.8.21"
-socket2 = "0.4.4"
 snap = "1.0.5"
+socket2 = "0.4.4"
 stable-eyre = "0.2.2"
 tempdir = "0.3"
 thiserror = "1.0.30"
@@ -79,13 +85,11 @@ tokio = { version = "1.19.2", features = ["rt-multi-thread", "fs", "signal", "te
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 tonic = "0.6.1"
 tracing = "0.1.31"
+tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-subscriber = { version = "0.3.9", features = ["json", "env-filter"] }
 tryhard = "0.4.0"
+url = { version = "2.2.2", features = ["serde"] }
 uuid = { version = "1", default-features = false, features = ["v4"] }
-enum-map = "=2.1.0"
-notify = "=5.0.0-pre.15"
-serde_stacker = "0.1.5"
-tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.0"

--- a/about.toml
+++ b/about.toml
@@ -21,8 +21,9 @@ accepted = [
     "CC0-1.0",
     "ISC",
     "MIT",
+    "MPL-2.0",
     "NOASSERTION",
-    "Unicode-DFS-2016"
+    "Unicode-DFS-2016",
 ]
 workarounds = ["ring"]
 

--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ default = "allow"
 exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
+    { name ="webpki-roots", version = "0.22.5", allow = ["MPL-2.0"] },
 ]
 
 [[licenses.clarify]]

--- a/docs/src/proxy.md
+++ b/docs/src/proxy.md
@@ -39,6 +39,20 @@ An endpoint's metadata can be specified alongside the endpoint in [static config
 
 A session represents ongoing communication flow between a client and an [Upstream Endpoint][endpoint]. See the [Session documentation][sessions-doc] for more information.
 
+###### ASN Maxmind Information
+If quilkin is provided a Maxmind database through the `mmdb` configuration
+option. Quilkin will log the following information in the `maxmind information`
+log.
+
+| Field | Description |
+|-------|-------------|
+| `number` | ASN Number |
+| `organization` | The organisation responsible for the ASN |
+| `country_code` | The corresponding country code |
+| `prefix` | The IP prefix CIDR address |
+| `prefix_entity` | The name of the entity for the prefix address |
+| `prefix_name` | The name of the prefix address |
+
 #### Metrics
 
 The proxy exposes the following general metrics (See the metrics sub-sections for metrics specific to other Quilkin components, e.g for metrics related to packet flow see [sessions metrics][session-metrics], or metrics exported by individual filters can be found in the documentation for each filter):

--- a/image/archive_dependencies.sh
+++ b/image/archive_dependencies.sh
@@ -26,7 +26,7 @@ CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
 # This should be reviewed before each release to make sure we're capturing all
 # the dependencies we need.
 
-dependencies=()
+dependencies=(webpki-roots)
 
 zip="$(pwd)/dependencies-src.zip"
 

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -30,6 +30,7 @@ pub struct Builder {
     pub clusters: ClusterMap,
     pub filters: Vec<Filter>,
     pub management_servers: Vec<ManagementServer>,
+    pub maxmind_db: Option<crate::maxmind_db::Source>,
 }
 
 impl Default for Builder {
@@ -40,6 +41,7 @@ impl Default for Builder {
             clusters: <_>::default(),
             filters: <_>::default(),
             management_servers: <_>::default(),
+            maxmind_db: <_>::default(),
         }
     }
 }
@@ -93,6 +95,13 @@ impl Builder {
         }
     }
 
+    pub fn maxmind_db(self, mmdb: crate::maxmind_db::Source) -> Self {
+        Self {
+            maxmind_db: mmdb.into(),
+            ..self
+        }
+    }
+
     pub fn build(self) -> crate::Result<Config> {
         self.try_into().map_err(<_>::from)
     }
@@ -131,6 +140,7 @@ impl TryFrom<Builder> for Config {
             filters: crate::filters::FilterChain::try_from(builder.filters)?.into(),
             management_servers: builder.management_servers.into(),
             metrics: <_>::default(),
+            maxmind_db: builder.maxmind_db.into(),
         })
     }
 }

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -38,6 +38,11 @@ impl<T> Slot<T> {
         }
     }
 
+    /// Creates a new empty slot.
+    pub fn empty() -> Self {
+        Self::new(None)
+    }
+
     /// Adds a watcher to to the slot. The watcher will fire whenever slot's
     /// value changes.
     pub fn watch(&self, watcher: impl Fn(&T) + Send + Sync + 'static) {
@@ -137,13 +142,13 @@ impl<T: PartialEq> PartialEq for Slot<T> {
     }
 }
 
-impl<T: Default> From<T> for Slot<T> {
+impl<T> From<T> for Slot<T> {
     fn from(data: T) -> Self {
         Self::new(data)
     }
 }
 
-impl<T: Default> From<Option<T>> for Slot<T> {
+impl<T> From<Option<T>> for Slot<T> {
     fn from(data: Option<T>) -> Self {
         Self::new(data)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 
 mod admin;
 mod cluster;
+mod maxmind_db;
 pub(crate) mod metrics;
 pub(crate) mod prost;
 mod proxy;
@@ -40,6 +41,8 @@ pub type Result<T, E = eyre::Error> = std::result::Result<T, E>;
 pub use self::{cli::Cli, config::Config, proxy::Proxy};
 
 pub use quilkin_macros::include_proto;
+
+pub(crate) use self::maxmind_db::MaxmindDb;
 
 #[cfg(doctest)]
 mod external_doc_tests {

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     match <quilkin::Cli as clap::Parser>::parse().drive().await {
         Ok(()) => std::process::exit(0),
         Err(error) => {
-            tracing::error!("Error while running quilkin:\n{}", error);
+            tracing::error!(%error, "fatal error");
             std::process::exit(-1)
         }
     }

--- a/src/maxmind_db.rs
+++ b/src/maxmind_db.rs
@@ -1,0 +1,170 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use maxminddb::Reader;
+use once_cell::sync::Lazy;
+
+type Result<T, E = Error> = std::result::Result<T, E>;
+
+static HTTP: Lazy<
+    hyper::Client<
+        hyper_rustls::HttpsConnector<hyper::client::connect::HttpConnector>,
+        hyper::body::Body,
+    >,
+> = Lazy::new(|| {
+    hyper::Client::builder().build(
+        hyper_rustls::HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_or_http()
+            .enable_http1()
+            .enable_http2()
+            .build(),
+    )
+});
+pub static CLIENT: Lazy<arc_swap::ArcSwapOption<MaxmindDb>> = Lazy::new(<_>::default);
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[serde(tag = "kind")]
+pub enum Source {
+    File { path: std::path::PathBuf },
+    Url { url: url::Url },
+}
+
+impl std::str::FromStr for Source {
+    type Err = eyre::Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Ok(url) = input.parse() {
+            Ok(Self::Url { url })
+        } else if let Ok(path) = input.parse() {
+            Ok(Self::File { path })
+        } else {
+            Err(eyre::eyre!("'{}' is not a valid URL or path", input))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MaxmindDb {
+    reader: Reader<Bytes>,
+}
+
+impl MaxmindDb {
+    fn new(reader: Reader<Bytes>) -> Self {
+        Self { reader }
+    }
+
+    pub fn instance() -> arc_swap::Guard<Option<Arc<MaxmindDb>>> {
+        CLIENT.load()
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn update(source: Source) -> Result<()> {
+        let db = Self::from_source(source).await?;
+        CLIENT.store(Some(Arc::new(db)));
+        tracing::info!("maxmind database updated");
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub async fn from_source(source: Source) -> Result<Self> {
+        match source {
+            Source::File { path } => Self::open(path).await,
+            Source::Url { url } => Self::open_url(&url).await,
+        }
+    }
+
+    #[tracing::instrument(skip_all, fields(path = %path.as_ref().display()))]
+    pub async fn open<A: AsRef<std::path::Path>>(path: A) -> Result<Self> {
+        let path = path.as_ref();
+        tracing::info!(path=%path.display(), "trying to read local maxmind database");
+        let bytes = Bytes::from(tokio::fs::read(path).await?);
+        Reader::from_source(bytes)
+            .map(Self::new)
+            .map_err(From::from)
+    }
+
+    /// Reads a Maxmind DB from `url`, and if `cache` is `true`, then will use
+    /// the cached result, retreiving a fresh copy otherwise.
+    #[tracing::instrument(skip_all, fields(url = %url))]
+    pub async fn open_url(url: &url::Url) -> Result<Self> {
+        tracing::info!("requesting maxmind database from network");
+        let data = hyper::body::to_bytes(
+            HTTP.get(url.as_str().try_into().unwrap())
+                .await?
+                .into_body(),
+        )
+        .await?;
+
+        tracing::debug!("finished download");
+        let reader = Reader::from_source(data)?;
+
+        Ok(Self { reader })
+    }
+}
+
+impl std::ops::Deref for MaxmindDb {
+    type Target = Reader<Bytes>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.reader
+    }
+}
+
+impl std::ops::DerefMut for MaxmindDb {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.reader
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct IpNetEntry {
+    #[serde(default)]
+    pub allocation: String,
+    #[serde(default)]
+    pub allocation_cc: String,
+    #[serde(default)]
+    pub allocation_registry: String,
+    #[serde(default)]
+    pub allocation_status: String,
+    #[serde(default)]
+    pub r#as: u64,
+    #[serde(default)]
+    pub as_cc: String,
+    #[serde(default)]
+    pub as_entity: String,
+    #[serde(default)]
+    pub as_name: String,
+    #[serde(default)]
+    pub as_private: bool,
+    #[serde(default)]
+    pub as_registry: String,
+    #[serde(default)]
+    pub prefix: String,
+    #[serde(default)]
+    pub prefix_asset: Vec<String>,
+    #[serde(default)]
+    pub prefix_assignment: String,
+    #[serde(default)]
+    pub prefix_bogon: bool,
+    #[serde(default)]
+    pub prefix_entity: String,
+    #[serde(default)]
+    pub prefix_name: String,
+    #[serde(default)]
+    pub prefix_origins: Vec<u64>,
+    #[serde(default)]
+    pub prefix_registry: String,
+    #[serde(default)]
+    pub rpki_status: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    MaxmindDb(#[from] maxminddb::MaxMindDBError),
+    #[error(transparent)]
+    Http(#[from] hyper::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}

--- a/src/proxy/sessions/manager.rs
+++ b/src/proxy/sessions/manager.rs
@@ -72,7 +72,6 @@ impl SessionManager {
                         break;
                     }
                     _ = interval.tick() => {
-                        tracing::debug!("Attempting to Prune Sessions");
                         Self::prune_sessions(&mut sessions).await;
 
                     }
@@ -98,6 +97,7 @@ impl SessionManager {
             .count();
 
         if expired_keys != 0 {
+            tracing::debug!("pruning expired sessions");
             // Go over the whole sessions map again in case anything expired
             // since acquiring the write lock.
             sessions

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -228,6 +228,14 @@ impl TestHelper {
     pub fn run_server(&mut self, server: crate::Proxy) {
         let (shutdown_tx, shutdown_rx) = watch::channel::<()>(());
         self.server_shutdown_tx.push(Some(shutdown_tx));
+
+        if server.config.admin.is_some() {
+            tokio::spawn(crate::admin::server(
+                crate::admin::Mode::Proxy,
+                server.config.clone(),
+            ));
+        }
+
         tokio::spawn(async move {
             server.run(shutdown_rx).await.unwrap();
         });

--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -22,7 +22,6 @@ use tokio_stream::StreamExt;
 use tracing_futures::Instrument;
 
 use crate::{
-    admin,
     config::Config,
     xds::{
         metrics,
@@ -79,10 +78,6 @@ impl ControlPlane {
             config,
             watchers: <_>::default(),
         };
-
-        if this.config.admin.is_some() {
-            tokio::spawn(admin::server(admin::Mode::Xds, this.config.clone()));
-        }
 
         this.config.clusters.watch({
             let this = this.clone();


### PR DESCRIPTION
This adds a Maxmind DB integration so that if you provide quilkin with the source of a maxmind database that matches the structure of IPNetDB, it will output info about the ASN of a new session source.

I also refactored the admin server to be in `cli` to reduce duplication between run and manage.

closes #450 