### PR TITLE
Add region parameters for control planes

### DIFF
--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -20,8 +20,21 @@ pub const PORT: u16 = 7800;
 /// a configuration source.
 #[derive(clap::Args, Clone)]
 pub struct Manage {
+    /// The TCP port to listen to, to serve discovery responses.
     #[clap(short, long, env = super::PORT_ENV_VAR, default_value_t = PORT)]
     port: u16,
+    /// The `region` to set in the cluster map for any provider
+    /// endpoints discovered.
+    #[clap(long, env = "QUILKIN_REGION")]
+    region: Option<String>,
+    /// The `zone` in the `region` to set in the cluster map for any provider
+    /// endpoints discovered.
+    #[clap(long, env = "QUILKIN_ZONE")]
+    zone: Option<String>,
+    /// The `sub_zone` in the `zone` in the `region` to set in the cluster map
+    /// for any provider endpoints discovered.
+    #[clap(long, env = "QUILKIN_SUB_ZONE")]
+    sub_zone: Option<String>,
     /// The configuration source for a management server.
     #[clap(subcommand)]
     pub provider: Providers,
@@ -50,6 +63,19 @@ pub enum Providers {
 
 impl Manage {
     pub async fn manage(&self, config: std::sync::Arc<crate::Config>) -> crate::Result<()> {
+        let locality = (self.region.is_some() || self.zone.is_some() || self.sub_zone.is_some())
+            .then(|| crate::endpoint::Locality {
+                region: self.region.clone().unwrap_or_default(),
+                zone: self.zone.clone().unwrap_or_default(),
+                sub_zone: self.sub_zone.clone().unwrap_or_default(),
+            });
+
+        if let Some(locality) = &locality {
+            config
+                .clusters
+                .modify(|map| map.update_unlocated_endpoints(locality));
+        }
+
         let provider_task = {
             const PROVIDER_RETRIES: u32 = 25;
             const PROVIDER_BACKOFF: std::time::Duration = std::time::Duration::from_millis(250);
@@ -62,11 +88,14 @@ impl Manage {
                 } => tokio::spawn(crate::config::watch::agones(
                     gameservers_namespace.clone(),
                     config_namespace.clone(),
+                    locality.clone(),
                     config.clone(),
                 )),
-                Providers::File { path } => {
-                    tokio::spawn(crate::config::watch::fs(config.clone(), path.clone()))
-                }
+                Providers::File { path } => tokio::spawn(crate::config::watch::fs(
+                    config.clone(),
+                    path.clone(),
+                    locality.clone(),
+                )),
             })
             .retries(PROVIDER_RETRIES)
             .exponential_backoff(PROVIDER_BACKOFF)

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,9 +71,10 @@ impl Config {
         serde_yaml::from_reader(input)
     }
 
-    pub fn update_from_json(
+    fn update_from_json(
         &self,
         map: serde_json::Map<String, serde_json::Value>,
+        locality: Option<crate::endpoint::Locality>,
     ) -> Result<(), eyre::Error> {
         macro_rules! replace_if_present {
             ($($field:ident),+) => {
@@ -86,6 +87,12 @@ impl Config {
         }
 
         replace_if_present!(clusters, filters, id);
+
+        if let Some(locality) = locality {
+            self.clusters
+                .modify(|map| map.update_unlocated_endpoints(&locality));
+        }
+
         self.apply_metrics();
 
         Ok(())

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -25,7 +25,7 @@ use crate::xds::config::endpoint::v3::{lb_endpoint::HostIdentifier, Endpoint as 
 
 pub use self::{
     address::EndpointAddress,
-    locality::{Locality, LocalityEndpoints},
+    locality::{Locality, LocalityEndpoints, LocalitySet},
 };
 
 type EndpointMetadata = crate::metadata::MetadataView<Metadata>;

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -74,6 +74,5 @@ async fn metrics_server() {
         .unwrap();
 
     let response = String::from_utf8(resp.to_vec()).unwrap();
-    dbg!(&response);
     assert!(response.contains(r#"quilkin_packets_total{event="read"} 2"#));
 }


### PR DESCRIPTION
More #600 work, this adds parameters for setting the `region`, `zone`, and `sub-zone` parameters for control plane services, which are set in clusters that they discover, in the future this will allow the relay to easily shard each control plane's endpoint configuration.