### PR TITLE
Add hotfix around xDS stream sometimes not responding with changes

### DIFF
--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -175,8 +175,8 @@ impl ControlPlane {
         Ok(Box::pin(async_stream::try_stream! {
             yield response;
 
+            let _span = tracing::trace_span!("stream loop");
             loop {
-                tracing::trace!("stream loop");
                 tokio::select! {
                     _ = rx.changed() => {
                         tracing::trace!("sending new discovery response");


### PR DESCRIPTION
This is a hot fix for #682, as mentioned, this isn't a complete fix for the issue, but it should be good enough for now to ensure that any updates don't get forgotten, and I think we'll want to keep this implementation of the hotfix in even after we properly fix the issue, as there could be other network issues which this would hopefully solve.

This hot fix is similar to before we're we set the client to repeatedly request new information. The difference between this and the old version, is that this will now only set updates after a set timeout where the proxy hasn't received any new updates, rather than a fixed polling rate, this ensures that there can only be so much drift between a proxy and management server before the proxy starts asking the management server for new information.