### PR TITLE
Update to Rust 1.71.1 (cargo CVE-2023-38497)

### DIFF
--- a/agones/src/sidecar.rs
+++ b/agones/src/sidecar.rs
@@ -94,7 +94,7 @@ clusters:
         gs.spec.ports[0].container = Some("quilkin".into());
 
         // set the gameserver container to the simple-game-server container.
-        let mut template = gs.spec.template.spec.as_mut().unwrap();
+        let template = gs.spec.template.spec.as_mut().unwrap();
         gs.spec.container = Some(template.containers[0].name.clone());
 
         let mount_name = "config".to_string();

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.69.0"
+channel = "1.71.1"
 components = ["rustfmt", "clippy"]

--- a/src/endpoint/locality.rs
+++ b/src/endpoint/locality.rs
@@ -225,7 +225,7 @@ impl LocalitySet {
 
     /// Inserts a new locality of endpoints.
     pub fn insert(&mut self, mut locality: LocalityEndpoints) {
-        let mut entry = self.0.entry(locality.locality.clone()).or_default();
+        let entry = self.0.entry(locality.locality.clone()).or_default();
         entry.locality = locality.locality;
         entry.endpoints.append(&mut locality.endpoints);
     }

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -14,7 +14,6 @@
  *  limitations under the License.
  */
 
-///! Complex integration tests that incorporate multiple elements
 use std::{net::Ipv4Addr, str::from_utf8};
 
 use tokio::time::{timeout, Duration};


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Was about time to update (cargo-deny was complaining), and there is a CVE in cargo, so seemed like the sensible thing to do.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html