### PR TITLE
remove unwrap

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -129,7 +129,7 @@ impl Proxy {
             Some(tokio::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-                    stream.send(ResourceType::Endpoint, &[]).await.unwrap();
+                    let _ = stream.send(ResourceType::Endpoint, &[]).await;
                 }
             }))
         } else {


### PR DESCRIPTION
This unwrap will fail when the connection fails, instead we ignore the error because we'll retry again in a few milliseconds.