### PR TITLE
Timeout for xDS gRPPC Client connection

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,7 @@ pub(crate) const LOG_SAMPLING_RATE: u64 = 1000;
 pub(crate) const BACKOFF_INITIAL_DELAY_MILLISECONDS: u64 = 500;
 pub(crate) const BACKOFF_MAX_DELAY_SECONDS: u64 = 30;
 pub(crate) const BACKOFF_MAX_JITTER_MILLISECONDS: u64 = 2000;
+pub(crate) const CONNECTION_TIMEOUT: u64 = 5;
 
 /// Config is the configuration of a proxy
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

I can't seem to find any default timeout for connection from a tonic gRPC connection - which leads me to think it will block forever.

This might be the cause of why there is only a single retry in #660, but at the very least, we should have a timeout anyway, just in case a connection ends up deadlocking for whatever reason.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #660

**Special notes for your reviewer**:

