### PR TITLE
Refactor metrics statics into free fns

### DIFF
--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -258,9 +258,7 @@ impl Filter for FilterChain {
                     }
                     None => {
                         tracing::trace!(%id, "read dropping packet");
-                        crate::metrics::PACKETS_DROPPED
-                            .with_label_values(&[crate::metrics::READ_DIRECTION_LABEL, id])
-                            .inc();
+                        crate::metrics::packets_dropped(crate::metrics::READ, id).inc();
                         return None;
                     }
                 }
@@ -283,9 +281,7 @@ impl Filter for FilterChain {
                     }
                     None => {
                         tracing::trace!(%id, "write dropping packet");
-                        crate::metrics::PACKETS_DROPPED
-                            .with_label_values(&[crate::metrics::WRITE_DIRECTION_LABEL, id])
-                            .inc();
+                        crate::metrics::packets_dropped(crate::metrics::WRITE, id).inc();
                         None
                     }
                 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -197,7 +197,7 @@ impl Proxy {
                     );
                     tokio::select! {
                         recv = socket.recv_from(&mut buf) => {
-                            let timer = crate::metrics::PROCESSING_TIME.with_label_values(&[crate::metrics::READ_DIRECTION_LABEL]).start_timer();
+                            let timer = crate::metrics::processing_time(crate::metrics::READ).start_timer();
                             match recv {
                                 Ok((size, source)) => {
                                     let contents = buf[..size].to_vec();
@@ -234,9 +234,7 @@ impl Proxy {
         let endpoints: Vec<_> = clusters.endpoints().collect();
         if endpoints.is_empty() {
             tracing::trace!("dropping packet, no upstream endpoints available");
-            crate::metrics::PACKETS_DROPPED
-                .with_label_values(&[crate::metrics::READ_DIRECTION_LABEL, "NoEndpointsAvailable"])
-                .inc();
+            crate::metrics::packets_dropped(crate::metrics::READ, "NoEndpointsAvailable").inc();
             return;
         }
 


### PR DESCRIPTION
This wraps a function around the metric static variables, this is to ensure at compile-time that all metrics always have the correct number of label values, previously there were one or two cases where one label was missing.