### PR TITLE
Add initial implementation of relay service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ bytes = { version = "1.3.0", features = ["serde"] }
 cached = "0.41.0"
 chrono = "0.4.23"
 clap = { version = "4.0.32", features = ["cargo", "derive", "env"] }
-dashmap = "5.4.0"
+dashmap = {version = "5.4.0", features = ["serde"] }
 dirs2 = "3.0.1"
 either = "1.8.0"
 enum-map = "2.4.2"

--- a/build.rs
+++ b/build.rs
@@ -21,9 +21,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     std::env::set_var("PROTOC", protobuf_src::protoc());
 
     let proto_files = vec![
-        "proto/data-plane-api/envoy/config/common/matcher/v3/matcher.proto",
         "proto/data-plane-api/envoy/config/accesslog/v3/accesslog.proto",
         "proto/data-plane-api/envoy/config/cluster/v3/cluster.proto",
+        "proto/data-plane-api/envoy/config/common/matcher/v3/matcher.proto",
         "proto/data-plane-api/envoy/config/listener/v3/listener.proto",
         "proto/data-plane-api/envoy/config/listener/v3/listener_components.proto",
         "proto/data-plane-api/envoy/config/route/v3/route.proto",
@@ -32,6 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/data-plane-api/envoy/service/discovery/v3/discovery.proto",
         "proto/data-plane-api/envoy/type/metadata/v3/metadata.proto",
         "proto/data-plane-api/envoy/type/tracing/v3/custom_tag.proto",
+        "proto/quilkin/relay/v1alpha1/relay.proto",
         "proto/quilkin/filters/capture/v1alpha1/capture.proto",
         "proto/quilkin/filters/compress/v1alpha1/compress.proto",
         "proto/quilkin/filters/concatenate_bytes/v1alpha1/concatenate_bytes.proto",

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -68,8 +68,7 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rustup component add rustfmt clippy && \
     rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-pc-windows-gnu && \
-    cargo install cargo-watch mdbook && \
-    cargo install --git https://gitlab.com/hydai/mdbook-variables.git --branch bump_toml && \
+     cargo install cargo-watch mdbook mdbook-variables && \
     cargo install cargo-about && \
     cargo install --locked cargo-deny && \
     rustup --version && \

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -68,7 +68,7 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rustup component add rustfmt clippy && \
     rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-pc-windows-gnu && \
-     cargo install cargo-watch mdbook mdbook-variables && \
+    cargo install cargo-watch mdbook mdbook-variables && \
     cargo install cargo-about && \
     cargo install --locked cargo-deny && \
     rustup --version && \

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -25,7 +25,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 # Install packages
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y lsb-release jq curl wget zip build-essential software-properties-common \ 
+    apt-get install -y lsb-release jq curl wget zip build-essential software-properties-common \
         libssl-dev pkg-config python3-pip bash-completion g++-x86-64-linux-gnu g++-mingw-w64-x86-64 && \
     pip3 install live-server && \
     echo "source /etc/bash_completion" >> /root/.bashrc
@@ -68,7 +68,8 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rustup component add rustfmt clippy && \
     rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-pc-windows-gnu && \
-    cargo install cargo-watch mdbook mdbook-variables && \
+    cargo install cargo-watch mdbook && \
+    cargo install --git https://gitlab.com/hydai/mdbook-variables.git --branch bump_toml && \
     cargo install cargo-about && \
     cargo install --locked cargo-deny && \
     rustup --version && \

--- a/docs/preprocessor.sh
+++ b/docs/preprocessor.sh
@@ -22,6 +22,7 @@ cargo run -q --manifest-path ../Cargo.toml -- -q generate-config-schema -o ../ta
 cargo run -q --manifest-path ../Cargo.toml &> ../target/quilkin.commands || true
 cargo run -q --manifest-path ../Cargo.toml -- proxy --help &> ../target/quilkin.proxy.commands || true
 cargo run -q --manifest-path ../Cargo.toml -- manage --help &> ../target/quilkin.manage.commands || true
+cargo run -q --manifest-path ../Cargo.toml -- relay --help &> ../target/quilkin.relay.commands || true
 
 # Credit: https://github.com/rust-lang/mdBook/issues/1462#issuecomment-778650045
 jq -M -c .[1] <&0

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -33,6 +33,12 @@
         - [Agones](./services/xds/providers/agones.md)
         - [Filesystem](./services/xds/providers/filesystem.md)
 
+---
+
+- [Relay](./services/relay.md)
+    - [Metrics]()
+    - [Providers]()
+
 # SDKs
 - [Unreal Engine](./sdks/unreal-engine.md)
 

--- a/docs/src/services/relay.md
+++ b/docs/src/services/relay.md
@@ -21,3 +21,86 @@ To view all options for the `relay` subcommand, run:
 $ quilkin relay --help
 {{#include ../../../target/quilkin.relay.commands}}
 ```
+
+## Quickstart
+To get started with the relay service we need to start the relay service, and
+then setup our configuration source. For this we're going to the built-in
+relay client in the control plane service to forward information to the relay.
+For this demo we'll use the file provider for the control plane, but this
+example works with any configuration provider.
+
+```yaml
+# quilkin.yaml
+version: v1alpha1
+clusters:
+  default:
+    localities:
+      - endpoints:
+          - address: 127.0.0.1:8888
+```
+
+To start the relay, run the `relay` command:
+
+```
+quilkin relay 
+```
+
+To spawn the control plane and have the control plane send its configuration,
+we need to run the `manage` command with the `--relay` flag with the address
+of the relay of the relay server we just spawned which is at port `7900` by
+default. We're also going to set `--admin-address` and `--port` flags to avoid
+port collision with the relay's admin and xds endpoints.
+
+```
+quilkin --admin-address http://localhost:8001 \
+    manage \
+    --port 7801 \
+    --relay http://localhost:7900 \
+    file quilkin.yaml
+```
+
+Now if we run cURL on both the relay and the control plane we should see that
+they both contain the same set of endpoints.
+
+```bash
+# Check Control Plane
+curl localhost:8001/config
+# Check Relay
+curl localhost:8000/config
+```
+
+Since the relay service also exposes a aDS control plane endpoint, that
+represents the merged set of all sources, to connect this to the proxy all we
+have to do is use the same `--management-server` flag that we use to specify
+the location of control planes, then the proxies will be able to pull
+configuration from the relay.
+
+```
+quilkin --admin-address http://localhost:8002 proxy --management-server http://127.0.0.1:7800
+```
+
+We can also additionally add a second control plane source to the relay, which
+will be merged with our control plane's configuration to create a singular
+set of data that the proxies can query using xDS discovery requests.
+
+```yaml
+# quilkin2.yaml
+version: v1alpha1
+clusters:
+  default:
+    localities:
+      - endpoints:
+          - address: 127.0.0.1:9999
+```
+
+```
+quilkin --admin-address http://localhost:8003 \
+    manage \
+    --port 7802 \
+    --relay http://localhost:7900 \
+    file quilkin.yaml
+```
+
+And that's it! We've just setup control planes to look for configuration changes
+in our system, a relay to merge any changes into a unified dataset, and set up
+proxies that make use of that data to decide where and how to send packets.

--- a/docs/src/services/relay.md
+++ b/docs/src/services/relay.md
@@ -1,0 +1,17 @@
+# xDS Control Plane
+
+| services | ports | Protocol |
+|----------|-------|-----------|
+| ADS | 7800 | gRPC(IPv4) |
+| CPDS | 7900 | gRPC(IPv4) |
+
+For multi-cluster integration, Quilkin provides a `relay` service, that can be
+used with a multiple [control plane](./xds.md) services to provide a unified
+"Aggregated Discovery Service" endpoint.
+
+To view all options for the `relay` subcommand, run:
+
+```shell
+$ quilkin relay --help
+{{#include ../../../target/quilkin.manage.commands}}
+```

--- a/docs/src/services/relay.md
+++ b/docs/src/services/relay.md
@@ -1,4 +1,4 @@
-# xDS Control Plane
+# Control Plane Relay
 
 | services | ports | Protocol |
 |----------|-------|-----------|
@@ -6,12 +6,18 @@
 | CPDS | 7900 | gRPC(IPv4) |
 
 For multi-cluster integration, Quilkin provides a `relay` service, that can be
-used with a multiple [control plane](./xds.md) services to provide a unified
-"Aggregated Discovery Service" endpoint.
+used with a multiple [control plane](./xds.md) services in different clusters to
+provide a unified "Aggregated Discovery Service" endpoint for [proxy](./proxy.md)
+services.
+
+To connect to a control plane to a relay, add the `--relay` flag to your control
+plane with the address of the relay. Then to connect a proxy service to the
+relay's ADS endpoint, you use the same `--management-server` argument for
+connecting to control planes.
 
 To view all options for the `relay` subcommand, run:
 
 ```shell
 $ quilkin relay --help
-{{#include ../../../target/quilkin.manage.commands}}
+{{#include ../../../target/quilkin.relay.commands}}
 ```

--- a/proto/quilkin/relay/v1alpha1/relay.proto
+++ b/proto/quilkin/relay/v1alpha1/relay.proto
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+
+package quilkin.relay.v1alpha1;
+
+import "envoy/service/discovery/v3/discovery.proto";
+
+// The Manager Discovery Service provides an RPC for a management
+// service to upstream its configuration to a relay service.
+// This RPC works essentially the same as xDS, except instead of the
+// client connecting to the server to receive configuration, the
+// client is connecting to the server send its configuration.
+//
+// This service enables the relay to merge the configuration of all
+// currently live management servers as a single aggregated
+// xDS server without the relay needing to maintain a list
+// of xDS servers to connect to in the relay itself.
+service AggregatedControlPlaneDiscoveryService {
+  // The RPC protocol begins with a single empty DiscoveryResponse
+  // initiated by the management server, after that this behaves
+  // the same as the management server xDS protocol, except with
+  // DiscoveryRequests initiated by the server rather than the client.
+  rpc StreamAggregatedResources(stream envoy.service.discovery.v3.DiscoveryResponse)
+      returns (stream envoy.service.discovery.v3.DiscoveryRequest) {
+  }
+}

--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -22,7 +22,7 @@ define_port!(7800);
 pub struct Manage {
     /// One or more `quilkin relay` endpoints to push configuration changes to.
     #[clap(short, long, env = "QUILKIN_MANAGEMENT_SERVER")]
-    pub relay_server: Vec<tonic::transport::Endpoint>,
+    pub relay: Vec<tonic::transport::Endpoint>,
     /// The TCP port to listen to, to serve discovery responses.
     #[clap(short, long, env = super::PORT_ENV_VAR, default_value_t = PORT)]
     port: u16,
@@ -110,11 +110,11 @@ impl Manage {
             })
         };
 
-        let _relay_stream = if !self.relay_server.is_empty() {
+        let _relay_stream = if !self.relay.is_empty() {
             tracing::info!("connecting to relay server");
             let client = crate::xds::client::MdsClient::connect(
                 String::clone(&config.id.load()),
-                self.relay_server.clone(),
+                self.relay.clone(),
             )
             .await?;
             Some(client.mds_client_stream(config.clone()))

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -81,12 +81,11 @@ impl Proxy {
         });
 
         if !self.to.is_empty() {
-            config.clusters.modify(|clusters| {
-                clusters.default_cluster_mut().localities = vec![self.to.clone().into()].into();
-            });
+            config.clusters.value().default_cluster_mut().localities =
+                vec![self.to.clone().into()].into();
         }
 
-        if config.clusters.load().endpoints().count() == 0 && self.management_server.is_empty() {
+        if config.clusters.value().endpoints().count() == 0 && self.management_server.is_empty() {
             return Err(eyre::eyre!(
                 "`quilkin proxy` requires at least one `to` address or `management_server` endpoint."
             ));

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-    sync::Arc,
-};
+use std::{net::SocketAddr, sync::Arc};
 
-use tokio::{net::UdpSocket, sync::watch, time::Duration};
+use tokio::{sync::watch, time::Duration};
 use tonic::transport::Endpoint;
 
 use crate::{proxy::SessionMap, utils::net, xds::ResourceType, Config, Result};
@@ -27,7 +24,7 @@ use crate::{proxy::SessionMap, utils::net, xds::ResourceType, Config, Result};
 #[cfg(doc)]
 use crate::filters::FilterFactory;
 
-pub const PORT: u16 = 7777;
+define_port!(7777);
 
 /// Run Quilkin as a UDP reverse proxy.
 #[derive(clap::Args, Clone)]
@@ -102,19 +99,18 @@ impl Proxy {
 
         let _xds_stream = if !self.management_server.is_empty() {
             let client =
-                crate::xds::Client::connect(String::clone(&id), self.management_server.clone())
+                crate::xds::AdsClient::connect(String::clone(&id), self.management_server.clone())
                     .await?;
-            let mut stream = client
-                .stream({
-                    let config = config.clone();
-                    move |resource| config.apply(resource)
-                })
-                .await?;
+            let mut stream = client.xds_client_stream(config.clone());
 
             tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
-            stream.send(ResourceType::Endpoint, &[]).await?;
+            stream
+                .discovery_request(ResourceType::Endpoint, &[])
+                .await?;
             tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
-            stream.send(ResourceType::Listener, &[]).await?;
+            stream
+                .discovery_request(ResourceType::Listener, &[])
+                .await?;
             Some(stream)
         } else {
             None
@@ -147,7 +143,7 @@ impl Proxy {
         // Contains config for each worker task.
         let mut workers = Vec::with_capacity(num_workers);
         for worker_id in 0..num_workers {
-            let socket = Arc::new(self.bind(self.port)?);
+            let socket = Arc::new(net::socket_with_reuse(self.port)?);
             workers.push(crate::proxy::DownstreamReceiveWorkerConfig {
                 worker_id,
                 socket: socket.clone(),
@@ -164,12 +160,6 @@ impl Proxy {
         }
 
         Ok(())
-    }
-
-    /// binds the local configured port with port and address reuse applied.
-    fn bind(&self, port: u16) -> Result<UdpSocket> {
-        let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, port);
-        net::socket_with_reuse(addr.into())
     }
 }
 

--- a/src/cli/relay.rs
+++ b/src/cli/relay.rs
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::sync::Arc;
+
+use crate::config::Config;
+
+pub const PORT: u16 = 7900;
+
+/// Runs Quilkin as a relay service that runs a Manager Discovery Service
+/// (mDS) for accepting cluster and configuration information from xDS
+/// management services, and exposing it as a single merged xDS service for
+/// proxy services.
+#[derive(clap::Args, Clone)]
+pub struct Relay {
+    /// Port for mDS service.
+    #[clap(short, long, env = "QUILKIN_MDS_PORT", default_value_t = PORT)]
+    mds_port: u16,
+    /// Port for xDS management_server service
+    #[clap(short, long, env = super::PORT_ENV_VAR, default_value_t = super::manage::PORT)]
+    xds_port: u16,
+}
+
+impl Relay {
+    pub async fn relay(&self, config: Arc<Config>) -> crate::Result<()> {
+        let xds_server = crate::xds::server::spawn(self.xds_port, config.clone());
+        let mds_server = tokio::spawn(crate::xds::server::control_plane_discovery_server(
+            self.mds_port,
+            config,
+        ));
+
+        tokio::select! {
+            result = xds_server => {
+                result
+            }
+            result = mds_server => {
+                result?
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,7 +121,13 @@ impl Config {
             }
             ResourceType::Cluster => {
                 let clusters = self.clusters.load();
-                for cluster in names.iter().filter_map(|name| clusters.get(name)) {
+                let clusters: Vec<_> = if names.is_empty() {
+                    clusters.values().collect()
+                } else {
+                    names.iter().filter_map(|name| clusters.get(name)).collect()
+                };
+
+                for cluster in clusters {
                     resources.push(resource_type.encode_to_any(
                         &crate::xds::config::cluster::v3::Cluster::try_from(cluster)?,
                     )?);

--- a/src/config/watch.rs
+++ b/src/config/watch.rs
@@ -18,3 +18,100 @@ pub mod agones;
 mod fs;
 
 pub use self::{agones::watch as agones, fs::watch as fs};
+
+use tokio::sync::watch;
+
+#[derive(Clone, Debug)]
+pub struct Watch<T> {
+    value: T,
+    watchers: std::sync::Arc<watch::Sender<T>>,
+}
+
+impl<T: Clone> Watch<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            watchers: std::sync::Arc::new(watch::channel(value.clone()).0),
+            value,
+        }
+    }
+
+    pub async fn has_changed(&self) -> Result<(), watch::error::RecvError> {
+        self.watchers.subscribe().changed().await
+    }
+}
+
+impl<T: Clone + PartialEq> Watch<T> {
+    pub fn value(&self) -> WatchGuard<T> {
+        WatchGuard { inner: self }
+    }
+
+    pub fn modify(&self, func: impl Fn(&WatchGuard<T>)) {
+        (func)(&WatchGuard { inner: self })
+    }
+
+    pub fn check_for_changes(&self) {
+        if self.value != *self.watchers.borrow() {
+            self.watchers.send_replace(self.value.clone());
+        }
+    }
+}
+
+impl<T: serde::Serialize> serde::Serialize for Watch<T> {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        self.value.serialize(ser)
+    }
+}
+
+impl<T: Default + Clone> Default for Watch<T> {
+    fn default() -> Self {
+        Watch::new(<_>::default())
+    }
+}
+
+impl<'de, T: serde::Deserialize<'de> + Clone> serde::Deserialize<'de> for Watch<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        <T>::deserialize(deserializer).map(Watch::new)
+    }
+}
+
+impl<T: schemars::JsonSchema> schemars::JsonSchema for Watch<T> {
+    fn schema_name() -> String {
+        <T>::schema_name()
+    }
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        <T>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        <T>::is_referenceable()
+    }
+}
+
+pub struct WatchGuard<'inner, T: Clone + PartialEq> {
+    inner: &'inner Watch<T>,
+}
+
+impl<'inner, T: Clone + PartialEq> Drop for WatchGuard<'inner, T> {
+    fn drop(&mut self) {
+        self.inner.check_for_changes();
+    }
+}
+
+impl<'inner, T: Clone + PartialEq> std::ops::Deref for WatchGuard<'inner, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner.value
+    }
+}
+
+impl<T: PartialEq> PartialEq for Watch<T> {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.value.eq(&rhs.value)
+    }
+}
+
+impl<T: Eq> Eq for Watch<T> {}

--- a/src/endpoint/locality.rs
+++ b/src/endpoint/locality.rs
@@ -218,6 +218,13 @@ impl LocalitySet {
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut LocalityEndpoints> + '_ {
         self.0.values_mut()
     }
+
+    pub fn merge(&mut self, cluster: &Self) {
+        for (key, value) in &cluster.0 {
+            let entry = self.0.entry(key.clone()).or_default();
+            *entry = value.clone();
+        }
+    }
 }
 
 impl Serialize for LocalitySet {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -147,8 +147,7 @@ impl DownstreamReceiveWorkerConfig {
         downstream_socket: Arc<UdpSocket>,
         sessions: SessionMap,
     ) -> std::io::Result<usize> {
-        let clusters = config.clusters.load();
-        let endpoints: Vec<_> = clusters.endpoints().collect();
+        let endpoints: Vec<_> = config.clusters.value().endpoints().collect();
         if endpoints.is_empty() {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,11 +15,7 @@
  */
 
 /// Common utilities for testing
-use std::{
-    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
-    str::from_utf8,
-    sync::Arc,
-};
+use std::{net::SocketAddr, str::from_utf8, sync::Arc};
 
 use once_cell::sync::Lazy;
 use tokio::{
@@ -292,9 +288,7 @@ where
 
 /// Opens a new socket bound to an ephemeral port
 pub async fn create_socket() -> UdpSocket {
-    let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 0);
-    // Use a standard socket in test utils as we only want to bind sockets to unused ports.
-    UdpSocket::bind(addr).await.unwrap()
+    crate::utils::net::socket_with_reuse(0).unwrap()
 }
 
 pub fn config_with_dummy_endpoint() -> Config {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -294,20 +294,18 @@ pub async fn create_socket() -> UdpSocket {
 pub fn config_with_dummy_endpoint() -> Config {
     let config = Config::default();
 
-    config.clusters.modify(|map| {
-        let _ = map.get_default_mut().insert(&mut Cluster {
-            name: "default".into(),
-            localities: vec![LocalityEndpoints {
-                locality: None,
-                endpoints: [Endpoint {
-                    address: (std::net::Ipv4Addr::LOCALHOST, 8080).into(),
-                    ..<_>::default()
-                }]
-                .into(),
+    config.clusters.value().insert(Cluster {
+        name: "default".into(),
+        localities: vec![LocalityEndpoints {
+            locality: None,
+            endpoints: [Endpoint {
+                address: (std::net::Ipv4Addr::LOCALHOST, 8080).into(),
+                ..<_>::default()
             }]
-            .into_iter()
-            .collect(),
-        });
+            .into(),
+        }]
+        .into_iter()
+        .collect(),
     });
 
     config

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -312,7 +312,7 @@ mod tests {
             let local_addr: crate::endpoint::EndpointAddress = socket.local_addr().unwrap().into();
 
             config.clusters.modify(|clusters| {
-                let cluster = clusters.default_cluster_mut();
+                let mut cluster = clusters.default_cluster_mut();
                 cluster.localities.clear();
                 cluster.insert(Endpoint::new(local_addr.clone()));
             });
@@ -345,7 +345,7 @@ mod tests {
                 local_addr,
                 config
                     .clusters
-                    .load()
+                    .value()
                     .get_default()
                     .unwrap()
                     .endpoints()

--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -98,11 +98,17 @@ impl ControlPlane {
             watchers: <_>::default(),
         };
 
-        this.config.clusters.watch({
+        tokio::spawn({
             let this = this.clone();
-            move |_| {
-                this.push_update(ResourceType::Endpoint);
-                this.push_update(ResourceType::Cluster);
+            async move {
+                loop {
+                    tokio::select! {
+                        _ = this.config.clusters.has_changed() => {
+                            this.push_update(ResourceType::Endpoint);
+                            this.push_update(ResourceType::Cluster);
+                        }
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
This PR adds the initial implementation of the multi-cluster relay service. This service allows you to connect multiple control planes into a single aDS server for all proxy services.

fixes #600 