### PR TITLE
Workaround for an issue in the quilkin proxy

### DIFF
--- a/src/config/providers/k8s/agones.rs
+++ b/src/config/providers/k8s/agones.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use std::net::ToSocketAddrs;
 use k8s_openapi::{
     apiextensions_apiserver::pkg::apis::apiextensions::v1::{
         CustomResourceDefinition, CustomResourceDefinitionNames, CustomResourceDefinitionSpec,
@@ -272,8 +273,9 @@ impl TryFrom<GameServer> for Endpoint {
             .as_ref()
             .and_then(|ports| ports.first().map(|status| status.port))
             .unwrap_or_default();
+        let socket_address = (address, port).to_socket_addrs()?.next().unwrap();
         let filter_metadata = crate::endpoint::Metadata { tokens };
-        Ok(Self::with_metadata((address, port).into(), filter_metadata))
+        Ok(Self::with_metadata(socket_address.into(), filter_metadata))
     }
 }
 

--- a/src/endpoint/address.rs
+++ b/src/endpoint/address.rs
@@ -64,7 +64,7 @@ impl EndpointAddress {
         Ok(if let Some(port) = self.port {
             match &self.host {
                 AddressKind::Ip(ip) => (*ip, port).to_socket_addrs()?.next().unwrap(),
-                AddressKind::Name(name) => (&**name, port).to_socket_addrs()?.next().unwrap(),
+                AddressKind::Name(name) => (&**name, port).to_socket_addrs()?.next().unwrap(), // The real issue originates from here, dns lookup makes proxying slow.
             }
         } else {
             match &self.host {


### PR DESCRIPTION
The proxy makes dns lookups that slows down proxying.

This patch makes dns lookups in the manager instead, sending ips to the proxy instance so it does not have to do lookups.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:

