### PR TITLE
Automatically update approved PRs with automerge

### DIFF
--- a/.github/workflows/pr_update.yml
+++ b/.github/workflows/pr_update.yml
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GitHub action that runs https://github.com/adRise/update-pr-branch on each push to
+# `main`. `update-pr-branch` will pick the oldest PR (by creation date) that is approved
+# with auto-merge enabled and update it to the latest `main`, forming a best-effort queue
+# of approved PRs.
+
+name: PR update
+
+on:
+  push:
+    branches:
+      - "main"
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Automatically update PR
+        uses: adRise/update-pr-branch@v0.6.0
+        with:
+          token: ${{ secrets.QUILKIN_BOT }}
+          base: "main"
+          required_approval_count: 1
+          require_passed_checks: true
+          sort: "created"
+          direction: "asc"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

GitHub action that will sequentially update to `main` PRs that pass all their checks and are set to "auto-merge".

Not quite as nice as a merge queue, but at least means you don't have to manually manage a queue of approved PRs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #737

**Special notes for your reviewer**:

Stolen from what we do on Agones.