### PR TITLE
Move instrument level to trace

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -259,7 +259,7 @@ impl Proxy {
     }
 
     /// Send a packet received from `recv_addr` to an endpoint.
-    #[tracing::instrument(skip_all, fields(source = %recv_addr, dest = %endpoint.address))]
+    #[tracing::instrument(level="trace", skip_all, fields(source = %recv_addr, dest = %endpoint.address))]
     async fn session_send_packet(
         packet: &[u8],
         recv_addr: EndpointAddress,


### PR DESCRIPTION
This was unintentionally not set to trace level, this should save us 6.7% of the time spent based on the metrics.
