### PR TITLE
Don't apply xDS resources when the version matches the previously applied version

### DIFF
--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -56,6 +56,8 @@ mod tests {
     /// for this test, we should only have single Agones integration test in this suite, since they
     /// could easily collide with each other.
     async fn agones_token_router() {
+        quilkin::test_utils::enable_tracing_log();
+
         let client = Client::new().await;
 
         let deployments: Api<Deployment> = client.namespaced_api();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -34,8 +34,7 @@ use crate::{
 static ENABLE_LOG: Lazy<()> = Lazy::new(|| {
     tracing_subscriber::fmt()
         .pretty()
-        .with_env_filter("quilkin=trace")
-        .with_max_level(tracing::Level::TRACE)
+        .with_env_filter("info,quilkin=trace")
         .init()
 });
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -34,7 +34,7 @@ use crate::{
 static ENABLE_LOG: Lazy<()> = Lazy::new(|| {
     tracing_subscriber::fmt()
         .pretty()
-        .with_max_level(tracing::Level::Debug)
+        .with_max_level(tracing::Level::DEBUG)
         .init()
 });
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -34,6 +34,7 @@ use crate::{
 static ENABLE_LOG: Lazy<()> = Lazy::new(|| {
     tracing_subscriber::fmt()
         .pretty()
+        .with_env_filter("quilkin=trace")
         .with_max_level(tracing::Level::TRACE)
         .init()
 });

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -34,7 +34,7 @@ use crate::{
 static ENABLE_LOG: Lazy<()> = Lazy::new(|| {
     tracing_subscriber::fmt()
         .pretty()
-        .with_env_filter("info,quilkin=trace")
+        .with_max_level(tracing::Level::Debug)
         .init()
 });
 

--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -126,7 +126,7 @@ impl ControlPlane {
         let watchers = &self.watchers[resource_type];
         watchers
             .version
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         tracing::trace!(%resource_type, watchers=watchers.sender.receiver_count(), "pushing update");
         if let Err(error) = watchers.sender.send(()) {
             tracing::warn!(%error, "pushing update failed");
@@ -148,7 +148,7 @@ impl ControlPlane {
         let nonce = uuid::Uuid::new_v4();
         response.version_info = watchers
             .version
-            .load(std::sync::atomic::Ordering::Relaxed)
+            .load(std::sync::atomic::Ordering::SeqCst)
             .to_string();
         response.control_plane = Some(crate::xds::config::core::v3::ControlPlane {
             identifier: (*self.config.id.load()).clone(),


### PR DESCRIPTION
Previously the client would always attempt to apply configuration changes, this changes it so we only apply changes when changes are present.