### PR TITLE
Don't drop the stream client until the function completes

### DIFF
--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -110,7 +110,7 @@ impl Proxy {
             stream
                 .discovery_request(ResourceType::Listener, &[])
                 .await?;
-            Some(stream)
+            Some((client, stream))
         } else {
             None
         };


### PR DESCRIPTION
Keeps the original xDS client alive until the function completes rather than dropping them after the initial requests.