### PR TITLE
Implement string interning and symbol resolution for metadata keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ tracing-subscriber = { version = "0.3.16", features = ["json", "env-filter"] }
 tryhard = "0.5.0"
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.1", default-features = false, features = ["v4"] }
+lasso = { version = "0.6.0", features = ["multi-threaded"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.1"

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -349,9 +349,7 @@ mod tests {
         assert_eq!(b"hello:odr:127.0.0.1:70", &*context.contents);
         assert_eq!(
             "receive",
-            context.metadata[&"downstream".to_string()]
-                .as_string()
-                .unwrap()
+            context.metadata[&"downstream".into()].as_string().unwrap()
         );
 
         let mut context = WriteContext::new(
@@ -364,9 +362,7 @@ mod tests {
 
         assert_eq!(
             "receive",
-            context.metadata[&"upstream".to_string()]
-                .as_string()
-                .unwrap()
+            context.metadata[&"upstream".into()].as_string().unwrap()
         );
         assert_eq!(b"hello:our:127.0.0.1:80:127.0.0.1:70", &*context.contents,);
     }
@@ -407,9 +403,7 @@ mod tests {
         );
         assert_eq!(
             "receive:receive",
-            context.metadata[&"downstream".to_string()]
-                .as_string()
-                .unwrap()
+            context.metadata[&"downstream".into()].as_string().unwrap()
         );
 
         let mut context = WriteContext::new(
@@ -426,9 +420,7 @@ mod tests {
         );
         assert_eq!(
             "receive:receive",
-            context.metadata[&"upstream".to_string()]
-                .as_string()
-                .unwrap()
+            context.metadata[&"upstream".into()].as_string().unwrap()
         );
     }
 

--- a/src/filters/match/config.rs
+++ b/src/filters/match/config.rs
@@ -71,7 +71,7 @@ impl TryFrom<proto::Match> for Config {
 pub struct DirectionalConfig {
     /// The key for the metadata to compare against.
     #[serde(rename = "metadataKey")]
-    pub metadata_key: String,
+    pub metadata_key: crate::metadata::Key,
     /// List of filters to compare and potentially run if any match.
     pub branches: Vec<Branch>,
     /// The behaviour for when none of the `branches` match.
@@ -84,7 +84,7 @@ impl TryFrom<DirectionalConfig> for proto::r#match::Config {
 
     fn try_from(config: DirectionalConfig) -> Result<Self, Self::Error> {
         Ok(Self {
-            metadata_key: Some(config.metadata_key),
+            metadata_key: Some(config.metadata_key.to_string()),
             branches: config
                 .branches
                 .into_iter()
@@ -100,7 +100,7 @@ impl TryFrom<proto::r#match::Config> for DirectionalConfig {
 
     fn try_from(value: proto::r#match::Config) -> Result<Self, Self::Error> {
         Ok(Self {
-            metadata_key: value.metadata_key.ok_or_else(|| {
+            metadata_key: value.metadata_key.map(From::from).ok_or_else(|| {
                 ConvertProtoConfigError::new("Missing", Some("metadata_key".into()))
             })?,
             branches: value

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-use std::{collections::HashMap, convert::TryFrom, sync::Arc};
-
-use crate::xds::config::core::v3::Metadata as ProtoMetadata;
+pub(crate) mod symbol;
 
 #[doc(hidden)]
 pub mod build {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 
+use std::{collections::HashMap, convert::TryFrom};
+
+use crate::xds::config::core::v3::Metadata as ProtoMetadata;
+
+pub use symbol::{Key, Reference, Symbol};
+
 /// Shared state between [`Filter`][crate::filters::Filter]s during processing for a single packet.
-pub type DynamicMetadata = HashMap<Arc<String>, Value>;
+pub type DynamicMetadata = HashMap<Key, Value>;
 
 pub const KEY: &str = "quilkin.dev";
 

--- a/src/metadata/symbol.rs
+++ b/src/metadata/symbol.rs
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use once_cell::sync::Lazy;
+
+use super::{DynamicMetadata, Value};
+
+static INTERNER: Lazy<lasso::ThreadedRodeo> = Lazy::new(lasso::ThreadedRodeo::new);
+
+/// A key in the metadata table.
+#[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Hash, Ord, schemars::JsonSchema)]
+pub struct Key(#[schemars(with = "String")] lasso::Spur);
+
+impl Key {
+    pub fn new<A: AsRef<str>>(key: A) -> Self {
+        Self(INTERNER.get_or_intern(key.as_ref()))
+    }
+
+    pub fn from_static(key: &'static str) -> Self {
+        Self(INTERNER.get_or_intern_static(key))
+    }
+
+    pub fn from_raw(spur: lasso::Spur) -> Self {
+        Self(spur)
+    }
+}
+
+impl From<lasso::Spur> for Key {
+    fn from(spur: lasso::Spur) -> Self {
+        Self::from_raw(spur)
+    }
+}
+
+impl From<String> for Key {
+    fn from(string: String) -> Self {
+        Self::new(string)
+    }
+}
+
+impl From<&'_ str> for Key {
+    fn from(string: &str) -> Self {
+        Self::new(string)
+    }
+}
+
+impl std::fmt::Debug for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        INTERNER.resolve(&self.0).fmt(f)
+    }
+}
+
+impl std::fmt::Display for Key {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        INTERNER.resolve(&self.0).fmt(f)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Key {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        std::borrow::Cow::<'de, str>::deserialize(deserializer).map(Self::new)
+    }
+}
+
+impl serde::Serialize for Key {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+/// A literal value or a reference to a value in a metadata map.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    serde::Serialize,
+    serde::Deserialize,
+    Eq,
+    Ord,
+    schemars::JsonSchema,
+)]
+#[serde(untagged)]
+pub enum Symbol {
+    Reference(Reference),
+    Literal(Value),
+}
+
+impl Symbol {
+    pub fn as_literal(&self) -> Option<&Value> {
+        match self {
+            Self::Literal(value) => Some(value),
+            Self::Reference(_) => None,
+        }
+    }
+
+    pub fn as_reference(&self) -> Option<&Reference> {
+        match self {
+            Self::Literal(_) => None,
+            Self::Reference(reference) => Some(reference),
+        }
+    }
+
+    /// Resolves a symbol into a [`Value`], using `ctx` for any references,
+    /// returning `None` if could not be found.
+    pub fn resolve<'literal: 'metadata, 'metadata>(
+        &'literal self,
+        metadata: &'metadata DynamicMetadata,
+    ) -> Option<&'metadata Value> {
+        match self {
+            Self::Literal(value) => Some(value),
+            Self::Reference(reference) => match metadata.get(&reference.key()) {
+                Some(value) => Some(value),
+                None => {
+                    tracing::warn!(key=%self.as_reference().unwrap(), "couldn't resolve key");
+                    None
+                }
+            },
+        }
+    }
+
+    /// Tries to [`Self::resolve`] the symbol to a `bytes::Bytes`, performing
+    /// a conversion process on different [`Value`] if relevant. Returning
+    /// `None` if it isn't supported currently.
+    ///
+    /// - [`Value::Bytes`] The value is copied as-is.
+    /// - [`Value::String`] The value is interpreted as a base64 string.
+    /// - [`Value::Number`] The value is an eight byte number encoded as big endian.
+    pub fn resolve_to_bytes<'literal: 'metadata, 'metadata>(
+        &'literal self,
+        metadata: &'metadata DynamicMetadata,
+    ) -> Option<bytes::Bytes> {
+        match self.resolve(metadata) {
+            Some(Value::Number(value)) => Some(Vec::from(value.to_be_bytes()).into()),
+            Some(Value::Bytes(bytes)) => Some(bytes.clone()),
+            Some(Value::String(string)) => Some(base64::decode(&string).ok()?.into()),
+            _ => None,
+        }
+    }
+}
+
+impl From<Value> for Symbol {
+    fn from(value: Value) -> Self {
+        Self::Literal(value)
+    }
+}
+
+impl From<Reference> for Symbol {
+    fn from(reference: Reference) -> Self {
+        Self::Reference(reference)
+    }
+}
+
+/// Reference to a metadata value.
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq, Ord, schemars::JsonSchema)]
+#[schemars(transparent)]
+pub struct Reference {
+    key: Key,
+}
+
+impl Reference {
+    pub fn new<A: AsRef<str>>(key: A) -> Self {
+        Self {
+            key: Key::new(key.as_ref()),
+        }
+    }
+
+    pub fn key(self) -> Key {
+        self.key
+    }
+}
+
+impl std::fmt::Display for Reference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "${}", self.key)
+    }
+}
+
+impl serde::Serialize for Reference {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Reference {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string = <std::borrow::Cow<'de, str>>::deserialize(deserializer)?;
+
+        if let Some(string) = string.strip_prefix('$') {
+            Ok(Self::new(string))
+        } else {
+            Err(<D::Error as serde::de::Error>::custom(
+                "references are required to start with `$`",
+            ))
+        }
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -63,7 +63,7 @@ impl Filter for TestFilter {
     fn read(&self, ctx: &mut ReadContext) -> Option<()> {
         // append values on each run
         ctx.metadata
-            .entry(Arc::new("downstream".into()))
+            .entry("downstream".into())
             .and_modify(|e| e.as_mut_string().unwrap().push_str(":receive"))
             .or_insert_with(|| Value::String("receive".into()));
 
@@ -75,7 +75,7 @@ impl Filter for TestFilter {
     fn write(&self, ctx: &mut WriteContext) -> Option<()> {
         // append values on each run
         ctx.metadata
-            .entry("upstream".to_string().into())
+            .entry("upstream".into())
             .and_modify(|e| e.as_mut_string().unwrap().push_str(":receive"))
             .or_insert_with(|| Value::String("receive".to_string()));
 


### PR DESCRIPTION
This PR adds string interning and symbol resolution for metadata keys, this lowers memory usage for strings, and moves from needing `Arc` to just having a 32 bit id. This also adds support for resolving values to a metadata value in configuration. This allows you to use dynamic metadata values in configuration in places where a static literal is currently allowed.