### PR TITLE
Resolve DNS asynchronously

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", default-features = false, features = ["v4"] }
 lasso = { version = "0.6.0", features = ["multi-threaded"] }
 kube.workspace = true
+trust-dns-resolver = { version = "0.22.0", features = ["tokio", "tokio-rustls", "dns-over-https-rustls"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ uuid = { version = "1.2.2", default-features = false, features = ["v4"] }
 lasso = { version = "0.6.0", features = ["multi-threaded"] }
 kube.workspace = true
 trust-dns-resolver = { version = "0.22.0", features = ["tokio", "tokio-rustls", "dns-over-https-rustls"] }
+async-trait = "0.1.68"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.1"

--- a/docs/src/services/proxy/filters/writing_custom_filters.md
+++ b/docs/src/services/proxy/filters/writing_custom_filters.md
@@ -39,12 +39,13 @@ sent to a downstream client.
 # struct Greet;
 use quilkin::filters::prelude::*;
 
+#[async_trait::async_trait]
 impl Filter for Greet {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         ctx.contents.extend(b"Hello");
         Ok(())
     }
-    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         ctx.contents.extend(b"Goodbye");
         Ok(())
     }

--- a/examples/quilkin-filter-example/Cargo.toml
+++ b/examples/quilkin-filter-example/Cargo.toml
@@ -35,6 +35,7 @@ serde = "1.0.147"
 serde_yaml = "0.9.14"
 bytes = "1.2.1"
 schemars = "0.8.11"
+async-trait = "0.1.68"
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -57,13 +57,14 @@ struct Greet {
     config: Config,
 }
 
+#[async_trait::async_trait]
 impl Filter for Greet {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         ctx.contents
             .splice(0..0, format!("{} ", self.config.greeting).into_bytes());
         Ok(())
     }
-    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         ctx.contents
             .splice(0..0, format!("{} ", self.config.greeting).into_bytes());
         Ok(())

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -192,13 +192,14 @@ impl<T: JsonSchema + Default> JsonSchema for Slot<T> {
     }
 }
 
+#[async_trait::async_trait]
 impl<T: crate::filters::Filter + Default> crate::filters::Filter for Slot<T> {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
-        self.load().read(ctx)
+    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+        self.load().read(ctx).await
     }
 
-    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
-        self.load().write(ctx)
+    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+        self.load().write(ctx).await
     }
 }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -82,12 +82,13 @@ pub use self::chain::FilterChain;
 ///
 /// struct Greet;
 ///
+/// #[async_trait::async_trait]
 /// impl Filter for Greet {
-///     fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+///     async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
 ///         ctx.contents.splice(0..0, b"Hello ".into_iter().copied());
 ///         Ok(())
 ///     }
-///     fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+///     async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
 ///         ctx.contents.splice(0..0, b"Goodbye ".into_iter().copied());
 ///         Ok(())
 ///     }
@@ -191,6 +192,7 @@ where
 ///   `write` implementation to execute.
 ///   * Labels
 ///     * `filter` The name of the filter being executed.
+#[async_trait::async_trait]
 pub trait Filter: Send + Sync {
     /// [`Filter::read`] is invoked when the proxy receives data from a
     /// downstream connection on the listening port.
@@ -198,7 +200,7 @@ pub trait Filter: Send + Sync {
     /// This function should return an `Some` if the packet processing should
     /// proceed. If the packet should be rejected, it will return [`None`]
     /// instead. By default, the context passes through unchanged.
-    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
         Ok(())
     }
 
@@ -208,7 +210,7 @@ pub trait Filter: Send + Sync {
     ///
     /// This function should return an `Some` if the packet processing should
     /// proceed. If the packet should be rejected, it will return [`None`]
-    fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
         Ok(())
     }
 }

--- a/src/filters/concatenate_bytes.rs
+++ b/src/filters/concatenate_bytes.rs
@@ -43,8 +43,9 @@ impl ConcatenateBytes {
     }
 }
 
+#[async_trait::async_trait]
 impl Filter for ConcatenateBytes {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         match self.on_read {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());
@@ -58,7 +59,7 @@ impl Filter for ConcatenateBytes {
         Ok(())
     }
 
-    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         match self.on_write {
             Strategy::Append => {
                 ctx.contents.extend(self.bytes.iter());

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -33,14 +33,15 @@ impl Drop {
     }
 }
 
+#[async_trait::async_trait]
 impl Filter for Drop {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
         Err(FilterError::new("intentionally dropped"))
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
         Err(FilterError::new("intentionally dropped"))
     }
 }

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -54,7 +54,7 @@ impl Filter for Firewall {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
     fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         for rule in &self.on_read {
-            if rule.contains(ctx.source.to_socket_addr()?) {
+            if rule.contains(ctx.source.to_socket_addr().await?) {
                 return match rule.action {
                     Action::Allow => {
                         debug!(
@@ -82,7 +82,7 @@ impl Filter for Firewall {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
     fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         for rule in &self.on_write {
-            if rule.contains(ctx.source.to_socket_addr()?) {
+            if rule.contains(ctx.source.to_socket_addr().await?) {
                 return match rule.action {
                     Action::Allow => {
                         debug!(

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -50,9 +50,10 @@ impl StaticFilter for Firewall {
     }
 }
 
+#[async_trait::async_trait]
 impl Filter for Firewall {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         for rule in &self.on_read {
             if rule.contains(ctx.source.to_socket_addr().await?) {
                 return match rule.action {
@@ -80,7 +81,7 @@ impl Filter for Firewall {
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         for rule in &self.on_write {
             if rule.contains(ctx.source.to_socket_addr().await?) {
                 return match rule.action {
@@ -123,9 +124,9 @@ mod tests {
 
     use super::*;
 
-    #[test]
+    #[tokio::test]
     #[traced_test]
-    fn read() {
+    async fn read() {
         let firewall = Firewall {
             on_read: vec![Rule {
                 action: Action::Allow,
@@ -141,7 +142,7 @@ mod tests {
             (local_ip, 80).into(),
             vec![],
         );
-        assert!(firewall.read(&mut ctx).is_ok());
+        assert!(firewall.read(&mut ctx).await.is_ok());
 
         let mut ctx = ReadContext::new(
             vec![Endpoint::new((Ipv4Addr::LOCALHOST, 8080).into())],
@@ -151,11 +152,11 @@ mod tests {
         assert!(logs_contain("quilkin::filters::firewall")); // the given name to the the logger by tracing
         assert!(logs_contain("Allow"));
 
-        assert!(firewall.read(&mut ctx).is_err());
+        assert!(firewall.read(&mut ctx).await.is_err());
     }
 
-    #[test]
-    fn write() {
+    #[tokio::test]
+    async fn write() {
         let firewall = Firewall {
             on_read: vec![],
             on_write: vec![Rule {
@@ -174,7 +175,7 @@ mod tests {
             local_addr.clone(),
             vec![],
         );
-        assert!(firewall.write(&mut ctx).is_ok());
+        assert!(firewall.write(&mut ctx).await.is_ok());
 
         let mut ctx = WriteContext::new(
             endpoint,
@@ -182,6 +183,6 @@ mod tests {
             local_addr,
             vec![],
         );
-        assert!(firewall.write(&mut ctx).is_err());
+        assert!(firewall.write(&mut ctx).await.is_err());
     }
 }

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -32,14 +32,15 @@ impl Pass {
     }
 }
 
+#[async_trait::async_trait]
 impl Filter for Pass {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
         Ok(())
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
         Ok(())
     }
 }

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -72,18 +72,19 @@ mod tests {
 
     struct TestFilter {}
 
+    #[async_trait::async_trait]
     impl Filter for TestFilter {
-        fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+        async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
             Err(FilterError::new("test error"))
         }
 
-        fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+        async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
             Err(FilterError::new("test error"))
         }
     }
 
-    #[test]
-    fn insert_and_get() {
+    #[tokio::test]
+    async fn insert_and_get() {
         load_test_filters();
 
         match FilterRegistry::get(&String::from("not.found"), CreateFilterArgs::fixed(None)) {
@@ -109,9 +110,11 @@ mod tests {
                 addr.clone(),
                 vec![]
             ))
+            .await
             .is_ok());
         assert!(filter
             .write(&mut WriteContext::new(endpoint, addr.clone(), addr, vec![],))
+            .await
             .is_ok());
     }
 }

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -150,7 +150,7 @@ impl DownstreamReceiveWorkerConfig {
 
         let filters = config.filters.load();
         let mut context = ReadContext::new(endpoints, packet.source, packet.contents);
-        filters.read(&mut context)?;
+        filters.read(&mut context).await?;
         let mut bytes_written = 0;
 
         for endpoint in context.endpoints.iter() {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -55,8 +55,9 @@ pub async fn available_addr() -> SocketAddr {
 // TestFilter is useful for testing that commands are executing filters appropriately.
 pub struct TestFilter;
 
+#[async_trait::async_trait]
 impl Filter for TestFilter {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         // append values on each run
         ctx.metadata
             .entry("downstream".into())
@@ -68,7 +69,7 @@ impl Filter for TestFilter {
         Ok(())
     }
 
-    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         // append values on each run
         ctx.metadata
             .entry("upstream".into())
@@ -254,7 +255,7 @@ impl TestHelper {
 }
 
 /// assert that read makes no changes
-pub fn assert_filter_read_no_change<F>(filter: &F)
+pub async fn assert_filter_read_no_change<F>(filter: &F)
 where
     F: Filter,
 {
@@ -263,13 +264,13 @@ where
     let contents = "hello".to_string().into_bytes();
     let mut context = ReadContext::new(endpoints.clone(), source, contents.clone());
 
-    filter.read(&mut context).unwrap();
+    filter.read(&mut context).await.unwrap();
     assert_eq!(endpoints, &*context.endpoints);
     assert_eq!(contents, &*context.contents);
 }
 
 /// assert that write makes no changes
-pub fn assert_write_no_change<F>(filter: &F)
+pub async fn assert_write_no_change<F>(filter: &F)
 where
     F: Filter,
 {
@@ -282,7 +283,7 @@ where
         contents.clone(),
     );
 
-    filter.write(&mut context).unwrap();
+    filter.write(&mut context).await.unwrap();
     assert_eq!(contents, &*context.contents);
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -352,7 +352,7 @@ mod tests {
         let msg = "hello";
         endpoint
             .socket
-            .send_to(msg.as_bytes(), &echo_addr.to_socket_addr().unwrap())
+            .send_to(msg.as_bytes(), &echo_addr.to_socket_addr().await.unwrap())
             .await
             .unwrap();
         assert_eq!(


### PR DESCRIPTION
This PR switches from using the blocking DNS lookup provided by tokio to `trust-dns-resolver`'s asynchronous resolver. ~~This should resolve #718 however currently it's blocked on either implementing #12, disabling the firewall filter, or changing the firewall logic, as that is the one filter currently that relies on being able to lookup DNS entries in order check them against the firewall.~~

fixes #718 