### PR TITLE
Refactor provider task retrying and move providers to their own module

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,10 +25,7 @@ use tokio::{signal, sync::watch};
 use crate::{admin::Mode, Config};
 
 pub use self::{
-    generate_config_schema::GenerateConfigSchema,
-    manage::{Manage, Providers},
-    proxy::Proxy,
-    relay::Relay,
+    generate_config_schema::GenerateConfigSchema, manage::Manage, proxy::Proxy, relay::Relay,
 };
 
 macro_rules! define_port {

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 
 mod config_type;
 mod error;
+pub mod provider;
 mod slot;
 pub mod watch;
 
@@ -38,7 +39,9 @@ use crate::{
     },
 };
 
-pub use self::{config_type::ConfigType, error::ValidationError, slot::Slot, watch::Watch};
+pub use self::{
+    config_type::ConfigType, error::ValidationError, provider::Providers, slot::Slot, watch::Watch,
+};
 
 base64_serde_type!(pub Base64Standard, base64::STANDARD);
 

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -1,0 +1,71 @@
+const RETRIES: u32 = 25;
+const BACKOFF_STEP: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// The available xDS source providers.
+#[derive(Clone, Debug, clap::Subcommand)]
+pub enum Providers {
+    /// Watches Agones' game server CRDs for `Allocated` game server endpoints,
+    /// and for a `ConfigMap` that specifies the filter configuration.
+    Agones {
+        /// The namespace under which the configmap is stored.
+        #[clap(short, long, default_value = "default")]
+        config_namespace: String,
+        /// The namespace under which the game servers run.
+        #[clap(short, long, default_value = "default")]
+        gameservers_namespace: String,
+    },
+
+    /// Watches for changes to the file located at `path`.
+    File {
+        /// The path to the source config.
+        path: std::path::PathBuf,
+    },
+}
+
+impl Providers {
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub fn spawn(
+        &self,
+        config: std::sync::Arc<crate::Config>,
+        locality: Option<crate::endpoint::Locality>,
+    ) -> tokio::task::JoinHandle<crate::Result<()>> {
+        match &self {
+            Self::Agones {
+                gameservers_namespace,
+                config_namespace,
+            } => tokio::spawn(Self::task({
+                let gameservers_namespace = gameservers_namespace.clone();
+                let config_namespace = config_namespace.clone();
+                move || {
+                    crate::config::watch::agones(
+                        gameservers_namespace.clone(),
+                        config_namespace.clone(),
+                        locality.clone(),
+                        config.clone(),
+                    )
+                }
+            })),
+            Self::File { path } => tokio::spawn(Self::task({
+                let path = path.clone();
+                move || crate::config::watch::fs(config.clone(), path.clone(), locality.clone())
+            })),
+        }
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn task<F>(task: impl FnMut() -> F) -> crate::Result<()>
+    where
+        F: std::future::Future<Output = crate::Result<()>>,
+    {
+        tryhard::retry_fn(task)
+            .retries(RETRIES)
+            .exponential_backoff(BACKOFF_STEP)
+            .on_retry(|attempt, _, error: &eyre::Error| {
+                let error = error.to_string();
+                async move {
+                    tracing::warn!(%attempt, %error, "provider task error, retrying");
+                }
+            })
+            .await
+    }
+}


### PR DESCRIPTION
Fixes #697 

This PR addresses the provider task failing, the issue was that we were retrying the spawn, rather than spawning the retry task. This also moves the providers to their own module so that they can be shared between services, for example in #662 