### PR TITLE
Hack around empty responses to relay

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -169,6 +169,11 @@ impl Config {
         tracing::trace!(resource=?response, "applying resource");
 
         let apply_cluster = |cluster: Cluster| {
+            if cluster.endpoints().count() == 0 {
+                tracing::warn!(?response, "empty endpoints");
+                return;
+            }
+
             tracing::trace!(endpoints = %serde_json::to_value(&cluster).unwrap(), "applying new endpoints");
             self.clusters
                 .value()


### PR DESCRIPTION
This shouldn't actually be merged, it's just a hack to help me debug, why the relay occasionally has empty endpoints despite the agent having a endpoint.