### PR TITLE
Rename run command to proxy

### DIFF
--- a/agones/src/pod.rs
+++ b/agones/src/pod.rs
@@ -31,7 +31,7 @@ mod tests {
         let client = Client::new().await;
 
         let pods: Api<Pod> = client.namespaced_api();
-        let cmds = ["run", "--to", "127.0.0.1:0"].map(String::from).to_vec();
+        let cmds = ["proxy", "--to", "127.0.0.1:0"].map(String::from).to_vec();
         let pod = Pod {
             metadata: ObjectMeta {
                 generate_name: Some("quilkin-".into()),

--- a/agones/src/sidecar.rs
+++ b/agones/src/sidecar.rs
@@ -100,7 +100,7 @@ clusters:
         let mount_name = "config".to_string();
         template.containers.push(quilkin_container(
             &client,
-            Some(vec!["run".into()]),
+            Some(vec!["proxy".into()]),
             Some(mount_name.clone()),
         ));
 

--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -359,7 +359,7 @@ management_servers:
             .unwrap();
         let mount_name = "config";
         let mut container =
-            quilkin_container(client, Some(vec!["run".into()]), Some(mount_name.into()));
+            quilkin_container(client, Some(vec!["proxy".into()]), Some(mount_name.into()));
 
         // we'll use a host port, since spinning up a load balancer takes a long time.
         // we know that port 7000 is open because this is an Agones cluster and it has associated

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -57,7 +57,7 @@ steps:
     entrypoint: bash
     args:
       - '-c'
-      - 'timeout --signal=INT --preserve-status 5s docker run --rm -v "/workspace/examples/proxy.yaml:/etc/quilkin/quilkin.yaml" ${_REPOSITORY}quilkin:$(make version) run'
+      - 'timeout --signal=INT --preserve-status 5s docker run --rm -v "/workspace/examples/proxy.yaml:/etc/quilkin/quilkin.yaml" ${_REPOSITORY}quilkin:$(make version) proxy'
     id: test-quilkin-image-default-config-file
     waitFor:
       - build
@@ -68,7 +68,7 @@ steps:
     entrypoint: bash
     args:
       - '-c'
-      - 'timeout --signal=INT --preserve-status 5s docker run -v /tmp:/etc/quilkin/ --rm ${_REPOSITORY}quilkin:$(make version) run --to="127.0.0.1:0"'
+      - 'timeout --signal=INT --preserve-status 5s docker run -v /tmp:/etc/quilkin/ --rm ${_REPOSITORY}quilkin:$(make version) proxy --to="127.0.0.1:0"'
     id: test-quilkin-image-command-line
     waitFor:
       - build

--- a/docs/src/admin.md
+++ b/docs/src/admin.md
@@ -28,7 +28,7 @@ Will return an HTTP status of 200 when all health checks pass.
 This provides a readiness probe endpoint, most commonly used in 
 [Kubernetes based systems](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-readiness-probes).
 
-Depending on whether Quilkin is run in Proxy mode i.e. `quilkin run`, vs an xDS provider mode, such as `quilkin 
+Depending on whether Quilkin is run in Proxy mode i.e. `quilkin proxy`, vs an xDS provider mode, such as `quilkin 
 manage agones`, will dictate how readiness is calculated: 
 
 #### Proxy Mode

--- a/docs/src/file-configuration.md
+++ b/docs/src/file-configuration.md
@@ -11,7 +11,7 @@ environment variable.
 
 ## Static Configuration
 
-Example of a full configuration for `quilkin run` that utlisies a static Endpoint configuration:
+Example of a full configuration for `quilkin proxy` that utlisies a static Endpoint configuration:
 
 ```yaml
 {{#include ../../examples/proxy.yaml:17:100}}
@@ -19,7 +19,7 @@ Example of a full configuration for `quilkin run` that utlisies a static Endpoin
 
 ## Dynamic Configuration
 
-Example of a full configuration for `quilkin run` that utlisies a dynamic Endpoint configuration through an 
+Example of a full configuration for `quilkin proxy` that utlisies a dynamic Endpoint configuration through an 
 [xDS management endpoint](./xds.md):
 
 ```yaml

--- a/docs/src/proxy-mode.md
+++ b/docs/src/proxy-mode.md
@@ -3,11 +3,11 @@
 The "proxy mode" is the primary mode of operation for Quilkin, wherein it acts as a non-transparent UDP proxy.
 
 This is driven by Quilkin being [executed](./using.md#command-line-interface) via the 
-[`run` subcommand](../api/quilkin/cli/struct.Run.html).
+[`proxy` subcommand](../api/quilkin/cli/struct.Proxy.html).
 
-To view all the options for the `run` subcommand, run: 
+To view all the options for the `proxy` subcommand, run: 
 
 ```shell
-$ quilkin run --help
+$ quilkin proxy --help
 {{#include ../../target/quilkin.run.commands}}
 ```

--- a/docs/src/proxy/maxmind.md
+++ b/docs/src/proxy/maxmind.md
@@ -3,7 +3,7 @@
 If Quilkin is provided a
 remote URL or local file path to a
 Maxmind IP Geolocation database through the `mmdb` [file](../file-configuration.md) or
-[command line](../../api/quilkin/cli/struct.Run.html#structfield.mmdb)
+[command line](../../api/quilkin/cli/struct.Proxy.html#structfield.mmdb)
 configuration, Quilkin will log the following information in the `maxmind information` log.
 
 | Field           | Description                                   |

--- a/docs/src/quickstarts/netcat.md
+++ b/docs/src/quickstarts/netcat.md
@@ -25,7 +25,7 @@ Next let's configure Quilkin in proxy mode, with a static configuration that poi
 UDP echo service we just started.
 
 ```shell
-quilkin run --to 127.0.0.1:8000
+quilkin proxy --to 127.0.0.1:8000
 ```
 
 This configuration will start Quilkin on the default port of 7000, and it will

--- a/docs/src/xds.md
+++ b/docs/src/xds.md
@@ -32,7 +32,7 @@ Since the range of resources configurable by the xDS API extends that of Quilkin
 ## Connecting to an xDS management server
 
 Connecting a Quilkin proxy to an xDS management server can be implemented via providing one or more URLs to
-the `management_servers` [command line](../api/quilkin/cli/struct.Run.html#structfield.management_server) or 
+the `management_servers` [command line](../api/quilkin/cli/struct.Proxy.html#structfield.management_server) or 
 [file configuration](./file-configuration.md#dynamic-configuration).
 
 

--- a/examples/agones-xonotic-sidecar/sidecar-compress.yaml
+++ b/examples/agones-xonotic-sidecar/sidecar-compress.yaml
@@ -61,7 +61,7 @@ spec:
             - name: xonotic
               image: gcr.io/agones-images/xonotic-example:0.8
             - name: quilkin
-              image: us-docker.pkg.dev/quilkin/release/quilkin:0.4.0
+              image: us-docker.pkg.dev/quilkin/release/quilkin:0.5.0
               args:
                 - proxy
               volumeMounts:

--- a/examples/agones-xonotic-sidecar/sidecar-compress.yaml
+++ b/examples/agones-xonotic-sidecar/sidecar-compress.yaml
@@ -63,7 +63,7 @@ spec:
             - name: quilkin
               image: us-docker.pkg.dev/quilkin/release/quilkin:0.4.0
               args:
-                - run
+                - proxy
               volumeMounts:
                 - name: config
                   mountPath: "/etc/quilkin"

--- a/examples/agones-xonotic-sidecar/sidecar.yaml
+++ b/examples/agones-xonotic-sidecar/sidecar.yaml
@@ -41,8 +41,8 @@ spec:
             - name: xonotic
               image: gcr.io/agones-images/xonotic-example:0.8
             - name: quilkin
-              image: us-docker.pkg.dev/quilkin/release/quilkin:0.4.0
-              args: ["run", "--port", "26001", "--to", "127.0.0.1:26000"]
+              image: us-docker.pkg.dev/quilkin/release/quilkin:0.5.0
+              args: ["proxy", "--port", "26001", "--to", "127.0.0.1:26000"]
               livenessProbe:
                 httpGet:
                   path: /live

--- a/examples/agones-xonotic-xds/README.md
+++ b/examples/agones-xonotic-xds/README.md
@@ -91,7 +91,7 @@ with it in `client-token.yaml`.
 Run this configuration locally as:
 
 ```shell
-$ quilkin -c ./client-token.yaml run
+$ quilkin -c ./client-token.yaml proxy
 {"timestamp":"2022-10-07T22:10:47.257635Z","level":"INFO","fields":{"message":"Starting Quilkin","version":"0.4.0-dev","commit":"c77260a2526542c564829a2c66935c60f00adcd2"},"target":"quilkin::cli"}
 {"timestamp":"2022-10-07T22:10:47.258273Z","level":"INFO","fields":{"message":"Starting","port":7000,"proxy_id":"markmandel45"},"target":"quilkin::proxy"}
 {"timestamp":"2022-10-07T22:10:47.258321Z","level":"INFO","fields":{"message":"Starting admin endpoint","address":"[::]:9092"},"target":"quilkin::admin"}

--- a/examples/agones-xonotic-xds/proxy-pool.yaml
+++ b/examples/agones-xonotic-xds/proxy-pool.yaml
@@ -42,8 +42,8 @@ spec:
     spec:
       containers:
         - name: quilkin
-          image: us-docker.pkg.dev/quilkin/release/quilkin:0.4.0
-          args: ["run", "--management-server", "http://quilkin-manage-agones:80"]
+          image: us-docker.pkg.dev/quilkin/release/quilkin:0.5.0-dev
+          args: ["proxy", "--management-server", "http://quilkin-manage-agones:80"]
           env:
             - name: RUST_LOG
               value: info #,quilkin=trace

--- a/examples/agones-xonotic-xds/proxy-pool.yaml
+++ b/examples/agones-xonotic-xds/proxy-pool.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
         - name: quilkin
-          image: us-docker.pkg.dev/quilkin/release/quilkin:0.5.0-dev
+          image: us-docker.pkg.dev/quilkin/release/quilkin:0.5.0
           args: ["proxy", "--management-server", "http://quilkin-manage-agones:80"]
           env:
             - name: RUST_LOG

--- a/examples/iperf3/run.sh
+++ b/examples/iperf3/run.sh
@@ -39,7 +39,7 @@ echo "Starting iperf3 server..."
 iperf3 --server --interval 10 --port 8001 > /quilkin/server.log &
 
 echo "Starting quilkin server..."
-quilkin run > /quilkin/quilkin.log &
+quilkin proxy > /quilkin/quilkin.log &
 
 echo "Waiting for startup..."
 # Wait for both processes to start up.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@
 
 mod generate_config_schema;
 mod manage;
-mod run;
+mod proxy;
 
 use std::{
     path::{Path, PathBuf},
@@ -30,7 +30,7 @@ use crate::{admin::Mode, Config};
 pub use self::{
     generate_config_schema::GenerateConfigSchema,
     manage::{Manage, Providers},
-    run::Run,
+    proxy::Proxy,
 };
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -59,7 +59,7 @@ pub struct Cli {
 /// The various Quilkin commands.
 #[derive(Clone, clap::Subcommand)]
 pub enum Commands {
-    Run(Run),
+    Proxy(Proxy),
     GenerateConfigSchema(GenerateConfigSchema),
     Manage(Manage),
 }
@@ -67,7 +67,7 @@ pub enum Commands {
 impl Commands {
     pub fn admin_mode(&self) -> Option<Mode> {
         match self {
-            Self::Run(_) => Some(Mode::Proxy),
+            Self::Proxy(_) => Some(Mode::Proxy),
             Self::Manage(_) => Some(Mode::Xds),
             Self::GenerateConfigSchema(_) => None,
         }
@@ -140,7 +140,7 @@ impl Cli {
         let fut = tryhard::retry_fn({
             let shutdown_rx = shutdown_rx.clone();
             move || match self.command.clone() {
-                Commands::Run(runner) => {
+                Commands::Proxy(runner) => {
                     let config = config.clone();
                     let shutdown_rx = shutdown_rx.clone();
                     tokio::spawn(

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -22,7 +22,7 @@ use crate::filters::FilterFactory;
 /// Run Quilkin as a UDP reverse proxy.
 #[derive(clap::Args, Clone)]
 #[non_exhaustive]
-pub struct Run {
+pub struct Proxy {
     /// One or more `quilkin manage` endpoints to listen to for config changes
     #[clap(short, long, env = "QUILKIN_MANAGEMENT_SERVER", conflicts_with("to"))]
     pub management_server: Vec<String>,
@@ -37,7 +37,7 @@ pub struct Run {
     pub to: Vec<SocketAddr>,
 }
 
-impl Run {
+impl Proxy {
     /// Start and run a proxy.
     pub async fn run(
         &self,
@@ -83,7 +83,7 @@ impl Run {
             && config.management_servers.load().is_empty()
         {
             return Err(eyre::eyre!(
-                "`quilkin run` requires at least one `to` address or `management_server` endpoint."
+                "`quilkin proxy` requires at least one `to` address or `management_server` endpoint."
             ));
         }
 


### PR DESCRIPTION
This PR changes the name of the run command to `proxy`. I think this makes it more clear what's being *run* than just run itself.