### PR TITLE
Update to Rust 1.64.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.63.0"
+channel = "1.64.0"
 components = ["rustfmt", "clippy"]

--- a/src/filters/load_balancer/endpoint_chooser.rs
+++ b/src/filters/load_balancer/endpoint_chooser.rs
@@ -58,7 +58,7 @@ pub struct RandomEndpointChooser;
 impl EndpointChooser for RandomEndpointChooser {
     fn choose_endpoints(&self, ctx: &mut ReadContext) {
         // The index is guaranteed to be in range.
-        let index = (&mut thread_rng()).gen_range(0..ctx.endpoints.len());
+        let index = thread_rng().gen_range(0..ctx.endpoints.len());
         ctx.endpoints = vec![ctx.endpoints[index].clone()];
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -206,7 +206,7 @@ impl Proxy {
                             let timer = crate::metrics::PROCESSING_TIME.with_label_values(&[crate::metrics::READ_DIRECTION_LABEL]).start_timer();
                             match recv {
                                 Ok((size, source)) => {
-                                    let contents = (&buf[..size]).to_vec();
+                                    let contents = buf[..size].to_vec();
                                     tracing::trace!(id = worker_id, size = size, source = %source, contents=&*debug::bytes_to_string(&contents), "received packet from downstream");
                                     let packet = DownstreamPacket {
                                         source: source.into(),


### PR DESCRIPTION
This updates the project to 1.64.0, and takes advantage of the new workspace inheritance to reduce the number of versions of duplicated or different dependencies and project metadata, as well as lines of clippy lints.