### PR TITLE
Include debug info on unknown server in warning

### DIFF
--- a/src/config/providers/k8s.rs
+++ b/src/config/providers/k8s.rs
@@ -151,7 +151,7 @@ pub fn update_endpoints_from_gameservers(
                     });
 
                     let Some(endpoint) = result else {
-                        tracing::warn!("received unknown gameserver to delete from k8s");
+                        tracing::warn!(?server, "received unknown gameserver to delete from k8s");
                         continue
                     };
 


### PR DESCRIPTION
Just to make it easier to see what was unknown so it's easier to tell what the server we received was.