### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,65 +41,65 @@ test = true
 quilkin-macros = { version = "0.4.0-dev", path = "./macros" }
 
 # Crates.io
-arc-swap = { version = "1.5.0", features = ["serde"] }
+arc-swap = { version = "1.5.1", features = ["serde"] }
 async-stream = "0.3.3"
 base64 = "0.13.0"
 base64-serde = "0.6.1"
-bytes = { version = "1.1.0", features = ["serde"] }
-cached = "0.34.0"
-chrono = "0.4.20"
-clap = { version = "3.1.2", features = ["cargo", "derive", "env"] }
-dashmap = "4.0.2"
+bytes = { version = "1.2.1", features = ["serde"] }
+cached = "0.39.0"
+chrono = "0.4.22"
+clap = { version = "4.0.13", features = ["cargo", "derive", "env"] }
+dashmap = "5.4.0"
 dirs2 = "3.0.1"
-either = "1.6.1"
-enum-map = "=2.1.0"
-eyre = "0.6.7"
-futures = "0.3.21"
-hyper = {version = "0.14.17", features = ["http2"] }
+either = "1.8.0"
+enum-map = "2.4.1"
+eyre = "0.6.8"
+futures = "0.3.24"
+hyper = { version = "0.14.20", features = ["http2"] }
 hyper-rustls = { version = "0.23.0", features = ["http2", "webpki-roots"] }
-ipnetwork = "0.18.0"
-k8s-openapi = { version = "0.15.0", features = ["v1_22", "schemars"] }
-kube = { version = "0.73.0", features = ["derive", "runtime", "rustls-tls", "client"], default-features = false }
+ipnetwork = "0.20.0"
+k8s-openapi = { version = "0.16.0", features = ["v1_22", "schemars"] }
+kube = { version = "0.75.0", features = ["derive", "runtime", "rustls-tls", "client"], default-features = false }
 maxminddb = "0.23.0"
-notify = "=5.0.0-pre.15"
-num_cpus = "1.13.0"
-once_cell = "1.9.0"
-parking_lot = "0.12"
-prometheus = { version = "0.13.0", default-features = false }
+notify = "5.0.0"
+num_cpus = "1.13.1"
+once_cell = "1.15.0"
+parking_lot = "0.12.1"
+prometheus = { version = "0.13.2", default-features = false }
 prost = "=0.9.0"
 prost-types = "=0.9.0"
 rand = "0.8.5"
-regex = "1.5.4"
-schemars = { version = "0.8.8", features = ["chrono", "bytes", "url"] }
-serde = { version = "1.0.130", features = ["derive", "rc"] }
-serde_json = "1.0.79"
+regex = "1.6.0"
+schemars = { version = "0.8.11", features = ["chrono", "bytes", "url"] }
+serde = { version = "1.0.145", features = ["derive", "rc"] }
+serde_json = "1.0.86"
 serde_regex = "1.1.0"
-serde_stacker = "0.1.5"
-serde_yaml = "0.8.21"
+serde_stacker = "0.1.6"
+serde_yaml = "0.9.13"
 snap = "1.0.5"
-socket2 = "0.4.4"
+socket2 = "0.4.7"
 stable-eyre = "0.2.2"
-tempdir = "0.3"
-thiserror = "1.0.30"
-tokio = { version = "1.19.2", features = ["rt-multi-thread", "fs", "signal", "test-util", "parking_lot", "tracing"] }
-tokio-stream = { version = "0.1.8", features = ["sync"] }
+tempdir = "0.3.7"
+thiserror = "1.0.37"
+tokio = { version = "1.21.2", features = ["rt-multi-thread", "fs", "signal", "test-util", "parking_lot", "tracing"] }
+tokio-stream = { version = "0.1.11", features = ["sync"] }
 tonic = "0.6.1"
-tracing = "0.1.31"
+tracing = "0.1.37"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
-tracing-subscriber = { version = "0.3.9", features = ["json", "env-filter"] }
-tryhard = "0.4.0"
-url = { version = "2.2.2", features = ["serde"] }
-uuid = { version = "1", default-features = false, features = ["v4"] }
+tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
+tryhard = "0.5.0"
+url = { version = "2.3.1", features = ["serde"] }
+uuid = { version = "1.2.1", default-features = false, features = ["v4"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-sys-info = "0.9.0"
+sys-info = "0.9.1"
 
 [dev-dependencies]
-regex = "1.5.4"
-criterion = { version = "0.3.5", features = ["html_reports"] }
-once_cell = "1.8.0"
-tracing-test = "0.2"
-pretty_assertions = "1.2.1"
+regex = "1.6.0"
+criterion = { version = "0.4.0", features = ["html_reports"] }
+once_cell = "1.15.0"
+tracing-test = "0.2.3"
+pretty_assertions = "1.3.0"
 
 [build-dependencies]
 tonic-build = { version = "0.6.0", default_features = false, features = ["transport", "prost"] }

--- a/agones/Cargo.toml
+++ b/agones/Cargo.toml
@@ -25,7 +25,7 @@ readme = "README.md"
 
 [dependencies]
 base64 = "0.13.0"
-k8s-openapi = { version = "0.15.0", features = ["v1_22"] }
-kube = { version = "0.73.1", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.16.0", features = ["v1_22"] }
+kube = { version = "0.75.0", features = ["runtime", "derive"] }
 quilkin = { path = "../" }
-tokio = { version = "1.19.2", features = ["sync", "parking_lot"] }
+tokio = { version = "1.21.2", features = ["sync", "parking_lot"] }

--- a/agones/src/lib.rs
+++ b/agones/src/lib.rs
@@ -101,7 +101,7 @@ impl Client {
     }
 
     /// Returns a typed API client for this client in this test namespace.
-    pub fn namespaced_api<K: Resource>(&self) -> Api<K>
+    pub fn namespaced_api<K: Resource<Scope = kube::core::NamespaceResourceScope>>(&self) -> Api<K>
     where
         <K as Resource>::DynamicType: Default,
     {
@@ -125,7 +125,7 @@ async fn setup_namespace(client: kube::Client) -> String {
         .map(chrono::Duration::seconds);
 
     for ns in nss {
-        let name = ns.name();
+        let name = ns.name_unchecked();
 
         let delete = delay
             .and_then(|duration| {
@@ -163,9 +163,9 @@ async fn setup_namespace(client: kube::Client) -> String {
         .await
         .expect("namespace to be created");
 
-    add_agones_service_account(client, test_namespace.name()).await;
+    add_agones_service_account(client, test_namespace.name_unchecked()).await;
 
-    test_namespace.name()
+    test_namespace.name_unchecked()
 }
 
 async fn add_agones_service_account(client: kube::Client, namespace: String) {
@@ -203,7 +203,7 @@ async fn add_agones_service_account(client: kube::Client, namespace: String) {
         },
         subjects: Some(vec![Subject {
             kind: "ServiceAccount".into(),
-            name: service_account.name(),
+            name: service_account.name_unchecked(),
             namespace: Some(namespace),
             api_group: None,
         }]),

--- a/agones/src/pod.rs
+++ b/agones/src/pod.rs
@@ -49,7 +49,7 @@ mod tests {
         let pod = pods.create(&pp, &pod).await.unwrap();
 
         // now wait for it be become ready.
-        let name = pod.name();
+        let name = pod.name_unchecked();
         let running = await_condition(pods, name.as_str(), is_pod_ready());
         timeout(Duration::from_secs(30), running)
             .await

--- a/agones/src/sidecar.rs
+++ b/agones/src/sidecar.rs
@@ -36,7 +36,7 @@ mod tests {
         let pp = PostParams::default();
         let gs = gameservers.create(&pp, &gs).await.unwrap();
 
-        let name = gs.name();
+        let name = gs.name_unchecked();
         let ready = await_condition(gameservers.clone(), name.as_str(), is_gameserver_ready());
         timeout(Duration::from_secs(30), ready)
             .await
@@ -107,14 +107,14 @@ clusters:
         template.volumes = Some(vec![Volume {
             name: mount_name,
             config_map: Some(ConfigMapVolumeSource {
-                name: Some(config_map.name()),
+                name: Some(config_map.name_unchecked()),
                 ..Default::default()
             }),
             ..Default::default()
         }]);
 
         let gs = gameservers.create(&pp, &gs).await.unwrap();
-        let name = gs.name();
+        let name = gs.name_unchecked();
         let ready = await_condition(gameservers.clone(), name.as_str(), is_gameserver_ready());
         timeout(Duration::from_secs(30), ready)
             .await

--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -92,7 +92,7 @@ filters:
         // any other.
         let fleet = fleet();
         let fleet = fleets.create(&pp, &fleet).await.unwrap();
-        let name = fleet.name();
+        let name = fleet.name_unchecked();
         timeout(
             Duration::from_secs(30),
             await_condition(fleets.clone(), name.as_str(), is_fleet_ready()),
@@ -102,7 +102,7 @@ filters:
         .unwrap();
 
         let lp = ListParams {
-            label_selector: Some(format!("agones.dev/fleet={}", fleet.name())),
+            label_selector: Some(format!("agones.dev/fleet={}", fleet.name_unchecked())),
             ..Default::default()
         };
         let list = gameservers.list(&lp).await.unwrap();
@@ -122,7 +122,7 @@ filters:
             .get_or_insert(Default::default())
             .insert("quilkin.dev/tokens".into(), base64::encode(token));
         gameservers
-            .replace(gs.name().as_str(), &pp, &gs)
+            .replace(gs.name_unchecked().as_str(), &pp, &gs)
             .await
             .unwrap();
         // and allocate it such that we have an endpoint.
@@ -164,7 +164,7 @@ filters:
                 break;
             }
         }
-        assert_eq!(format!("NAME: {}\n", gs.name()), response);
+        assert_eq!(format!("NAME: {}\n", gs.name_unchecked()), response);
     }
 
     /// Creates Quilkin xDS management instance that is in the mode to watch Agones GameServers
@@ -302,7 +302,7 @@ filters:
         services.create(&pp, &service).await.unwrap();
 
         // make sure the deployment and service are ready
-        let name = deployment.name();
+        let name = deployment.name_unchecked();
         timeout(
             Duration::from_secs(30),
             await_condition(deployments.clone(), name.as_str(), is_deployment_ready()),
@@ -369,7 +369,7 @@ management_servers:
                         volumes: Some(vec![Volume {
                             name: mount_name.into(),
                             config_map: Some(ConfigMapVolumeSource {
-                                name: Some(config_map.name()),
+                                name: Some(config_map.name_unchecked()),
                                 ..Default::default()
                             }),
                             ..Default::default()
@@ -383,7 +383,7 @@ management_servers:
         };
 
         let deployment = deployments.create(&pp, &deployment).await.unwrap();
-        let name = deployment.name();
+        let name = deployment.name_unchecked();
         // should not be ready, since there are no endpoints, but let's wait 3 seconds, make sure it doesn't do something we don't expect
         let result = timeout(
             Duration::from_secs(3),

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -33,6 +33,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.36"
-quote = "1.0.15"
-syn = { version = "1.0.86", features = ["full", "derive"] }
+proc-macro2 = "1.0.46"
+quote = "1.0.21"
+syn = { version = "1.0.102", features = ["full", "derive"] }

--- a/src/cli/generate_config_schema.rs
+++ b/src/cli/generate_config_schema.rs
@@ -22,7 +22,7 @@ pub struct GenerateConfigSchema {
     pub output_directory: std::path::PathBuf,
     /// A list of one or more filter IDs to generate or 'all' to generate all
     /// available filter schemas.
-    #[clap(min_values = 1, default_value = "all")]
+    #[clap(num_args = 1.., default_value = "all")]
     pub filter_ids: Vec<String>,
 }
 

--- a/src/config/watch/agones/crd.rs
+++ b/src/config/watch/agones/crd.rs
@@ -107,6 +107,7 @@ impl serde::Serialize for GameServer {
 
 impl Resource for GameServer {
     type DynamicType = ();
+    type Scope = kube::core::NamespaceResourceScope;
 
     fn group(_: &()) -> std::borrow::Cow<'_, str> {
         "agones.dev".into()

--- a/src/config/watch/fs.rs
+++ b/src/config/watch/fs.rs
@@ -23,9 +23,12 @@ use crate::Config;
 pub async fn watch(config: Arc<Config>, path: impl Into<std::path::PathBuf>) -> crate::Result<()> {
     let path = path.into();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    let mut watcher = notify::RecommendedWatcher::new(move |res| {
-        tx.send(res).unwrap();
-    })
+    let mut watcher = notify::RecommendedWatcher::new(
+        move |res| {
+            tx.send(res).unwrap();
+        },
+        <_>::default(),
+    )
     .unwrap();
 
     watcher.watch(&path, notify::RecursiveMode::Recursive)?;


### PR DESCRIPTION
Updates the dependencies to the latest versions. Except for prost and tonic, as it requires a `protoc` in the environment and the one in `apt` is not the same version as the one we use so it doesn't work without more changes.

The code changes:

- `kube`  added a `Scope` associated type, and deprecated the `name` function with `name_any` and `name_unchecked`
- `notify::RecommendedWatcher::new` now takes a config parameter, to which we pass the default.
- `clap` changed `min_values` to `num_args`.