### PR TITLE
Add Pprof profiling endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,43 +53,47 @@ arc-swap = { version = "1.6.0", features = ["serde"] }
 async-stream = "0.3.5"
 base64.workspace = true
 base64-serde = "0.7.0"
-bytes = { version = "1.4.0", features = ["serde"] }
-cached = "0.45.0"
-chrono = "0.4.28"
-clap = { version = "4.4.2", features = ["cargo", "derive", "env"] }
+bytes = { version = "1.5.0", features = ["serde"] }
+cached = "0.46.0"
+chrono = "0.4.31"
+clap = { version = "4.4.6", features = ["cargo", "derive", "env"] }
 dashmap = { version = "5.5.3", features = ["serde"] }
 dirs2 = "3.0.1"
 either = "1.9.0"
-enum-map = "2.6.1"
+enum-map = "2.6.3"
 eyre = "0.6.8"
 futures.workspace = true
 hyper = { version = "0.14.27", features = ["http2"] }
 hyper-rustls = { version = "0.24.1", features = ["http2", "webpki-roots"] }
+form_urlencoded = "1.2.0"
 ipnetwork = "0.20.0"
 k8s-openapi.workspace = true
+kube.workspace = true
+libflate = "2.0.0"
 maxminddb = "0.23.0"
 notify = "6.1.1"
 num_cpus = "1.16.0"
 once_cell = "1.18.0"
 parking_lot = "0.12.1"
+pprof = { version = "0.13.0", features = ["prost", "prost-codec"] }
 prometheus = { version = "0.13.3", default-features = false }
-prost = "0.12.0"
-prost-types = "0.12.0"
+prost = "0.12.1"
+prost-types = "0.12.1"
 rand = "0.8.5"
-regex = "1.9.5"
-schemars = { version = "0.8.13", features = ["chrono", "bytes", "url"] }
+regex = "1.9.6"
+schemars = { version = "0.8.15", features = ["chrono", "bytes", "url"] }
 serde = { version = "1.0.188", features = ["derive", "rc"] }
-serde_json = "1.0.105"
+serde_json = "1.0.107"
 serde_regex = "1.1.0"
 serde_stacker = "0.1.10"
 serde_yaml = "0.9.25"
 snap = "1.1.0"
-socket2 = { version = "0.5.3", features = ["all"] }
+socket2 = { version = "0.5.4", features = ["all"] }
 stable-eyre = "0.2.2"
-thiserror = "1.0.48"
+thiserror = "1.0.49"
 tokio.workspace = true
 tokio-stream = { version = "0.1.14", features = ["sync"] }
-tonic = "0.10.0"
+tonic = "0.10.2"
 tracing.workspace = true
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
@@ -97,19 +101,18 @@ tryhard = "0.5.1"
 url = { version = "2.4.1", features = ["serde"] }
 uuid = { version = "1.4.1", default-features = false, features = ["v4"] }
 lasso = { version = "0.7.2", features = ["multi-threaded"] }
-kube.workspace = true
 trust-dns-resolver = { version = "0.23.0", features = ["tokio", "tokio-rustls", "dns-over-https-rustls"] }
 async-trait = "0.1.73"
 nom = "7.1.3"
 atty = "0.2.14"
 strum = "0.25.0"
-strum_macros = "0.25"
+strum_macros = "0.25.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.1"
 
 [dev-dependencies]
-regex = "1.9.5"
+regex = "1.9.6"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 once_cell = "1.18.0"
 tracing-test = "0.2.4"
@@ -118,9 +121,9 @@ tempfile = "3.8.0"
 rand = "0.8.5"
 
 [build-dependencies]
-tonic-build = { version = "0.10.0", default_features = false, features = ["transport", "prost"] }
-prost-build = "0.12.0"
-built = { version = "0.6.1", features = ["git2"] }
+tonic-build = { version = "0.10.2", default_features = false, features = ["transport", "prost"] }
+prost-build = "0.12.1"
+built = { version = "0.7.0", features = ["git2"] }
 protobuf-src = { version = "1.1.0", optional = true }
 
 [features]

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -156,16 +156,18 @@ fn collect_metrics() -> Response<Body> {
 
 /// Collects profiling information using `prof` for an optional `duration` or
 /// the default if `None`.
-async fn collect_pprof(duration: Option<std::time::Duration>) -> Result<Response<Body>, eyre::Error> {
+async fn collect_pprof(
+    duration: Option<std::time::Duration>,
+) -> Result<Response<Body>, eyre::Error> {
     let duration = duration.unwrap_or_else(|| std::time::Duration::from_secs(2));
     tracing::info!(duration_seconds = duration.as_secs(), "profiling");
 
     let guard = pprof::ProfilerGuardBuilder::default()
-            .frequency(1000)
-            // From the pprof docs, this blocklist helps prevent deadlock with
-            // libgcc's unwind.
-            .blocklist(&["libc", "libgcc", "pthread", "vdso"])
-            .build()?;
+        .frequency(1000)
+        // From the pprof docs, this blocklist helps prevent deadlock with
+        // libgcc's unwind.
+        .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+        .build()?;
 
     tokio::time::sleep(duration).await;
 
@@ -198,7 +200,9 @@ mod tests {
     #[tokio::test]
     async fn collect_pprof() {
         // Custom time to make the test fast.
-        super::collect_pprof(Some(std::time::Duration::from_millis(1))).await.unwrap();
+        super::collect_pprof(Some(std::time::Duration::from_millis(1)))
+            .await
+            .unwrap();
     }
 
     #[test]


### PR DESCRIPTION
This adds a proof profiling endpoint for Quilkin, allowing Quilkin to be continuously profiled using tools like Grafana Phlare.