### PR TITLE
Build macos binaries on ARM

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -143,8 +143,7 @@ endif
 
 # Build binary for x86_64-apple-darwin
 # Use BUILD_LOCAL=1 to build through local cargo rather than through the build container.
-# Warning: May fail on arm64 hosts.
-build-macos-binary: ensure-multi-arch
+build-macos-binary:
 ifdef BUILD_LOCAL
 	cargo $(cargo_build_x86_64_apple)
 else
@@ -152,7 +151,7 @@ else
 		-v $(CARGO_HOME)/registry:/root/.cargo/registry \
 		-e "CARGO_TARGET_DIR=$(CARGO_TARGET_DIR)" \
 		-e "CC=o64-clang" -e "CXX=o64-clang++" \
-		joseluisq/rust-linux-darwin-builder:$(rust_toolchain) \
+		us-docker.pkg.dev/quilkin/ci/rust-linux-darwin-builder:$(rust_toolchain) \
 			sh -c "rustup target add x86_64-apple-darwin && cargo $(cargo_build_x86_64_apple)"
 endif
 

--- a/build/darwin-builder/Makefile
+++ b/build/darwin-builder/Makefile
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+project_path := $(realpath $(dir mkfile_path)/../..)
+rust_toolchain := $(shell grep channel $(project_path)/rust-toolchain.toml | awk '{ print $$3 }')
+
+build:
+	gcloud builds submit . --substitutions _TAG=$(rust_toolchain)

--- a/build/darwin-builder/cloudbuild.yaml
+++ b/build/darwin-builder/cloudbuild.yaml
@@ -1,0 +1,52 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Cloud Build script for building and hosting a multi-arch version of
+# https://github.com/joseluisq/rust-linux-darwin-builder until there is official support.
+#
+
+steps:
+  - name: gcr.io/cloud-builders/git
+    args:
+      - clone
+      - https://github.com/joseluisq/rust-linux-darwin-builder.git
+  - name: gcr.io/cloud-builders/docker
+    id: setup
+    entrypoint: bash
+    args:
+      - "-c"
+      - |
+        docker run --privileged --rm tonistiigi/binfmt --install linux/amd64,linux/arm64
+        docker buildx create --name darwin-builder --driver docker-container --bootstrap
+        docker buildx use darwin-builder
+    # We run this twice, because the build takes longer than 1h, the OAuth token expires. So we build once (takes a long time)
+    # Then the --push invocation will use the local build cache, so the OAuth token gets refreshed and we can successfully push the multi-platform image.
+  - name: gcr.io/cloud-builders/docker
+    id: build
+    dir: rust-linux-darwin-builder
+    entrypoint: bash
+    args:
+      - "-c"
+      - docker buildx build --platform linux/amd64,linux/arm64 -t us-docker.pkg.dev/$PROJECT_ID/ci/rust-linux-darwin-builder:${_TAG} .
+  - name: gcr.io/cloud-builders/docker
+    id: build-push
+    dir: rust-linux-darwin-builder
+    entrypoint: bash
+    args:
+      - "-c"
+      - docker buildx build --platform linux/amd64,linux/arm64 --push -t us-docker.pkg.dev/$PROJECT_ID/ci/rust-linux-darwin-builder:${_TAG} .
+timeout: 14400s
+options:
+  machineType: E2_HIGHCPU_32


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

While we wait for the darwin-linux image to have official images for arm64, we can host our own, since the work has been done. So this includes cloud build scripts to create the image and host it on the Quilkin repo. We can run this manually for each new Rust version we want to support (takes about 1.5h to run).

So this removes the need for emulation to compile a mac/amd64 binary, on an arm64 host (such as a M1) and sets us up to be able to produce a mac/arm64 binary as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #608

**Special notes for your reviewer**:

N/A