### PR TITLE
Consistency of "packets_dropped_total" metric

### DIFF
--- a/docs/src/filters/capture.md
+++ b/docs/src/filters/capture.md
@@ -59,7 +59,7 @@ clusters:
 
 ### Metrics
 
-* `quilkin_filter_Capture_packets_dropped`
+* `quilkin_filter_Capture_packets_dropped_total`
   A counter of the total number of packets that have been dropped due to their length being less than the configured
   `size`.
 

--- a/docs/src/filters/local_rate_limit.md
+++ b/docs/src/filters/local_rate_limit.md
@@ -50,5 +50,5 @@ To configure a rate limiter, we specify the maximum rate at which the proxy is a
 
 ### Metrics
 
-* `quilkin_filter_LocalRateLimit_packets_dropped`  
+* `quilkin_filter_LocalRateLimit_packets_dropped_total`  
   A counter over the total number of packets that have exceeded the configured maximum rate limit and have been dropped as a result.

--- a/docs/src/filters/token_router.md
+++ b/docs/src/filters/token_router.md
@@ -50,7 +50,7 @@ View the [CaptureBytes](./capture.md) filter documentation for more details.
 
 ### Metrics
 
-* `quilkin_filter_TokenRouter_packets_dropped`
+* `quilkin_filter_TokenRouter_packets_dropped_total`
   A counter of the total number of packets that have been dropped. This is also provided with a `Reason` label, as there
   are differing reasons for packets to be dropped:
     * `NoEndpointMatch` - The token provided via the Filter dynamic metadata does not match any Endpoint's tokens.

--- a/examples/grafana-dashboards/dashboards/dashboard-gameservers.yaml
+++ b/examples/grafana-dashboards/dashboards/dashboard-gameservers.yaml
@@ -457,7 +457,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": true,
-              "expr": "sum(rate(quilkin_packets_dropped[$__rate_interval]))",
+              "expr": "sum(rate(quilkin_packets_dropped_total[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "dropped packet rate",

--- a/src/filters/capture/metrics.rs
+++ b/src/filters/capture/metrics.rs
@@ -27,7 +27,7 @@ impl Metrics {
     pub(super) fn new() -> prometheus::Result<Self> {
         Ok(Metrics {
             packets_dropped_total: IntCounter::with_opts(filter_opts(
-                "packets_dropped",
+                "packets_dropped_total",
                 "CaptureBytes",
                 "Total number of packets dropped due capture size being larger than the received packet",
             ))?

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -258,7 +258,7 @@ impl Filter for FilterChain {
                     }
                     None => {
                         tracing::trace!(%id, "read dropping packet");
-                        crate::metrics::packets_dropped(crate::metrics::READ, id).inc();
+                        crate::metrics::packets_dropped_total(crate::metrics::READ, id).inc();
                         return None;
                     }
                 }
@@ -281,7 +281,7 @@ impl Filter for FilterChain {
                     }
                     None => {
                         tracing::trace!(%id, "write dropping packet");
-                        crate::metrics::packets_dropped(crate::metrics::WRITE, id).inc();
+                        crate::metrics::packets_dropped_total(crate::metrics::WRITE, id).inc();
                         None
                     }
                 }

--- a/src/filters/compress/metrics.rs
+++ b/src/filters/compress/metrics.rs
@@ -22,8 +22,8 @@ use crate::metrics::{filter_opts, CollectorExt};
 
 /// Register and manage metrics for this filter
 pub(super) struct Metrics {
-    pub(super) packets_dropped_compress: GenericCounter<AtomicU64>,
-    pub(super) packets_dropped_decompress: GenericCounter<AtomicU64>,
+    pub(super) packets_dropped_total_compress: GenericCounter<AtomicU64>,
+    pub(super) packets_dropped_total_decompress: GenericCounter<AtomicU64>,
     pub(super) compressed_bytes_total: GenericCounter<AtomicU64>,
     pub(super) decompressed_bytes_total: GenericCounter<AtomicU64>,
 }
@@ -56,9 +56,9 @@ impl Metrics {
         .register_if_not_exists()?;
 
         Ok(Metrics {
-            packets_dropped_compress: dropped_metric
+            packets_dropped_total_compress: dropped_metric
                 .get_metric_with_label_values(vec!["Compress"].as_slice())?,
-            packets_dropped_decompress: dropped_metric
+            packets_dropped_total_decompress: dropped_metric
                 .get_metric_with_label_values(vec!["Decompress"].as_slice())?,
             compressed_bytes_total,
             decompressed_bytes_total,

--- a/src/filters/local_rate_limit/metrics.rs
+++ b/src/filters/local_rate_limit/metrics.rs
@@ -28,7 +28,7 @@ impl Metrics {
     pub(super) fn new() -> MetricsResult<Self> {
         Ok(Metrics {
             packets_dropped_total: IntCounter::with_opts(filter_opts(
-                "packets_dropped",
+                "packets_dropped_total",
                 "LocalRateLimit",
                 "Total number of packets dropped due to rate limiting",
             ))?

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -65,7 +65,7 @@ impl Filter for TokenRouter {
                     metadata_key = %self.config.metadata_key,
                     "Dropping packet, no routing token was found"
                 );
-                self.metrics.packets_dropped_no_token_found.inc();
+                self.metrics.packets_dropped_total_no_token_found.inc();
                 None
             }
             Some(value) => match value {
@@ -85,7 +85,7 @@ impl Filter for TokenRouter {
                             token = &*base64::encode(token),
                             "No endpoint matched token"
                         );
-                        self.metrics.packets_dropped_no_endpoint_match.inc();
+                        self.metrics.packets_dropped_total_no_endpoint_match.inc();
                         None
                     } else {
                         Some(())
@@ -93,11 +93,11 @@ impl Filter for TokenRouter {
                 }
                 _ => {
                     tracing::trace!(
-                        count = ?self.metrics.packets_dropped_invalid_token.get(),
+                        count = ?self.metrics.packets_dropped_total_invalid_token.get(),
                         metadata_key = %self.config.metadata_key,
                         "Packets are being dropped as routing token has invalid type: expected Value::Bytes"
                     );
-                    self.metrics.packets_dropped_invalid_token.inc();
+                    self.metrics.packets_dropped_total_invalid_token.inc();
                     None
                 }
             },
@@ -235,19 +235,22 @@ mod tests {
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"567".to_vec().into()));
 
         assert!(filter.read(&mut ctx).is_none());
-        assert_eq!(1, filter.metrics.packets_dropped_no_endpoint_match.get());
+        assert_eq!(
+            1,
+            filter.metrics.packets_dropped_total_no_endpoint_match.get()
+        );
 
         // no key
         let mut ctx = new_ctx();
         assert!(filter.read(&mut ctx).is_none());
-        assert_eq!(1, filter.metrics.packets_dropped_no_token_found.get());
+        assert_eq!(1, filter.metrics.packets_dropped_total_no_token_found.get());
 
         // wrong type key
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::String(String::from("wrong")));
         assert!(filter.read(&mut ctx).is_none());
-        assert_eq!(1, filter.metrics.packets_dropped_invalid_token.get());
+        assert_eq!(1, filter.metrics.packets_dropped_total_invalid_token.get());
     }
 
     #[test]

--- a/src/filters/token_router/metrics.rs
+++ b/src/filters/token_router/metrics.rs
@@ -22,9 +22,9 @@ use crate::metrics::{filter_opts, CollectorExt};
 
 /// Register and manage metrics for this filter
 pub(super) struct Metrics {
-    pub(super) packets_dropped_no_token_found: GenericCounter<AtomicU64>,
-    pub(super) packets_dropped_invalid_token: GenericCounter<AtomicU64>,
-    pub(super) packets_dropped_no_endpoint_match: GenericCounter<AtomicU64>,
+    pub(super) packets_dropped_total_no_token_found: GenericCounter<AtomicU64>,
+    pub(super) packets_dropped_total_invalid_token: GenericCounter<AtomicU64>,
+    pub(super) packets_dropped_total_no_endpoint_match: GenericCounter<AtomicU64>,
 }
 
 impl Metrics {
@@ -32,7 +32,7 @@ impl Metrics {
         let label_names = vec!["reason"];
         let metric = IntCounterVec::new(
             filter_opts(
-                "packets_dropped",
+                "packets_dropped_total",
                 "TokenRouter",
                 "Total number of packets dropped. labels: reason.",
             ),
@@ -41,11 +41,11 @@ impl Metrics {
         .register_if_not_exists()?;
 
         Ok(Metrics {
-            packets_dropped_no_token_found: metric
+            packets_dropped_total_no_token_found: metric
                 .get_metric_with_label_values(vec!["NoTokenFound"].as_slice())?,
-            packets_dropped_invalid_token: metric
+            packets_dropped_total_invalid_token: metric
                 .get_metric_with_label_values(vec!["InvalidToken"].as_slice())?,
-            packets_dropped_no_endpoint_match: metric
+            packets_dropped_total_no_endpoint_match: metric
                 .get_metric_with_label_values(vec!["NoEndpointMatch"].as_slice())?,
         })
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -141,11 +141,11 @@ pub(crate) fn packets_total(direction: Direction) -> IntCounter {
     PACKETS_TOTAL.with_label_values(&[direction.label()])
 }
 
-pub(crate) fn packets_dropped(direction: Direction, reason: &str) -> IntCounter {
+pub(crate) fn packets_dropped_total(direction: Direction, reason: &str) -> IntCounter {
     static PACKETS_DROPPED: Lazy<IntCounterVec> = Lazy::new(|| {
         prometheus::register_int_counter_vec_with_registry! {
             prometheus::opts! {
-                "packets_dropped",
+                "packets_dropped_total",
                 "Total number of dropped packets",
             },
             &[Direction::LABEL, "reason"],

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -234,7 +234,8 @@ impl Proxy {
         let endpoints: Vec<_> = clusters.endpoints().collect();
         if endpoints.is_empty() {
             tracing::trace!("dropping packet, no upstream endpoints available");
-            crate::metrics::packets_dropped(crate::metrics::READ, "NoEndpointsAvailable").inc();
+            crate::metrics::packets_dropped_total(crate::metrics::READ, "NoEndpointsAvailable")
+                .inc();
             return;
         }
 

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -259,7 +259,7 @@ impl Session {
 
         let handle_error = |error: Error| {
             error.log();
-            crate::metrics::packets_dropped(
+            crate::metrics::packets_dropped_total(
                 crate::metrics::WRITE,
                 "proxy::Session::process_recv_packet",
             )
@@ -318,7 +318,8 @@ impl Session {
                 crate::metrics::bytes_total(crate::metrics::READ).inc_by(size as u64);
             }
             Err(error) => {
-                crate::metrics::packets_dropped(crate::metrics::READ, "proxy::Session::send").inc();
+                crate::metrics::packets_dropped_total(crate::metrics::READ, "proxy::Session::send")
+                    .inc();
                 crate::metrics::errors_total(crate::metrics::READ).inc();
                 tracing::error!(kind=%error.kind(), "{}", error);
                 return;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Per https://prometheus.io/docs/practices/naming/#metric-names

"A metric name should have a suffix describing the unit, in plural form Note that an accumulating count has `total` as a suffix, in addition to the unit if applicable."

Therefore, all "packets_dropped" metric names should be "packet_dropped_total".

This implements that change across all packets_dropped metric (which as far as I can tell is the only metric missing this suffix) for both the metric and variable name, which was sometimes implemented and sometimes not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

N/A