### PR TITLE
Make: package_version less brittle

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -29,10 +29,10 @@ rust_toolchain := $(shell grep channel $(project_path)/rust-toolchain.toml | awk
 
 # if this is a release, don't put the sha, otherwise, leave it off.
 ifdef QUILKIN_RELEASE
-	package_version := $(shell grep version -m 1 $(project_path)/Cargo.toml | awk '{print $$3}')
+	package_version := $(shell grep -A1 -w "name = \"quilkin\"" $(project_path)/Cargo.toml | grep version -m 1 | awk '{print $$3}')
 else
 	git_sha := $(shell git rev-parse --short=7 HEAD)
-	package_version := $(shell grep version -m 1 $(project_path)/Cargo.toml | awk '{print $$3}')-${git_sha}
+	package_version := $(shell grep -A1 -w "name = \"quilkin\"" $(project_path)/Cargo.toml | grep version -m 1 | awk '{print $$3}')-${git_sha}
 endif
 
 # Set this value if you want to use an external registry


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

There is no easy / cross platform way to get at the local crate's version, so we are doing some grepping, since we can assume grep is installed on local machines.

This change makes the grep pipeline less brittle by looking for the `name="quilkin"` block first before grepping for the version details.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Unblocks #670

**Special notes for your reviewer**:

N/A