### PR TITLE
(Mostly) Build tools working on arm64

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -64,8 +64,11 @@ cargo_build_x86_64_windows := build --release --target x86_64-pc-windows-gnu
 #    |_|\__,_|_|  \__, |\___|\__|___/
 #                 |___/
 
-help:
+help: ensure-multi-arch
 	@cat $(MAKEFILE_LIST) | docker run --rm -i xanders/make-help
+
+ensure-multi-arch:
+	@docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64 > /dev/null 2>&1
 
 # output the current build version
 version:
@@ -120,7 +123,7 @@ build-linux-binary: ensure-build-image
 ifdef BUILD_LOCAL
 	cargo $(cargo_build_x86_64_linux)
 else
-	docker run --rm $(common_rust_args) \
+	docker run --rm $(common_rust_args) -e "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/x86_64-linux-gnu-gcc" \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) $(cargo_build_x86_64_linux)
 endif
 
@@ -130,13 +133,14 @@ build-windows-binary: ensure-build-image
 ifdef BUILD_LOCAL
 	cargo $(cargo_build_x86_64_windows)
 else
-	docker run --rm $(common_rust_args) \
+	docker run --rm $(common_rust_args) -e "CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=/usr/bin/x86_64-w64-mingw32-gcc" \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) $(cargo_build_x86_64_windows)
 endif
 
 # Build binary for x86_64-apple-darwin
 # Use BUILD_LOCAL=1 to build through local cargo rather than through the build container.
-build-macos-binary:
+# Warning: May fail on arm64 hosts.
+build-macos-binary: ensure-multi-arch
 ifdef BUILD_LOCAL
 	cargo $(cargo_build_x86_64_apple)
 else
@@ -144,8 +148,8 @@ else
 		-v $(CARGO_HOME)/registry:/root/.cargo/registry \
 		-e "CARGO_TARGET_DIR=$(CARGO_TARGET_DIR)" \
 		-e "CC=o64-clang" -e "CXX=o64-clang++" \
-        joseluisq/rust-linux-darwin-builder:$(rust_toolchain) \
-        	sh -c "rustup target add x86_64-apple-darwin && cargo $(cargo_build_x86_64_apple)"
+		joseluisq/rust-linux-darwin-builder:$(rust_toolchain) \
+			sh -c "rustup target add x86_64-apple-darwin && cargo $(cargo_build_x86_64_apple)"
 endif
 
 # Build container image.
@@ -164,13 +168,15 @@ endif
 		--entrypoint=bash $(BUILD_IMAGE_TAG) -c 'cargo about generate license.html.hbs > license.html'
 	docker run --rm $(common_rust_args) \
 		--entrypoint=bash $(BUILD_IMAGE_TAG) -c './image/archive_dependencies.sh'
-	docker build -t $(IMAGE_TAG) -f $(project_path)/image/Dockerfile $(project_path)
+	docker build --platform=linux/amd64 -t $(IMAGE_TAG) -f $(project_path)/image/Dockerfile $(project_path)
 
 # Builds Quilkin, pushes it to a repository (use REPOSITORY arg to set value)
 # and then runs the Agones integration tests. See targets `build-images` and `push` for more options and details.
 # Not part of `test` as it requires a Kubernetes cluster to be provisioned and running.
 # To pass extra arguments to `cargo test`, to run only a single test, for example, use the `ARGS` variable
 # to set those options.
+# If a `kubectl` authentication failure occurs, run `kubectl get ns` to confirm access and refresh the Kubernetes
+# authentication token, and try again if successful.
 test-agones: push
 test-agones:
 	$(MAKE) run-test-agones

--- a/build/README.md
+++ b/build/README.md
@@ -70,6 +70,13 @@ To use the tooling for Make + Docker testing and development, you will need:
 * Make installed
 * [Docker installed](https://docs.docker.com/get-docker/)
 
+#### Known issues
+
+* If you are running on an arm64 machine, such as an M1 Mac, `make build-macos-binary` to build an amd64 macOS 
+  binary will fail. Depending on your setup, it may be possible to use `BUILD_LOCAL=1 make build-macos-binary` to 
+  attempt to build the binary with local `cargo` tooling. This is generally only a release time task, so we expect 
+  it to be of minimal impact. See [#608](https://github.com/googleforgames/quilkin/issues/608) for more details.
+
 #### Run tests
 
 `make test` will run all tests for this project, except the [Agones](https:/agones.dev) integration tests.

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/cloud-builders/docker
+FROM debian:bullseye
 
 ARG RUST_TOOLCHAIN
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    CROSS_DOCKER_IN_DOCKER=true \
     LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 
 # Install packages
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y jq wget zip build-essential libssl-dev pkg-config python3-pip bash-completion g++-mingw-w64-x86-64 && \
+    apt-get install -y lsb-release jq curl wget zip build-essential software-properties-common \ 
+        libssl-dev pkg-config python3-pip bash-completion g++-x86-64-linux-gnu g++-mingw-w64-x86-64 && \
     pip3 install live-server && \
     echo "source /etc/bash_completion" >> /root/.bashrc
 
@@ -37,12 +37,9 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
     echo "source /usr/share/google-cloud-sdk/completion.bash.inc" >> /root/.bashrc && \
     echo "source <(kubectl completion bash)" >> /root/.bashrc
 
-# install tarrafrm
-# Credit: https://learn.hashicorp.com/tutorials/terraform/install-cli
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main" && \
-    apt-get update -y && apt-get install terraform -y && \
-    terraform -install-autocomplete
+# install terraform. There is no apt support for arm64, so direct downloading instead.
+RUN wget --quiet -O terraform.zip "https://releases.hashicorp.com/terraform/1.3.1/terraform_1.3.1_linux_$(dpkg --print-architecture).zip" && \
+    unzip terraform.zip && rm terraform.zip && mv terraform /usr/local/bin/
 
 # install helm
 # Credit: https://helm.sh/docs/intro/install/
@@ -51,20 +48,30 @@ RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | b
 
 # Install htmltest
 WORKDIR /tmp
-RUN wget --quiet -O htmltest.tar.gz https://github.com/wjdp/htmltest/releases/download/v0.16.0/htmltest_0.16.0_linux_amd64.tar.gz && \
+RUN wget --quiet -O htmltest.tar.gz "https://github.com/wjdp/htmltest/releases/download/v0.16.0/htmltest_0.16.0_linux_$(dpkg --print-architecture).tar.gz" && \
      tar -xf htmltest.tar.gz && mv ./htmltest /usr/local/bin/ && rm htmltest.tar.gz
 
-# Install Rust
-RUN wget --quiet https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \
-    chmod +x rustup-init && \
-    ./rustup-init -y --no-modify-path --default-toolchain $RUST_TOOLCHAIN && \
+# Install Rust. Inspiration from: https://github.com/rust-lang/docker-rust/blob/master/1.64.0/bullseye/Dockerfile
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)" && \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu';; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf';; \
+        arm64) rustArch='aarch64-unknown-linux-gnu';; \
+        i386) rustArch='i686-unknown-linux-gnu';; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac && \
+    wget --quiet "https://static.rust-lang.org/rustup/dist/${rustArch}/rustup-init" && \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_TOOLCHAIN --default-host ${rustArch}; \
     rm rustup-init && \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rustup component add rustfmt clippy && \
-    rustup target add x86_64-pc-windows-gnu && \
+    rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-pc-windows-gnu && \
     cargo install cargo-watch mdbook && \
     cargo install cargo-about && \
     cargo install --locked cargo-deny && \
     rustup --version && \
     cargo --version && \
     rustc --version
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Using linux/arm64 at the test environment, this implements almost all of getting the build toolchain working on an arm64 host machine.

`make build-macos-binary` is currently not working, but I've left that for later, and documented it as a known issue.

Everything else is working!

Also includes:

* Cleanup unneeded things in build image.
* Updates to linkers used when cross compiling.
* Document known issues with compiling mac binaries.
* Ensure emulation exists where required.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

Work on ##608

**Special notes for your reviewer**:

This also sets us up for:
* #610 
* #611 
