### PR TITLE
Add test for relay proxy routing (and support for file providers)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ serde_yaml = "0.9.16"
 snap = "1.1.0"
 socket2 = "0.4.7"
 stable-eyre = "0.2.2"
-tempdir = "0.3.7"
 thiserror = "1.0.38"
 tokio.workspace = true
 tokio-stream = { version = "0.1.11", features = ["sync"] }
@@ -107,6 +106,7 @@ criterion = { version = "0.4.0", features = ["html_reports"] }
 once_cell = "1.17.0"
 tracing-test = "0.2.3"
 pretty_assertions = "1.3.0"
+tempfile = "3.3.0"
 
 [build-dependencies]
 tonic-build = { version = "0.8.4", default_features = false, features = ["transport", "prost"] }

--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -27,19 +27,19 @@ pub struct Manage {
     pub relay: Vec<tonic::transport::Endpoint>,
     /// The TCP port to listen to, to serve discovery responses.
     #[clap(short, long, env = super::PORT_ENV_VAR, default_value_t = PORT)]
-    port: u16,
+    pub port: u16,
     /// The `region` to set in the cluster map for any provider
     /// endpoints discovered.
     #[clap(long, env = "QUILKIN_REGION")]
-    region: Option<String>,
+    pub region: Option<String>,
     /// The `zone` in the `region` to set in the cluster map for any provider
     /// endpoints discovered.
     #[clap(long, env = "QUILKIN_ZONE")]
-    zone: Option<String>,
+    pub zone: Option<String>,
     /// The `sub_zone` in the `zone` in the `region` to set in the cluster map
     /// for any provider endpoints discovered.
     #[clap(long, env = "QUILKIN_SUB_ZONE")]
-    sub_zone: Option<String>,
+    pub sub_zone: Option<String>,
     /// The configuration source for a management server.
     #[clap(subcommand)]
     pub provider: crate::config::Providers,

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -110,7 +110,7 @@ impl Proxy {
             stream
                 .discovery_request(ResourceType::Listener, &[])
                 .await?;
-            Some(stream)
+            Some((client, stream))
         } else {
             None
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,7 @@ impl Config {
             ($($field:ident),+) => {
                 $(
                     if let Some(value) = map.get(stringify!($field)) {
+                        tracing::trace!(%value, "replacing {}", stringify!($field));
                         self.$field.try_replace(serde_json::from_value(value.clone())?);
                     }
                 )+
@@ -95,6 +96,7 @@ impl Config {
             let clusters = self.clusters.value();
 
             if let Some(value) = map.get("clusters") {
+                tracing::trace!(clusters=%value, "merging new clusters");
                 clusters.merge(serde_json::from_value(value.clone())?);
             }
 
@@ -167,6 +169,8 @@ impl Config {
 
     #[tracing::instrument(skip_all, fields(response = response.type_url()))]
     pub fn apply(&self, response: &Resource) -> crate::Result<()> {
+        tracing::trace!(resource=?response, "applying resource");
+
         let apply_cluster = |cluster: Cluster| {
             tracing::trace!(endpoints = %serde_json::to_value(&cluster).unwrap(), "applying new endpoints");
             self.clusters

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -42,7 +42,7 @@ impl Providers {
         config: std::sync::Arc<crate::Config>,
         locality: Option<crate::endpoint::Locality>,
     ) -> tokio::task::JoinHandle<crate::Result<()>> {
-        match dbg!(&self) {
+        match &self {
             Self::Agones {
                 gameservers_namespace,
                 config_namespace,

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -28,7 +28,7 @@ pub use self::{
     locality::{Locality, LocalityEndpoints, LocalitySet},
 };
 
-type EndpointMetadata = crate::metadata::MetadataView<Metadata>;
+pub type EndpointMetadata = crate::metadata::MetadataView<Metadata>;
 
 /// A destination endpoint with any associated metadata.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone, Eq, schemars::JsonSchema)]

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -132,6 +132,10 @@ impl std::fmt::Debug for FilterChain {
 
 impl PartialEq for FilterChain {
     fn eq(&self, rhs: &Self) -> bool {
+        if self.filters.len() != rhs.filters.len() {
+            return false;
+        }
+
         self.filters.iter().zip(&rhs.filters).all(
             |((lhs_name, lhs_instance), (rhs_name, rhs_instance))| {
                 lhs_name == rhs_name && lhs_instance.config == rhs_instance.config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,15 +17,16 @@
 #![deny(unused_must_use)]
 
 mod admin;
-mod cluster;
 mod maxmind_db;
+mod proxy;
+
 pub(crate) mod metrics;
 pub(crate) mod prost;
-mod proxy;
 pub(crate) mod ttl_map;
 pub(crate) mod utils;
 
 pub mod cli;
+pub mod cluster;
 pub mod config;
 pub mod endpoint;
 pub mod filters;

--- a/src/xds/client.rs
+++ b/src/xds/client.rs
@@ -202,7 +202,7 @@ impl<C: ServiceClient> Client<C> {
         .with_config(retry_config);
 
         let client = connect_to_server
-            .instrument(tracing::trace_span!("mds_client_connect"))
+            .instrument(tracing::trace_span!("client_connect"))
             .await?;
         tracing::info!("Connected to relay server");
         Ok(client)


### PR DESCRIPTION
This PR adds a token routing test except using the relay as the configuration provider for the proxy. This also adds support for file providers to the relay so that the test could be done as a unit test in the library.