### PR TITLE
Fix not receiving stream pushes

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -114,14 +114,11 @@ impl Proxy {
             let client = crate::xds::Client::connect(self.config.clone()).await?;
             let mut stream = client.stream().await?;
 
+            tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
             stream.send(ResourceType::Endpoint, &[]).await?;
+            tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
             stream.send(ResourceType::Listener, &[]).await?;
-            Some(tokio::spawn(async move {
-                loop {
-                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
-                    let _ = stream.send(ResourceType::Endpoint, &[]).await;
-                }
-            }))
+            Some(stream)
         } else {
             None
         };


### PR DESCRIPTION
This is a smaller and better fix for the streams not always being established.

It's still not a full fix which know what issue is (the requests are sent before the stream is ready), and am working on PR for it, but haven't been able to make it pass tests yet.