### PR TITLE
Unit and integration test debugging enhancements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@
 members = [".", "./macros", "./agones"]
 
 [workspace.dependencies]
-kube = { version = "0.83.0", features = ["derive", "runtime", "rustls-tls", "client"], default-features = false }
+kube = { version = "0.84.0", features = ["derive", "runtime", "rustls-tls", "client"], default-features = false }
 k8s-openapi = { version = "0.18.0", features = ["v1_25", "schemars"] }
 tokio = { version = "1.28.1", features = ["rt-multi-thread", "fs", "signal", "test-util", "parking_lot", "tracing"] }
 base64 = "0.21.0"
+tracing = "0.1.37"
+futures = "0.3.28"
 
 [package]
 name = "quilkin"
@@ -60,7 +62,7 @@ dirs2 = "3.0.1"
 either = "1.8.1"
 enum-map = "2.5.0"
 eyre = "0.6.8"
-futures = "0.3.28"
+futures.workspace = true
 hyper = { version = "0.14.26", features = ["http2"] }
 hyper-rustls = { version = "0.24.0", features = ["http2", "webpki-roots"] }
 ipnetwork = "0.20.0"
@@ -88,7 +90,7 @@ thiserror = "1.0.40"
 tokio.workspace = true
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tonic = "0.9.2"
-tracing = "0.1.37"
+tracing.workspace = true
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 tryhard = "0.5.0"

--- a/agones/Cargo.toml
+++ b/agones/Cargo.toml
@@ -29,3 +29,5 @@ k8s-openapi.workspace = true
 kube = { workspace = true, features = ["openssl-tls", "client", "derive", "runtime"] }
 quilkin = { path = "../" }
 tokio.workspace = true
+futures.workspace = true
+tracing.workspace = true

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -15,13 +15,13 @@
  */
 
 /// Common utilities for testing
-use std::{net::SocketAddr, str::from_utf8, sync::Arc};
+use std::{net::SocketAddr, str::from_utf8, sync::Arc, sync::Once};
 
-use once_cell::sync::Lazy;
 use tokio::{
     net::UdpSocket,
     sync::{mpsc, oneshot, watch},
 };
+use tracing_subscriber::EnvFilter;
 
 use crate::{
     cluster::Cluster,
@@ -31,17 +31,17 @@ use crate::{
     metadata::Value,
 };
 
-static ENABLE_LOG: Lazy<()> = Lazy::new(|| {
-    tracing_subscriber::fmt()
-        .pretty()
-        .with_max_level(tracing::Level::TRACE)
-        .init()
-});
+static LOG_ONCE: Once = Once::new();
 
-/// Call to safely enable `tracing` logging calls, at the TRACE level.
+/// Call to safely enable logging calls with a given tracing env filter, e.g. "quilkin=debug"
 /// This can be very useful when attempting to debug unit and integration tests.
-pub fn enable_tracing_log() {
-    Lazy::force(&ENABLE_LOG);
+pub fn enable_log(filter: impl Into<EnvFilter>) {
+    LOG_ONCE.call_once(|| {
+        tracing_subscriber::fmt()
+            .pretty()
+            .with_env_filter(filter)
+            .init()
+    });
 }
 
 /// Returns a local address on a port that is not assigned to another test.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

* Finer control over log levels and filters by allowing env filters in a new `enable_log(filter: impl Into<EnvFilter>)` implementation.
* On the `agones` integration side a new `debug_pods(client: &Client, labels: String)` function that will output both the Events and all the logs for any pods that match a given selector.
* Example of use within a currently failing `agones_token_router` agones integration test in PR #712.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #695

**Special notes for your reviewer**:

Still need to work out why #712 is failing.