### PR TITLE
Move QCMP to a seperate port

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -34,6 +34,9 @@ fn run_quilkin(port: u16, endpoint: SocketAddr) {
 
         let proxy = quilkin::cli::Proxy {
             port,
+            qcmp_port: runtime
+                .block_on(quilkin::test_utils::available_addr())
+                .port(),
             ..<_>::default()
         };
 

--- a/docs/src/services/proxy.md
+++ b/docs/src/services/proxy.md
@@ -1,8 +1,9 @@
 # Proxy
 
-| services | ports | Protocol   |
-|----------|-------|------------|
-| proxy    | 7777  | UDP (IPv4) |
+| Services | Ports | Protocol           |
+|----------|-------|--------------------|
+| Proxy    | 7777  | UDP (IPv4)         |
+| QCMP     | 7600  | UDP (IPv4 && IPv6) |
 
 "Proxy" is the primary Quilkin service, which acts as a non-transparent UDP
 proxy.

--- a/docs/src/services/proxy/qcmp.md
+++ b/docs/src/services/proxy/qcmp.md
@@ -1,5 +1,9 @@
 # Quilkin Control Message Protocol (QCMP)
 
+| services | ports | Protocol |
+|----------|-------|-----------|
+| QCMP | 7600 | UDP (IPv4 && IPv6) |
+
 In addition to the TCP based administration API, Quilkin provides a meta API
 over UDP. The purpose of this API is to provide meta operations that can be
 used by untrusted clients. Currently the API is focuses on providing pings for

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -151,6 +151,7 @@ impl Protocol {
         self.encode_into_buffer(&mut buffer);
         buffer
     }
+
     /// Encodes the protocol command into a buffer of bytes for network transmission.
     pub fn encode_into_buffer(&self, buffer: &mut Vec<u8>) {
         buffer.extend(MAGIC_NUMBER);

--- a/tests/qcmp.rs
+++ b/tests/qcmp.rs
@@ -25,7 +25,7 @@ async fn proxy_ping() {
     let mut t = TestHelper::default();
     let server_port = quilkin::test_utils::available_addr().await.port();
     let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
+        qcmp_port: server_port,
         to: vec![(Ipv4Addr::UNSPECIFIED, 0).into()],
         ..<_>::default()
     };


### PR DESCRIPTION
This PR moves QCMP onto its own port and worker in the proxy, I initially I thought I needed this, but after I wrote I found a better solution in the client, but I decided to open the PR anyway as makes the implementation cleaner and in theory faster as it avoids allocating on the heap (though I haven't actually measured if this is noticeable). This has the added benefit of allowing operators to choose to disable the protocol by not exposing the port, or allowing operators to have QCMP only instances.

Also I removed the `shutdown_rx` in the downstream workers as that would cause the process to stop accepting packets after it shut down.