### PR TITLE
Move xDS task out of Proxy, add Agones as another discovery task

### DIFF
--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -345,9 +345,14 @@ filters:
         let mut container = quilkin_container(
             client,
             Some(vec![
-                "proxy".into(),
-                "--management-server=http://quilkin-manage-agones:7800".into(),
-            ]),
+                            "proxy".into(),
+            <<<<<<< HEAD
+                            "--management-server=http://quilkin-manage-agones:7800".into(),
+            =======
+                            "xds".into(),
+                            "http://quilkin-manage-agones:80".into(),
+            >>>>>>> 76dd00a3 (Move xDS task out of Proxy, add Agones as another discovery task)
+                        ]),
             None,
         );
 

--- a/examples/agones-xonotic-xds/proxy-pool.yaml
+++ b/examples/agones-xonotic-xds/proxy-pool.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: quilkin
           image: us-docker.pkg.dev/quilkin/release/quilkin:0.5.0
-          args: ["proxy", "--management-server", "http://quilkin-manage-agones:80"]
+          args: ["proxy", "xds", "http://quilkin-manage-agones:80"]
           env:
             - name: RUST_LOG
               value: info #,quilkin=trace

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+//! Quilkin's command line interface.
+
+pub mod generate_config_schema;
+pub mod manage;
+mod providers;
+pub mod proxy;
 
 use std::{
     path::{Path, PathBuf},
@@ -24,15 +30,13 @@ use tokio::{signal, sync::watch};
 
 use crate::{admin::Mode, Config};
 
+#[doc(inline)]
 pub use self::{
     generate_config_schema::GenerateConfigSchema,
-    manage::{Manage, Providers},
+    manage::{Manage, Providers as ManageProviders},
+    providers::Kubernetes,
     proxy::Proxy,
 };
-
-pub mod generate_config_schema;
-pub mod manage;
-pub mod proxy;
 
 const ETC_CONFIG_PATH: &str = "/etc/quilkin/quilkin.yaml";
 const PORT_ENV_VAR: &str = "QUILKIN_PORT";

--- a/src/cli/providers.rs
+++ b/src/cli/providers.rs
@@ -1,0 +1,11 @@
+/// Watches Agones' game server CRDs for `Allocated` game server endpoints,
+/// and for a `ConfigMap` that specifies the filter configuration.
+#[derive(Debug, Clone, clap::Args)]
+pub struct Kubernetes {
+    /// The namespace under which the configmap is stored.
+    #[clap(short, long, default_value = "default")]
+    pub config_namespace: String,
+    /// The namespace under which the game servers run.
+    #[clap(short, long, default_value = "default")]
+    pub gameservers_namespace: String,
+}

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -15,44 +15,49 @@
  */
 
 use std::{
+    future::Future,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::Arc,
 };
 
+use futures::FutureExt;
 use tokio::{net::UdpSocket, sync::watch, time::Duration};
 use tonic::transport::Endpoint;
 
-use crate::{proxy::SessionMap, utils::net, xds::ResourceType, Config, Result};
+use crate::{proxy::SessionMap, utils::net, Config, Result};
+
+#[doc(inline)]
+use crate::maxmind_db::Source;
 
 #[cfg(doc)]
 use crate::filters::FilterFactory;
 
-pub const PORT: u16 = 7777;
+const PORT: u16 = 7777;
 
 /// Run Quilkin as a UDP reverse proxy.
 #[derive(clap::Args, Clone)]
 pub struct Proxy {
-    /// One or more `quilkin manage` endpoints to listen to for config changes
-    #[clap(short, long, env = "QUILKIN_MANAGEMENT_SERVER", conflicts_with("to"))]
-    pub management_server: Vec<Endpoint>,
     /// The remote URL or local file path to retrieve the Maxmind database.
     #[clap(long, env)]
-    pub mmdb: Option<crate::maxmind_db::Source>,
+    pub mmdb: Option<Source>,
     /// The port to listen on.
     #[clap(short, long, env = super::PORT_ENV_VAR, default_value_t = PORT)]
     pub port: u16,
     /// One or more socket addresses to forward packets to.
-    #[clap(short, long, env = "QUILKIN_DEST")]
+    #[clap(short, long, env = "QUILKIN_DEST", conflicts_with("provider"))]
     pub to: Vec<SocketAddr>,
+    /// One or more socket addresses to forward packets to.
+    #[clap(subcommand)]
+    pub provider: Option<Providers>,
 }
 
 impl Default for Proxy {
     fn default() -> Self {
         Self {
-            management_server: <_>::default(),
             mmdb: <_>::default(),
             port: PORT,
             to: <_>::default(),
+            provider: <_>::default(),
         }
     }
 }
@@ -61,7 +66,7 @@ impl Proxy {
     /// Start and run a proxy.
     pub async fn run(
         &self,
-        config: std::sync::Arc<crate::Config>,
+        config: Arc<crate::Config>,
         mut shutdown_rx: tokio::sync::watch::Receiver<()>,
     ) -> crate::Result<()> {
         const SESSION_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
@@ -89,44 +94,30 @@ impl Proxy {
             });
         }
 
-        if config.clusters.load().endpoints().count() == 0 && self.management_server.is_empty() {
+        if self.provider.is_none() && config.clusters.load().endpoints().count() == 0 {
             return Err(eyre::eyre!(
-                "`quilkin proxy` requires at least one `to` address or `management_server` endpoint."
+                "`quilkin proxy` requires at least one `to` address or a configuration discovery provider."
             ));
         }
 
         let id = config.id.load();
         tracing::info!(port = self.port, proxy_id = &*id, "Starting");
 
-        let sessions = SessionMap::new(SESSION_TIMEOUT_SECONDS, SESSION_EXPIRY_POLL_INTERVAL);
-
-        let _xds_stream = if !self.management_server.is_empty() {
-            let client =
-                crate::xds::Client::connect(String::clone(&id), self.management_server.clone())
-                    .await?;
-            let mut stream = client
-                .stream({
-                    let config = config.clone();
-                    move |resource| config.apply(resource)
-                })
-                .await?;
-
-            tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
-            stream.send(ResourceType::Endpoint, &[]).await?;
-            tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
-            stream.send(ResourceType::Listener, &[]).await?;
-            Some(stream)
-        } else {
-            None
-        };
-
+        let sessions =
+            crate::proxy::SessionMap::new(SESSION_TIMEOUT_SECONDS, SESSION_EXPIRY_POLL_INTERVAL);
         self.run_recv_from(&config, sessions, shutdown_rx.clone())?;
         tracing::info!("Quilkin is ready");
 
-        shutdown_rx
-            .changed()
-            .await
-            .map_err(|error| eyre::eyre!(error))
+        match self.run_discovery_provider_task(&config) {
+            Some(provider_task) => tokio::select! {
+                result = provider_task => result.map(drop),
+                result = shutdown_rx.changed() => result.map_err(|error| eyre::eyre!(error)),
+            },
+            None => shutdown_rx
+                .changed()
+                .await
+                .map_err(|error| eyre::eyre!(error)),
+        }
     }
 
     /// Spawns a background task that sits in a loop, receiving packets from the passed in socket.
@@ -171,211 +162,73 @@ impl Proxy {
         let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port);
         net::socket_with_reuse(addr.into())
     }
+
+    /// Runs a configuration discovery task based on what provider is given.
+    fn run_discovery_provider_task(
+        &self,
+        config: &Arc<crate::Config>,
+    ) -> Option<impl Future<Output = crate::Result<ProviderResult>>> {
+        match &self.provider {
+            Some(Providers::Xds { management_server }) => {
+                Some(Self::run_xds_discovery(config.clone(), management_server.clone()).boxed())
+            }
+            Some(Providers::Agones(args)) => Some(Self::run_agones_discovery(config, args).boxed()),
+            None => None,
+        }
+    }
+
+    /// Starts the xDS configuration discovery task that will update `config`
+    /// based on changes provided to the client.
+    async fn run_xds_discovery(
+        config: Arc<crate::Config>,
+        management_servers: Vec<Endpoint>,
+    ) -> crate::Result<ProviderResult> {
+        let client =
+            crate::xds::Client::connect(String::clone(&config.id.load()), management_servers)
+                .await?;
+        let mut stream = client
+            .stream(move |resource| config.apply(resource))
+            .await?;
+
+        tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
+        stream.send(crate::xds::ResourceType::Endpoint, &[]).await?;
+        tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
+        stream.send(crate::xds::ResourceType::Listener, &[]).await?;
+
+        Ok(ProviderResult::Xds(client, stream))
+    }
+
+    /// Runs a Agones/Kubernetes configuration discovery task.
+    fn run_agones_discovery(
+        config: &Arc<crate::Config>,
+        args: &crate::cli::Kubernetes,
+    ) -> impl Future<Output = Result<ProviderResult>> {
+        let config = config.clone();
+        let gsn = args.gameservers_namespace.clone();
+        let cn = args.config_namespace.clone();
+
+        crate::task::provider(move || {
+            crate::config::watch::agones(gsn.clone(), cn.clone(), None, config.clone())
+                .map(|result| result.map(|_| ProviderResult::Agones))
+        })
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[non_exhaustive]
+pub enum ProviderResult {
+    Xds(crate::xds::Client, crate::xds::client::Stream),
+    Agones,
+}
 
-    use tokio::time::{timeout, Duration};
-
-    use crate::{
-        config,
-        endpoint::Endpoint,
-        test_utils::{available_addr, create_socket, load_test_filters, TestHelper},
-    };
-
-    #[tokio::test]
-    async fn run_server() {
-        let mut t = TestHelper::default();
-
-        let endpoint1 = t.open_socket_and_recv_single_packet().await;
-        let endpoint2 = t.open_socket_and_recv_single_packet().await;
-
-        let local_addr = available_addr().await;
-        let proxy = crate::cli::Proxy {
-            port: local_addr.port(),
-            ..<_>::default()
-        };
-
-        let config = Arc::new(crate::Config::default());
-        config.clusters.modify(|clusters| {
-            clusters.insert_default(vec![
-                Endpoint::new(endpoint1.socket.local_addr().unwrap().into()),
-                Endpoint::new(endpoint2.socket.local_addr().unwrap().into()),
-            ])
-        });
-
-        t.run_server(config, proxy, None);
-
-        let msg = "hello";
-        endpoint1
-            .socket
-            .send_to(msg.as_bytes(), &local_addr)
-            .await
-            .unwrap();
-        assert_eq!(
-            msg,
-            timeout(Duration::from_secs(1), endpoint1.packet_rx)
-                .await
-                .expect("should get a packet")
-                .unwrap()
-        );
-        assert_eq!(
-            msg,
-            timeout(Duration::from_secs(1), endpoint2.packet_rx)
-                .await
-                .expect("should get a packet")
-                .unwrap()
-        );
-    }
-
-    #[tokio::test]
-    async fn run_client() {
-        let mut t = TestHelper::default();
-
-        let endpoint = t.open_socket_and_recv_single_packet().await;
-
-        let local_addr = available_addr().await;
-        let proxy = crate::cli::Proxy {
-            port: local_addr.port(),
-            ..<_>::default()
-        };
-        let config = Arc::new(Config::default());
-        config.clusters.modify(|clusters| {
-            clusters.insert_default(vec![Endpoint::new(
-                endpoint.socket.local_addr().unwrap().into(),
-            )])
-        });
-        t.run_server(config, proxy, None);
-
-        let msg = "hello";
-        endpoint
-            .socket
-            .send_to(msg.as_bytes(), &local_addr)
-            .await
-            .unwrap();
-        assert_eq!(
-            msg,
-            timeout(Duration::from_millis(100), endpoint.packet_rx)
-                .await
-                .unwrap()
-                .unwrap()
-        );
-    }
-
-    #[tokio::test]
-    async fn run_with_filter() {
-        let mut t = TestHelper::default();
-
-        load_test_filters();
-        let endpoint = t.open_socket_and_recv_single_packet().await;
-        let local_addr = available_addr().await;
-        let config = Arc::new(Config::default());
-        config.filters.store(
-            crate::filters::FilterChain::try_from(vec![config::Filter {
-                name: "TestFilter".to_string(),
-                config: None,
-            }])
-            .map(Arc::new)
-            .unwrap(),
-        );
-        config.clusters.modify(|clusters| {
-            clusters.insert_default(vec![Endpoint::new(
-                endpoint.socket.local_addr().unwrap().into(),
-            )])
-        });
-        t.run_server(
-            config,
-            crate::cli::Proxy {
-                port: local_addr.port(),
-                ..<_>::default()
-            },
-            None,
-        );
-
-        let msg = "hello";
-        endpoint
-            .socket
-            .send_to(msg.as_bytes(), &local_addr)
-            .await
-            .unwrap();
-
-        // search for the filter strings.
-        let result = timeout(Duration::from_millis(100), endpoint.packet_rx)
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(result.contains(msg), "'{}' not found in '{}'", msg, result);
-        assert!(result.contains(":odr:"), ":odr: not found in '{}'", result);
-    }
-
-    #[tokio::test]
-    async fn spawn_downstream_receive_workers() {
-        let t = TestHelper::default();
-
-        let socket = Arc::new(create_socket().await);
-        let addr = socket.local_addr().unwrap();
-        let (_shutdown_tx, shutdown_rx) = watch::channel(());
-        let endpoint = t.open_socket_and_recv_single_packet().await;
-        let msg = "hello";
-        let config = Arc::new(Config::default());
-        config.clusters.modify(|clusters| {
-            clusters.insert_default(vec![endpoint.socket.local_addr().unwrap()])
-        });
-
-        // we'll test a single DownstreamReceiveWorkerConfig
-        crate::proxy::DownstreamReceiveWorkerConfig {
-            worker_id: 1,
-            socket: socket.clone(),
-            config,
-            sessions: <_>::default(),
-            shutdown_rx,
-        }
-        .spawn();
-
-        let socket = create_socket().await;
-        socket.send_to(msg.as_bytes(), &addr).await.unwrap();
-
-        assert_eq!(
-            msg,
-            timeout(Duration::from_secs(1), endpoint.packet_rx)
-                .await
-                .expect("should receive a packet")
-                .unwrap()
-        );
-    }
-
-    #[tokio::test]
-    async fn run_recv_from() {
-        let t = TestHelper::default();
-        let (_shutdown_tx, shutdown_rx) = watch::channel(());
-
-        let msg = "hello";
-        let endpoint = t.open_socket_and_recv_single_packet().await;
-        let local_addr = available_addr().await;
-        let proxy = crate::cli::Proxy {
-            port: local_addr.port(),
-            ..<_>::default()
-        };
-
-        let config = Arc::new(crate::Config::default());
-        config.clusters.modify(|clusters| {
-            clusters.insert_default(vec![endpoint.socket.local_addr().unwrap()])
-        });
-
-        proxy
-            .run_recv_from(&config, <_>::default(), shutdown_rx)
-            .unwrap();
-
-        let socket = create_socket().await;
-        socket.send_to(msg.as_bytes(), &local_addr).await.unwrap();
-        assert_eq!(
-            msg,
-            timeout(Duration::from_secs(1), endpoint.packet_rx)
-                .await
-                .expect("should receive a packet")
-                .unwrap()
-        );
-    }
+#[derive(Debug, Clone, clap::Subcommand)]
+#[non_exhaustive]
+pub enum Providers {
+    Agones(crate::cli::Kubernetes),
+    /// Listens to the provided management endpoint(s) for configuration changes.
+    Xds {
+        /// The list of endpoints to connect to, Quilkin will connect to the
+        /// first successful endpoint.
+        #[clap(short, long, env = "QUILKIN_MANAGEMENT_SERVER")]
+        management_server: Vec<Endpoint>,
+    },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,11 @@
 mod admin;
 mod cluster;
 mod maxmind_db;
+mod proxy;
+mod task;
+
 pub(crate) mod metrics;
 pub(crate) mod prost;
-mod proxy;
 pub(crate) mod ttl_map;
 pub(crate) mod utils;
 

--- a/src/maxmind_db.rs
+++ b/src/maxmind_db.rs
@@ -23,6 +23,8 @@ static HTTP: Lazy<
 });
 pub static CLIENT: Lazy<arc_swap::ArcSwapOption<MaxmindDb>> = Lazy::new(<_>::default);
 
+/// The source of a Maxmind database, available either locally at a specified
+/// path or remotely from a publicly available URL.
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 #[serde(tag = "kind")]
 pub enum Source {

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,0 +1,19 @@
+pub(crate) fn provider<FUTURE, TASK, OUTPUT, ERROR>(
+    task: TASK,
+) -> impl std::future::Future<Output = Result<OUTPUT, ERROR>>
+where
+    ERROR: std::fmt::Display,
+    FUTURE: std::future::Future<Output = Result<OUTPUT, ERROR>>,
+    TASK: Fn() -> FUTURE,
+{
+    const PROVIDER_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
+    tryhard::retry_fn(task)
+        .retries(u32::MAX)
+        .exponential_backoff(PROVIDER_BACKOFF)
+        .on_retry(|_, _, error| {
+            let error = error.to_string();
+            async move {
+                tracing::warn!(%error, "provider task error, retrying");
+            }
+        })
+}

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -169,7 +169,7 @@ mod tests {
         .unwrap();
 
         let client_addr = crate::test_utils::available_addr().await;
-        let client_config = serde_json::from_value(serde_json::json!({
+        let client_config: Arc<Config> = serde_json::from_value(serde_json::json!({
             "version": "v1alpha1",
             "id": "test-proxy",
         }))
@@ -184,7 +184,9 @@ mod tests {
         tokio::spawn(server::spawn(xds_port, xds_config.clone()));
         let client_proxy = crate::cli::Proxy {
             port: client_addr.port(),
-            management_server: vec![format!("http://0.0.0.0:{}", xds_port).parse().unwrap()],
+            provider: Some(crate::cli::proxy::Providers::Xds {
+                management_server: vec![format!("http://0.0.0.0:{}", xds_port).parse().unwrap()],
+            }),
             ..<_>::default()
         };
 


### PR DESCRIPTION
This PR removes the requirement of using management server when in a single cluster. Now Quilkin can now watch for Agones changes in the proxy instance directly. This also moves the xDS client from being inside the proxy, to be run alongside it as a configuration discovery provider along with agones. This layout also opens the pathway in the future to support other configuration discovery providers such as Docker or Consul, if desired.



With #661 you'd now write the proxy as the following for agones and xDS

```
quilkin proxy agones
```

```
quilkin proxy xds http://quilkin-management-server
```


---

I'll update the documentation once CI passes.