### PR TITLE
Refactor filter model from Context->Response into ref mut Context

### DIFF
--- a/docs/src/filters/writing_custom_filters.md
+++ b/docs/src/filters/writing_custom_filters.md
@@ -40,13 +40,13 @@ sent to a downstream client.
 use quilkin::filters::prelude::*;
 
 impl Filter for Greet {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+    fn read(&self, ctx: &mut ReadContext) -> Option<()> {
         ctx.contents.extend(b"Hello");
-        Some(ctx.into())
+        Some(())
     }
-    fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+    fn write(&self, ctx: &mut WriteContext) -> Option<()> {
         ctx.contents.extend(b"Goodbye");
-        Some(ctx.into())
+        Some(())
     }
 }
 ```

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -58,15 +58,15 @@ struct Greet {
 }
 
 impl Filter for Greet {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+    fn read(&self, ctx: &mut ReadContext) -> Option<()> {
         ctx.contents
             .splice(0..0, format!("{} ", self.config.greeting).into_bytes());
-        Some(ctx.into())
+        Some(())
     }
-    fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+    fn write(&self, ctx: &mut WriteContext) -> Option<()> {
         ctx.contents
             .splice(0..0, format!("{} ", self.config.greeting).into_bytes());
-        Some(ctx.into())
+        Some(())
     }
 }
 // ANCHOR_END: filter

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -186,11 +186,11 @@ impl<T: JsonSchema + Default> JsonSchema for Slot<T> {
 }
 
 impl<T: crate::filters::Filter + Default> crate::filters::Filter for Slot<T> {
-    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
+    fn read(&self, ctx: &mut ReadContext) -> Option<()> {
         self.load().read(ctx)
     }
 
-    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
+    fn write(&self, ctx: &mut WriteContext) -> Option<()> {
         self.load().write(ctx)
     }
 }

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -43,7 +43,7 @@ pub mod token_router;
 pub mod prelude {
     pub use super::{
         ConvertProtoConfigError, CreateFilterArgs, Error, Filter, FilterInstance, ReadContext,
-        ReadResponse, StaticFilter, WriteContext, WriteResponse,
+        StaticFilter, WriteContext,
     };
 }
 
@@ -62,12 +62,12 @@ pub use self::{
     local_rate_limit::LocalRateLimit,
     pass::Pass,
     r#match::Match,
-    read::{ReadContext, ReadResponse},
+    read::ReadContext,
     registry::FilterRegistry,
     set::{FilterMap, FilterSet},
     timestamp::Timestamp,
     token_router::TokenRouter,
-    write::{WriteContext, WriteResponse},
+    write::WriteContext,
 };
 
 pub(crate) use self::chain::FilterChain;
@@ -83,13 +83,13 @@ pub(crate) use self::chain::FilterChain;
 /// struct Greet;
 ///
 /// impl Filter for Greet {
-///     fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+///     fn read(&self, ctx: &mut ReadContext) -> Option<()> {
 ///         ctx.contents.splice(0..0, b"Hello ".into_iter().copied());
-///         Some(ctx.into())
+///         Some(())
 ///     }
-///     fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+///     fn write(&self, ctx: &mut WriteContext) -> Option<()> {
 ///         ctx.contents.splice(0..0, b"Goodbye ".into_iter().copied());
-///         Some(ctx.into())
+///         Some(())
 ///     }
 /// }
 ///
@@ -194,23 +194,20 @@ pub trait Filter: Send + Sync {
     /// [`Filter::read`] is invoked when the proxy receives data from a
     /// downstream connection on the listening port.
     ///
-    /// This function should return a [`ReadResponse`] containing the array of
-    /// endpoints that the packet should be sent to and the packet that should
-    /// be sent (which may be manipulated) as well. If the packet should be
-    /// rejected, return [`None`].  By default, the context passes
-    /// through unchanged.
-    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
-        Some(ctx.into())
+    /// This function should return an `Some` if the packet processing should
+    /// proceed. If the packet should be rejected, it will return [`None`]
+    /// instead. By default, the context passes through unchanged.
+    fn read(&self, _: &mut ReadContext) -> Option<()> {
+        Some(())
     }
 
     /// [`Filter::write`] is invoked when the proxy is about to send data to a
     /// downstream connection via the listening port after receiving it via one
     /// of the upstream Endpoints.
     ///
-    /// This function should return an [`WriteResponse`] containing the packet to
-    /// be sent (which may be manipulated). If the packet should be rejected,
-    /// return [`None`]. By default, the context passes through unchanged.
-    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
-        Some(ctx.into())
+    /// This function should return an `Some` if the packet processing should
+    /// proceed. If the packet should be rejected, it will return [`None`]
+    fn write(&self, _: &mut WriteContext) -> Option<()> {
+        Some(())
     }
 }

--- a/src/filters/concatenate_bytes.rs
+++ b/src/filters/concatenate_bytes.rs
@@ -44,7 +44,7 @@ impl ConcatenateBytes {
 }
 
 impl Filter for ConcatenateBytes {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
+    fn read(&self, ctx: &mut ReadContext) -> Option<()> {
         match self.on_read {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());
@@ -55,10 +55,10 @@ impl Filter for ConcatenateBytes {
             Strategy::DoNothing => {}
         }
 
-        Some(ctx.into())
+        Some(())
     }
 
-    fn write(&self, mut ctx: WriteContext) -> Option<WriteResponse> {
+    fn write(&self, ctx: &mut WriteContext) -> Option<()> {
         match self.on_write {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());
@@ -69,7 +69,7 @@ impl Filter for ConcatenateBytes {
             Strategy::DoNothing => {}
         }
 
-        Some(ctx.into())
+        Some(())
     }
 }
 

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -42,16 +42,16 @@ impl Debug {
 
 impl Filter for Debug {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
+    fn read(&self, ctx: &mut ReadContext) -> Option<()> {
         info!(id = ?self.config.id, source = ?&ctx.source, contents = ?String::from_utf8_lossy(&ctx.contents), "Read filter event");
-        Some(ctx.into())
+        Some(())
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
+    fn write(&self, ctx: &mut WriteContext) -> Option<()> {
         info!(id = ?self.config.id, endpoint = ?ctx.endpoint.address, source = ?&ctx.source,
             dest = ?&ctx.dest, contents = ?String::from_utf8_lossy(&ctx.contents), "Write filter event");
-        Some(ctx.into())
+        Some(())
     }
 }
 

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -35,12 +35,12 @@ impl Drop {
 
 impl Filter for Drop {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, _: ReadContext) -> Option<ReadResponse> {
+    fn read(&self, _: &mut ReadContext) -> Option<()> {
         None
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write(&self, _: WriteContext) -> Option<WriteResponse> {
+    fn write(&self, _: &mut WriteContext) -> Option<()> {
         None
     }
 }

--- a/src/filters/load_balancer.rs
+++ b/src/filters/load_balancer.rs
@@ -39,9 +39,9 @@ impl LoadBalancer {
 }
 
 impl Filter for LoadBalancer {
-    fn read(&self, mut ctx: ReadContext) -> Option<ReadResponse> {
-        self.endpoint_chooser.choose_endpoints(&mut ctx);
-        Some(ctx.into())
+    fn read(&self, ctx: &mut ReadContext) -> Option<()> {
+        self.endpoint_chooser.choose_endpoints(ctx);
+        Some(())
     }
 }
 
@@ -67,13 +67,15 @@ mod tests {
         input_addresses: &[EndpointAddress],
         source: EndpointAddress,
     ) -> Vec<EndpointAddress> {
-        filter
-            .read(ReadContext::new(
-                input_addresses.iter().cloned().map(Endpoint::new).collect(),
-                source,
-                vec![],
-            ))
-            .unwrap()
+        let mut context = ReadContext::new(
+            Vec::from_iter(input_addresses.iter().cloned().map(Endpoint::new)),
+            source,
+            vec![],
+        );
+
+        filter.read(&mut context).unwrap();
+
+        context
             .endpoints
             .iter()
             .map(|ep| ep.address.clone())

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -34,13 +34,13 @@ impl Pass {
 
 impl Filter for Pass {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, ctx: ReadContext) -> Option<ReadResponse> {
-        Some(ctx.into())
+    fn read(&self, _: &mut ReadContext) -> Option<()> {
+        Some(())
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write(&self, ctx: WriteContext) -> Option<WriteResponse> {
-        Some(ctx.into())
+    fn write(&self, _: &mut WriteContext) -> Option<()> {
+        Some(())
     }
 }
 

--- a/src/filters/read.rs
+++ b/src/filters/read.rs
@@ -45,44 +45,8 @@ impl ReadContext {
         }
     }
 
-    /// Creates a new [`ReadContext`] from a given [`ReadResponse`].
-    pub fn with_response(source: EndpointAddress, response: ReadResponse) -> Self {
-        Self {
-            endpoints: response.endpoints,
-            source,
-            contents: response.contents,
-            metadata: response.metadata,
-        }
+    pub fn metadata(mut self, metadata: DynamicMetadata) -> Self {
+        self.metadata = metadata;
+        self
     }
-}
-
-impl From<ReadContext> for ReadResponse {
-    fn from(ctx: ReadContext) -> Self {
-        Self {
-            endpoints: ctx.endpoints,
-            contents: ctx.contents,
-            metadata: ctx.metadata,
-        }
-    }
-}
-
-/// The output of [`Filter::read`].
-///
-/// New instances are created from [`ReadContext`].
-///
-/// ```rust
-/// # use quilkin::filters::{ReadContext, ReadResponse};
-///   fn read(ctx: ReadContext) -> Option<ReadResponse> {
-///       Some(ctx.into())
-///   }
-/// ```
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct ReadResponse {
-    /// The upstream endpoints that the packet should be forwarded to.
-    pub endpoints: Vec<Endpoint>,
-    /// Contents of the packet to be forwarded.
-    pub contents: Vec<u8>,
-    /// Arbitrary values that can be passed from one filter to another
-    pub metadata: DynamicMetadata,
 }

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -66,18 +66,16 @@ mod tests {
 
     use super::*;
     use crate::endpoint::{Endpoint, EndpointAddress};
-    use crate::filters::{
-        Filter, FilterRegistry, ReadContext, ReadResponse, WriteContext, WriteResponse,
-    };
+    use crate::filters::{Filter, FilterRegistry, ReadContext, WriteContext};
 
     struct TestFilter {}
 
     impl Filter for TestFilter {
-        fn read(&self, _: ReadContext) -> Option<ReadResponse> {
+        fn read(&self, _: &mut ReadContext) -> Option<()> {
             None
         }
 
-        fn write(&self, _: WriteContext) -> Option<WriteResponse> {
+        fn write(&self, _: &mut WriteContext) -> Option<()> {
             None
         }
     }
@@ -104,14 +102,14 @@ mod tests {
         let endpoint = Endpoint::new(addr.clone());
 
         assert!(filter
-            .read(ReadContext::new(
+            .read(&mut ReadContext::new(
                 vec![endpoint.clone()],
                 addr.clone(),
                 vec![]
             ))
             .is_some());
         assert!(filter
-            .write(WriteContext::new(&endpoint, addr.clone(), addr, vec![],))
+            .write(&mut WriteContext::new(endpoint, addr.clone(), addr, vec![],))
             .is_some());
     }
 }

--- a/src/filters/write.rs
+++ b/src/filters/write.rs
@@ -26,9 +26,9 @@ use crate::filters::Filter;
 
 /// The input arguments to [`Filter::write`].
 #[non_exhaustive]
-pub struct WriteContext<'a> {
+pub struct WriteContext {
     /// The upstream endpoint that we're expecting packets from.
-    pub endpoint: &'a Endpoint,
+    pub endpoint: Endpoint,
     /// The source of the received packet.
     pub source: EndpointAddress,
     /// The destination of the received packet.
@@ -39,63 +39,20 @@ pub struct WriteContext<'a> {
     pub metadata: DynamicMetadata,
 }
 
-/// The output of [`Filter::write`].
-///
-/// New instances are created from [`WriteContext`].
-///
-/// ```rust
-/// # use quilkin::filters::{WriteContext, WriteResponse};
-///   fn write(ctx: WriteContext) -> Option<WriteResponse> {
-///       Some(ctx.into())
-///   }
-/// ```
-#[non_exhaustive]
-pub struct WriteResponse {
-    /// Contents of the packet to be sent back to the original sender.
-    pub contents: Vec<u8>,
-    /// Arbitrary values that can be passed from one filter to another.
-    pub metadata: DynamicMetadata,
-}
-
-impl WriteContext<'_> {
+impl WriteContext {
     /// Creates a new [`WriteContext`]
     pub fn new(
-        endpoint: &Endpoint,
+        endpoint: Endpoint,
         source: EndpointAddress,
         dest: EndpointAddress,
         contents: Vec<u8>,
-    ) -> WriteContext {
-        WriteContext {
+    ) -> Self {
+        Self {
             endpoint,
             source,
             dest,
             contents,
             metadata: HashMap::new(),
-        }
-    }
-
-    /// Creates a new [`WriteContext`] from a given [`WriteResponse`].
-    pub fn with_response(
-        endpoint: &Endpoint,
-        source: EndpointAddress,
-        dest: EndpointAddress,
-        response: WriteResponse,
-    ) -> WriteContext {
-        WriteContext {
-            endpoint,
-            source,
-            dest,
-            contents: response.contents,
-            metadata: response.metadata,
-        }
-    }
-}
-
-impl From<WriteContext<'_>> for WriteResponse {
-    fn from(ctx: WriteContext) -> Self {
-        Self {
-            contents: ctx.contents,
-            metadata: ctx.metadata,
         }
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -240,17 +240,15 @@ impl Proxy {
             return;
         }
 
-        let result = args.config.filters.load().read(ReadContext::new(
-            endpoints,
-            packet.source.clone(),
-            packet.contents,
-        ));
+        let filters = args.config.filters.load();
+        let mut context = ReadContext::new(endpoints, packet.source, packet.contents);
+        let result = filters.read(&mut context);
 
-        if let Some(response) = result {
-            for endpoint in response.endpoints.iter() {
+        if let Some(()) = result {
+            for endpoint in context.endpoints.iter() {
                 Self::session_send_packet(
-                    &response.contents,
-                    packet.source.clone(),
+                    &context.contents,
+                    context.source.clone(),
                     endpoint,
                     args,
                 )


### PR DESCRIPTION
This moves the filter model from converting `Context`s into `Response` to modifying the context in place. This removes a lot of conversion code in the binary and anecdotally I noticed minor improvements in performance just from using it like this.