### PR TITLE
Docs: `quilkin run` vs `proxy` bug in preprocessor

### DIFF
--- a/docs/preprocessor.sh
+++ b/docs/preprocessor.sh
@@ -20,7 +20,7 @@ cargo run -q --manifest-path ../Cargo.toml -- -q generate-config-schema -o ../ta
 
 # Output all the command line help
 cargo run -q --manifest-path ../Cargo.toml &> ../target/quilkin.commands || true
-cargo run -q --manifest-path ../Cargo.toml -- run --help &> ../target/quilkin.run.commands || true
+cargo run -q --manifest-path ../Cargo.toml -- proxy --help &> ../target/quilkin.proxy.commands || true
 cargo run -q --manifest-path ../Cargo.toml -- manage --help &> ../target/quilkin.manage.commands || true
 
 # Credit: https://github.com/rust-lang/mdBook/issues/1462#issuecomment-778650045

--- a/docs/src/proxy-mode.md
+++ b/docs/src/proxy-mode.md
@@ -9,5 +9,5 @@ To view all the options for the `proxy` subcommand, run:
 
 ```shell
 $ quilkin proxy --help
-{{#include ../../target/quilkin.run.commands}}
+{{#include ../../target/quilkin.proxy.commands}}
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup

/kind documentation

> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Fixed documentation bug with the change from `quilkin run` to `quilkin proxy`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:

Work on #669 