### PR TITLE
Flatten proxy config section into root

### DIFF
--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -322,6 +322,8 @@ filters:
         let pp = PostParams::default();
         let config = r#"
 version: v1alpha1
+admin:
+    address: 0.0.0.0:9092
 management_servers:
   - address: http://quilkin-manage-agones:80
 "#;

--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -67,6 +67,7 @@ mod tests {
 
         let config = r#"
 version: v1alpha1
+admin: null
 filters:
   - name: quilkin.filters.capture.v1alpha1.Capture # Capture and remove the authentication token
     config:
@@ -322,8 +323,7 @@ filters:
         let pp = PostParams::default();
         let config = r#"
 version: v1alpha1
-admin:
-    address: 0.0.0.0:9092
+admin: null
 management_servers:
   - address: http://quilkin-manage-agones:80
 "#;

--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -67,7 +67,6 @@ mod tests {
 
         let config = r#"
 version: v1alpha1
-admin: null
 filters:
   - name: quilkin.filters.capture.v1alpha1.Capture # Capture and remove the authentication token
     config:
@@ -323,7 +322,6 @@ filters:
         let pp = PostParams::default();
         let config = r#"
 version: v1alpha1
-admin: null
 management_servers:
   - address: http://quilkin-manage-agones:80
 "#;

--- a/docs/src/filters/writing_custom_filters.md
+++ b/docs/src/filters/writing_custom_filters.md
@@ -101,8 +101,7 @@ at port 4321.
 ```yaml
 # quilkin.yaml
 version: v1alpha1
-proxy:
-  port: 7001
+port: 7001
 filters:
   - name: greet.v1
 clusters:

--- a/docs/src/proxy-configuration.md
+++ b/docs/src/proxy-configuration.md
@@ -18,21 +18,16 @@ properties:
       The configuration file version to use.
     enum:
       - v1alpha1
-  proxy:
-    type: object
-    description: |
-      Configuration of core proxy behavior.
-    properties:
-      id:
-        type: string
-        description: |
+  id:
+      type: string
+      description: |
           An identifier for the proxy instance.
-        default: On linux, the machine hostname is used as default. On all other platforms a UUID is generated for the proxy.
-      port:
-        type: integer
-        description: |
+      default: On linux, the machine hostname is used as default. On all other platforms a UUID is generated for the proxy.
+  port:
+      type: integer
+      description: |
           The listening port for the proxy.
-        default: 7000
+      default: 7000
   admin:
     type: object
     description: |

--- a/docs/src/proxy-configuration.md
+++ b/docs/src/proxy-configuration.md
@@ -26,7 +26,7 @@ properties:
   port:
       type: integer
       description: |
-          The listening port for the proxy.
+          The listening port. In "proxy" mode, the port for traffic to be sent to. In "manage" mode, the port to connect to the xDS API.
       default: 7000
   admin:
     type: object

--- a/examples/agones-xonotic-sidecar/sidecar-compress.yaml
+++ b/examples/agones-xonotic-sidecar/sidecar-compress.yaml
@@ -21,8 +21,7 @@ metadata:
 data:
   quilkin.yaml: |
     version: v1alpha1
-    proxy:
-      port: 26001
+    port: 26001
     filters:
       - name: quilkin.filters.compress.v1alpha1.Compress
         config:

--- a/examples/control-plane.yaml
+++ b/examples/control-plane.yaml
@@ -19,9 +19,8 @@
 #
 
 version: v1alpha1
-proxy:
-  id: my-proxy # An identifier for the proxy instance.
-  port: 7001 # the port to receive traffic to locally
+id: my-proxy # An identifier for the proxy instance.
+port: 7001 # the port to receive traffic to locally
 management_servers: # array of management servers to configure the proxy with.
                     # Multiple servers can be provided for redundancy.
   - address: http://127.0.0.1:26000

--- a/examples/iperf3/proxy.yaml
+++ b/examples/iperf3/proxy.yaml
@@ -19,9 +19,8 @@
 #
 
 version: v1alpha1
-proxy:
-  id: iperf3
-  port: 8000
+id: iperf3
+port: 8000
 clusters:
   default:
     localities:

--- a/examples/proxy.yaml
+++ b/examples/proxy.yaml
@@ -19,9 +19,8 @@
 #
 
 version: v1alpha1
-proxy:
-  id: my-proxy # An identifier for the proxy instance.
-  port: 7001 # the port to receive traffic to locally
+id: my-proxy # An identifier for the proxy instance.
+port: 7001 # the port to receive traffic to locally
 clusters: # grouping of clusters
   default:
     localities: # grouping of endpoints within a cluster

--- a/examples/quilkin-filter-example/config.yaml
+++ b/examples/quilkin-filter-example/config.yaml
@@ -16,8 +16,7 @@
 
 # ANCHOR: yaml
 version: v1alpha1
-proxy:
-  port: 7001
+port: 7001
 filters:
 - name: greet.v1
   config:

--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -18,8 +18,8 @@
 /// a configuration source.
 #[derive(clap::Args)]
 pub struct Manage {
-    #[clap(env, short, long)]
-    port: u16,
+    #[clap(short, long, env = "QUILKIN_PORT")]
+    port: Option<u16>,
     /// The configuration source for a management server.
     #[clap(subcommand)]
     pub provider: Providers,
@@ -48,7 +48,10 @@ pub enum Providers {
 
 impl Manage {
     pub async fn manage(&self, config: std::sync::Arc<crate::Config>) -> crate::Result<()> {
-        config.port.store(self.port.into());
+        if let Some(port) = self.port {
+            config.port.store(port.into());
+        }
+
         let provider_task = match &self.provider {
             Providers::Agones {
                 gameservers_namespace,

--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -18,6 +18,8 @@
 /// a configuration source.
 #[derive(clap::Args)]
 pub struct Manage {
+    #[clap(env, short, long)]
+    port: u16,
     /// The configuration source for a management server.
     #[clap(subcommand)]
     pub provider: Providers,
@@ -46,6 +48,7 @@ pub enum Providers {
 
 impl Manage {
     pub async fn manage(&self, config: std::sync::Arc<crate::Config>) -> crate::Result<()> {
+        config.port.store(self.port.into());
         let provider_task = match &self.provider {
             Providers::Agones {
                 gameservers_namespace,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -45,7 +45,7 @@ impl Run {
         shutdown_rx: tokio::sync::watch::Receiver<()>,
     ) -> crate::Result<()> {
         if let Some(port) = self.port {
-            config.proxy.modify(|proxy| proxy.port = port);
+            config.port.store(port.into());
         }
 
         let _mmdb_task = self.mmdb.clone().map(|source| {

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -19,7 +19,7 @@ use std::collections::HashSet;
 use super::{Config, Filter};
 use crate::{
     cluster::ClusterMap,
-    config::{Admin, ManagementServer, Proxy, ValidationError, Version},
+    config::{Admin, ManagementServer, ValidationError, Version},
 };
 
 /// Builder for a [`Config`]
@@ -130,11 +130,8 @@ impl TryFrom<Builder> for Config {
 
         Ok(Self {
             version: Version::V1Alpha1.into(),
-            proxy: Proxy {
-                id: "test".into(),
-                port: builder.port,
-            }
-            .into(),
+            id: String::from("test").into(),
+            port: builder.port.into(),
             admin: builder.admin.into(),
             clusters: builder.clusters.into(),
             filters: crate::filters::FilterChain::try_from(builder.filters)?.into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ async fn main() {
     match <quilkin::Cli as clap::Parser>::parse().drive().await {
         Ok(()) => std::process::exit(0),
         Err(error) => {
-            tracing::error!(%error, "fatal error");
+            tracing::error!(%error, error_debug=?error, "fatal error");
             std::process::exit(-1)
         }
     }

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -159,10 +159,8 @@ mod tests {
         let xds_config: Arc<Config> = serde_json::from_value(serde_json::json!({
             "admin": null,
             "version": "v1alpha1",
-            "proxy": {
-                "id": "test-proxy",
-                "port": xds_port
-            },
+            "id": "test-proxy",
+            "port": xds_port,
             "clusters": {
                 "default": {
                     "localities": [localities]
@@ -176,10 +174,8 @@ mod tests {
         let client_config: Config = serde_json::from_value(serde_json::json!({
             "version": "v1alpha1",
             "admin": null,
-            "proxy": {
-                "id": "test-proxy",
-                "port": client_addr.port(),
-            },
+            "id": "test-proxy",
+            "port": client_addr.port(),
             "management_servers": [{
                 "address": format!("http://0.0.0.0:{}", xds_port),
             }]
@@ -292,10 +288,8 @@ mod tests {
         let config: Arc<Config> = serde_json::from_value(serde_json::json!({
             "version": "v1alpha1",
             "admin": null,
-            "proxy": {
-                "id": "test-proxy",
-                "port": 23456u16,
-            },
+            "id": "test-proxy",
+            "port": 23456u16,
             "management_servers": [{
                 "address": "http://127.0.0.1:23456",
             }]

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -268,7 +268,7 @@ impl Stream {
     ) -> Result<()> {
         let request = DiscoveryRequest {
             node: Some(Node {
-                id: config.proxy.load().id.clone(),
+                id: (*config.id.load()).clone(),
                 user_agent_name: "quilkin".into(),
                 ..Node::default()
             }),

--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -37,7 +37,7 @@ use crate::{
 
 #[tracing::instrument(skip_all)]
 pub async fn spawn(config: std::sync::Arc<crate::Config>) -> crate::Result<()> {
-    let port = config.proxy.load().port;
+    let port = *config.port.load();
 
     let server = AggregatedDiscoveryServiceServer::new(ControlPlane::from_arc(config));
     let server = tonic::transport::Server::builder().add_service(server);
@@ -127,7 +127,7 @@ impl ControlPlane {
             .load(std::sync::atomic::Ordering::Relaxed)
             .to_string();
         response.control_plane = Some(crate::xds::config::core::v3::ControlPlane {
-            identifier: self.config.proxy.load().id.clone(),
+            identifier: (*self.config.id.load()).clone(),
         });
         response.nonce = nonce.to_string();
 


### PR DESCRIPTION
This makes it clear that `port` and `id` can refer a management server's port and id, not just a proxy's. Also added management server's `port` flag.