### PR TITLE
Add timestamp filter

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/quilkin/filters/match/v1alpha1/match.proto",
         "proto/quilkin/filters/pass/v1alpha1/pass.proto",
         "proto/quilkin/filters/token_router/v1alpha1/token_router.proto",
+        "proto/quilkin/filters/timestamp/v1alpha1/timestamp.proto",
         "proto/udpa/xds/core/v3/resource_name.proto",
     ]
     .iter()

--- a/docs/src/filters/timestamp.md
+++ b/docs/src/filters/timestamp.md
@@ -1,0 +1,46 @@
+# Timestamp
+
+The `Timestamp` filter accepts a UNIX timestamp from metadata and observes the
+duration between that timestamp and now. Mostly useful in combination with other
+filters such as `Capture` to pull timestamp data from packets.
+
+#### Filter name
+```text
+quilkin.filters.timestamp.v1alpha1.Timestamp
+```
+
+### Configuration Examples
+```rust
+# let yaml = "
+version: v1alpha1
+filters:
+  - name: quilkin.filters.capture.v1alpha1.Capture
+    config:
+      metadataKey: example.com/session_duration
+      prefix:
+        size: 3
+        remove: false
+  - name: quilkin.filters.timestamp.v1alpha1.Timestamp
+    config:
+        metadataKey: example.com/session_duration
+clusters:
+  default:
+    localities:
+      - endpoints:
+        - address: 127.0.0.1:26000
+# ";
+# let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
+# quilkin::Proxy::try_from(config).unwrap();
+```
+
+### Configuration Options ([Rust Doc](../../api/quilkin/filters/timestamp/struct.Config.html))
+
+```yaml
+{{#include ../../../target/quilkin.filters.timestamp.v1alpha1.yaml}}
+```
+
+### Metrics
+
+* `quilkin_filter_timestamp_seconds{metadata_key, direction}`
+  A histogram of durations from `metadata_key` to now in the packet `direction`.
+

--- a/proto/quilkin/filters/timestamp/v1alpha1/timestamp.proto
+++ b/proto/quilkin/filters/timestamp/v1alpha1/timestamp.proto
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package quilkin.filters.timestamp.v1alpha1;
+
+import "google/protobuf/wrappers.proto";
+
+message Timestamp {
+  google.protobuf.StringValue metadata_key = 1;
+}

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -35,6 +35,7 @@ pub mod load_balancer;
 pub mod local_rate_limit;
 pub mod r#match;
 pub mod pass;
+pub mod timestamp;
 pub mod token_router;
 
 /// Prelude containing all types and traits required to implement [`Filter`] and
@@ -64,6 +65,7 @@ pub use self::{
     read::{ReadContext, ReadResponse},
     registry::FilterRegistry,
     set::{FilterMap, FilterSet},
+    timestamp::Timestamp,
     token_router::TokenRouter,
     write::{WriteContext, WriteResponse},
 };

--- a/src/filters/error.rs
+++ b/src/filters/error.rs
@@ -105,6 +105,13 @@ impl ConvertProtoConfigError {
             field,
         }
     }
+
+    pub fn missing_field(field: &'static str) -> Self {
+        Self {
+            reason: format!("`{field}` is required but not found"),
+            field: Some(field.into()),
+        }
+    }
 }
 
 /// Returns a [`ConvertProtoConfigError`] with an error message when

--- a/src/filters/set.rs
+++ b/src/filters/set.rs
@@ -62,6 +62,7 @@ impl FilterSet {
                 filters::LocalRateLimit::factory(),
                 filters::Match::factory(),
                 filters::Pass::factory(),
+                filters::Timestamp::factory(),
                 filters::TokenRouter::factory(),
             ]
             .into_iter()

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use chrono::prelude::*;
+use once_cell::sync::Lazy;
+use prometheus::HistogramVec;
+
+use crate::{
+    filters::prelude::*,
+    metadata::Value,
+    metrics::{
+        histogram_opts, registry, BUCKET_COUNT, BUCKET_FACTOR, BUCKET_START, DIRECTION_LABEL,
+        METADATA_KEY_LABEL, READ_DIRECTION_LABEL, WRITE_DIRECTION_LABEL,
+    },
+};
+
+crate::include_proto!("quilkin.filters.timestamp.v1alpha1");
+use self::quilkin::filters::timestamp::v1alpha1 as proto;
+
+pub(crate) static METRIC: Lazy<HistogramVec> = Lazy::new(|| {
+    prometheus::register_histogram_vec_with_registry! {
+        histogram_opts(
+            "seconds",
+            SUBSYSTEM,
+            "The duration of seconds of the `metadata_key` metric",
+            prometheus::exponential_buckets(BUCKET_START, BUCKET_FACTOR, BUCKET_COUNT).unwrap(),
+        ),
+        &[METADATA_KEY_LABEL, DIRECTION_LABEL],
+        registry(),
+    }
+    .unwrap()
+});
+
+const SUBSYSTEM: &str = "filters_timestamp";
+
+/// A filter that reads a metadata value as a timestamp to be observed in
+/// a histogram.
+#[derive(Debug, Clone)]
+pub struct Timestamp {
+    config: Arc<Config>,
+}
+
+impl Timestamp {
+    /// Observes the duration since a timestamp stored in `metadata` and now,
+    /// if present.
+    pub fn observe(
+        &self,
+        metadata: &crate::metadata::DynamicMetadata,
+        direction_label: &'static str,
+    ) {
+        let value = metadata
+            .get(&self.config.metadata_key)
+            .and_then(|item| match item {
+                Value::Number(item) => Some(*item as i64),
+                Value::Bytes(vec) => Some(i64::from_be_bytes((**vec).try_into().ok()?)),
+                _ => None,
+            });
+
+        let value = match value {
+            Some(item) => item,
+            None => return,
+        };
+
+        let naive = match NaiveDateTime::from_timestamp_opt(value, 0) {
+            Some(datetime) => datetime,
+            None => {
+                tracing::warn!(
+                    timestamp = value,
+                    metadata_key = &*self.config.metadata_key,
+                    "invalid unix timestamp"
+                );
+                return;
+            }
+        };
+
+        // Create a normal DateTime from the NaiveDateTime
+        let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
+
+        let now = Utc::now();
+        let seconds = now.signed_duration_since(datetime).num_seconds();
+        self.metric(direction_label).observe(seconds as f64);
+    }
+
+    fn metric(&self, direction_label: &'static str) -> prometheus::Histogram {
+        METRIC.with_label_values(&[&*self.config.metadata_key, direction_label])
+    }
+}
+
+impl Timestamp {
+    fn new(config: Config) -> Result<Self, Error> {
+        Ok(Self {
+            config: Arc::new(config),
+        })
+    }
+}
+
+impl TryFrom<Config> for Timestamp {
+    type Error = Error;
+
+    fn try_from(config: Config) -> Result<Self, Self::Error> {
+        Self::new(config)
+    }
+}
+
+impl Filter for Timestamp {
+    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
+        self.observe(&ctx.metadata, READ_DIRECTION_LABEL);
+        Some(ctx.into())
+    }
+
+    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
+        self.observe(&ctx.metadata, WRITE_DIRECTION_LABEL);
+        Some(ctx.into())
+    }
+}
+
+impl StaticFilter for Timestamp {
+    const NAME: &'static str = "quilkin.filters.timestamp.v1alpha1.Timestamp";
+    type Configuration = Config;
+    type BinaryConfiguration = proto::Timestamp;
+
+    fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, Error> {
+        Self::new(Self::ensure_config_exists(config)?)
+    }
+}
+
+/// Config represents a [self]'s configuration.
+#[derive(
+    Clone, Debug, Eq, PartialEq, schemars::JsonSchema, serde::Serialize, serde::Deserialize,
+)]
+pub struct Config {
+    /// The metadata key to read the UTC UNIX Timestamp from.
+    #[serde(rename = "metadataKey")]
+    pub metadata_key: String,
+}
+
+impl Config {
+    pub fn new(metadata_key: impl Into<String>) -> Self {
+        Self {
+            metadata_key: metadata_key.into(),
+        }
+    }
+}
+
+impl From<Config> for proto::Timestamp {
+    fn from(config: Config) -> Self {
+        Self {
+            metadata_key: Some(config.metadata_key),
+        }
+    }
+}
+
+impl TryFrom<proto::Timestamp> for Config {
+    type Error = ConvertProtoConfigError;
+
+    fn try_from(p: proto::Timestamp) -> Result<Self, Self::Error> {
+        Ok(Self {
+            metadata_key: p
+                .metadata_key
+                .ok_or_else(|| ConvertProtoConfigError::missing_field("metadata_key"))?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::filters::capture::{self, Capture};
+
+    #[test]
+    fn basic() {
+        const TIMESTAMP_KEY: &str = "BASIC";
+        let filter = Timestamp::from_config(Config::new(TIMESTAMP_KEY.to_string()).into());
+        let mut ctx = ReadContext::new(
+            vec![],
+            (std::net::Ipv4Addr::UNSPECIFIED, 0).into(),
+            b"hello".to_vec(),
+        );
+        ctx.metadata.insert(
+            Arc::new(TIMESTAMP_KEY.into()),
+            Value::Number(Utc::now().timestamp() as u64),
+        );
+
+        let _ = filter.read(ctx).unwrap();
+
+        assert_eq!(1, filter.metric(READ_DIRECTION_LABEL).get_sample_count());
+    }
+
+    #[test]
+    fn with_capture() {
+        const TIMESTAMP_KEY: &str = "WITH_CAPTURE";
+        let capture = Capture::from_config(
+            capture::Config {
+                metadata_key: TIMESTAMP_KEY.into(),
+                strategy: capture::Suffix {
+                    remove: true,
+                    size: 8,
+                }
+                .into(),
+            }
+            .into(),
+        );
+        let timestamp = Timestamp::from_config(Config::new(TIMESTAMP_KEY.to_string()).into());
+        let source = (std::net::Ipv4Addr::UNSPECIFIED, 0);
+        let ctx = ReadContext::new(
+            vec![],
+            source.into(),
+            [0, 0, 0, 0, 99, 81, 55, 181].to_vec(),
+        );
+
+        let response = capture.read(ctx).unwrap();
+        let _ = timestamp
+            .read(ReadContext::with_response(source.into(), response))
+            .unwrap();
+
+        assert_eq!(1, timestamp.metric(READ_DIRECTION_LABEL).get_sample_count());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod external_doc_tests {
     #![doc = include_str!("../docs/src/filters/load_balancer.md")]
     #![doc = include_str!("../docs/src/filters/local_rate_limit.md")]
     #![doc = include_str!("../docs/src/filters/match.md")]
+    #![doc = include_str!("../docs/src/filters/timestamp.md")]
     #![doc = include_str!("../docs/src/filters/token_router.md")]
     #![doc = include_str!("../docs/src/filters/writing_custom_filters.md")]
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -21,6 +21,10 @@ use prometheus::{
 
 pub use prometheus::Result;
 
+/// "metadata_key" is used as a label for metrics that can apply metrics based
+/// on specific metadata.
+pub const METADATA_KEY_LABEL: &str = "metadata_key";
+
 /// "event" is used as a label for Metrics that can apply to both Filter
 /// `read` and `write` executions.
 pub const DIRECTION_LABEL: &str = "event";
@@ -42,14 +46,14 @@ pub fn registry() -> &'static Registry {
 /// Start the histogram bucket at a quarter of a millisecond, as number below a millisecond are
 /// what we are aiming for, but some granularity below a millisecond is useful for performance
 /// profiling.
-const BUCKET_START: f64 = 0.00025;
+pub(crate) const BUCKET_START: f64 = 0.00025;
 
-const BUCKET_FACTOR: f64 = 2.0;
+pub(crate) const BUCKET_FACTOR: f64 = 2.0;
 
 /// At an exponential factor of 2.0 (BUCKET_FACTOR), 13 iterations gets us to just over 1 second.
 /// Any processing that occurs over a second is far too long, so we end bucketing there as we don't
 /// care about granularity past 1 second.
-const BUCKET_COUNT: usize = 13;
+pub(crate) const BUCKET_COUNT: usize = 13;
 
 pub(crate) static PROCESSING_TIME: Lazy<HistogramVec> = Lazy::new(|| {
     prometheus::register_histogram_vec_with_registry! {


### PR DESCRIPTION
This adds a new timestamp filter that reads in a metadata value as a unix timestamp, and then observes the duration between then and now in a histogram metric that's keyed by the direction and metadata key. This is mainly useful in combination with things like `Capture` which then allows you to parse timestamps from packets.