### PR TITLE
Fix watch on clusters, by removing inner Arc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ once_cell = "1.17.1"
 tracing-test = "0.2.4"
 pretty_assertions = "1.3.0"
 tempfile = "3.5.0"
+rand = "0.8.5"
 
 [build-dependencies]
 tonic-build = { version = "0.9.2", default_features = false, features = ["transport", "prost"] }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -96,7 +96,7 @@ fn handle_request(
 }
 
 fn check_proxy_readiness(config: &Config) -> Response<Body> {
-    if config.clusters.value().endpoints().count() > 0 {
+    if config.clusters.read().endpoints().count() > 0 {
         return Response::new("ok".into());
     }
 
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn check_proxy_readiness() {
         let config = Config::default();
-        assert_eq!(config.clusters.value().endpoints().count(), 0);
+        assert_eq!(config.clusters.read().endpoints().count(), 0);
 
         let response = super::check_proxy_readiness(&config);
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
@@ -154,7 +154,7 @@ mod tests {
         )]
         .into()]);
 
-        config.clusters.value().insert(cluster);
+        config.clusters.write().insert(cluster);
 
         let response = super::check_proxy_readiness(&config);
         assert_eq!(response.status(), StatusCode::OK);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -228,7 +228,6 @@ mod tests {
     };
 
     use crate::{
-        cluster::ClusterMap,
         config::{Filter, Providers},
         endpoint::{Endpoint, LocalityEndpoints},
         filters::{Capture, StaticFilter, TokenRouter},
@@ -242,9 +241,9 @@ mod tests {
             .map(Arc::new)
             .unwrap();
         let filters_file = tempfile::NamedTempFile::new().unwrap();
+        let config = Config::default();
 
         std::fs::write(filters_file.path(), {
-            let config = Config::default();
             config.filters.store(
                 vec![
                     Filter {
@@ -272,16 +271,18 @@ mod tests {
         .unwrap();
 
         let endpoints_file = tempfile::NamedTempFile::new().unwrap();
+        let config = Config::default();
         std::fs::write(endpoints_file.path(), {
-            let mut config = Config::default();
-            config.clusters = crate::config::Watch::new(ClusterMap::new_with_default_cluster(
-                LocalityEndpoints::from(vec![Endpoint::with_metadata(
+            config
+                .clusters
+                .write()
+                .default_cluster_mut()
+                .insert(LocalityEndpoints::from(vec![Endpoint::with_metadata(
                     (std::net::Ipv4Addr::LOCALHOST, server_port).into(),
                     crate::endpoint::Metadata {
                         tokens: vec!["abc".into()].into_iter().collect(),
                     },
-                )]),
-            ));
+                )]));
             serde_yaml::to_string(&config).unwrap()
         })
         .unwrap();
@@ -335,36 +336,71 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         tokio::spawn(proxy.drive());
         tokio::time::sleep(Duration::from_millis(500)).await;
-
         let local_addr = crate::test_utils::available_addr().await;
         let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, local_addr.port()))
             .await
             .map(Arc::new)
             .unwrap();
-        let msg = b"helloabc";
-        socket
-            .send_to(msg, &(std::net::Ipv4Addr::LOCALHOST, 7777))
-            .await
+        let config = Config::default();
+
+        for _ in 0..5 {
+            let token = random_three_characters();
+
+            tracing::info!(?token, "writing new config");
+            std::fs::write(endpoints_file.path(), {
+                config
+                    .clusters
+                    .write()
+                    .default_cluster_mut()
+                    .insert(LocalityEndpoints::from(vec![Endpoint::with_metadata(
+                        (std::net::Ipv4Addr::LOCALHOST, server_port).into(),
+                        crate::endpoint::Metadata {
+                            tokens: vec![token.clone()].into_iter().collect(),
+                        },
+                    )]));
+                serde_yaml::to_string(&config).unwrap()
+            })
             .unwrap();
-
-        let recv = |socket: Arc<UdpSocket>| async move {
-            let mut buf = [0; u16::MAX as usize];
-            let length = socket.recv(&mut buf).await.unwrap();
-            buf[0..length].to_vec()
-        };
-
-        assert_eq!(
-            b"hello",
-            &&*timeout(Duration::from_secs(5), (recv)(server_socket.clone()))
+            tokio::time::sleep(Duration::from_millis(80)).await;
+            let mut msg = Vec::from(*b"hello");
+            msg.extend_from_slice(&token);
+            tracing::info!(?token, "sending packet");
+            socket
+                .send_to(&msg, &(std::net::Ipv4Addr::LOCALHOST, 7777))
                 .await
-                .expect("should have received a packet")
-        );
+                .unwrap();
 
-        // send an invalid packet
-        let msg = b"helloxyz";
-        socket.send_to(msg, &local_addr).await.unwrap();
+            let recv = |socket: Arc<UdpSocket>| async move {
+                let mut buf = [0; u16::MAX as usize];
+                let length = socket.recv(&mut buf).await.unwrap();
+                buf[0..length].to_vec()
+            };
 
-        let result = timeout(Duration::from_secs(3), (recv)(server_socket.clone())).await;
-        assert!(result.is_err(), "should not have received a packet");
+            assert_eq!(
+                b"hello",
+                &&*timeout(Duration::from_secs(5), (recv)(server_socket.clone()))
+                    .await
+                    .expect("should have received a packet")
+            );
+
+            tracing::info!(?token, "received packet");
+
+            tracing::info!(?token, "sending bad packet");
+            // send an invalid packet
+            let msg = b"hello\xFF\xFF\xFF";
+            socket.send_to(msg, &local_addr).await.unwrap();
+
+            let result = timeout(Duration::from_secs(3), (recv)(server_socket.clone())).await;
+            assert!(result.is_err(), "should not have received a packet");
+            tracing::info!(?token, "didn't receive bad packet");
+        }
+    }
+
+    fn random_three_characters() -> Vec<u8> {
+        use rand::prelude::SliceRandom;
+        let chars: Vec<u8> = (*b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ").into();
+        let mut rng = rand::thread_rng();
+
+        (0..3).map(|_| *chars.choose(&mut rng).unwrap()).collect()
     }
 }

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -86,11 +86,12 @@ impl Proxy {
         });
 
         if !self.to.is_empty() {
-            config.clusters.value().default_cluster_mut().localities =
-                vec![self.to.clone().into()].into();
+            config.clusters.modify(|clusters| {
+                clusters.default_cluster_mut().localities = vec![self.to.clone().into()].into();
+            });
         }
 
-        if config.clusters.value().endpoints().count() == 0 && self.management_server.is_empty() {
+        if config.clusters.read().endpoints().count() == 0 && self.management_server.is_empty() {
             return Err(eyre::eyre!(
                 "`quilkin proxy` requires at least one `to` address or `management_server` endpoint."
             ));

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
@@ -107,7 +107,7 @@ fn default_cluster_name() -> String {
 
 /// Represents a full snapshot of all clusters.
 #[derive(Clone, Default, Debug, Serialize)]
-pub struct ClusterMap(Arc<DashMap<String, Cluster>>);
+pub struct ClusterMap(DashMap<String, Cluster>);
 
 type DashMapRef<'inner> = dashmap::mapref::one::Ref<'inner, String, Cluster>;
 type DashMapRefMut<'inner> = dashmap::mapref::one::RefMut<'inner, String, Cluster>;
@@ -262,13 +262,13 @@ impl<'de> Deserialize<'de> for ClusterMap {
             entry.name = entry.key().clone();
         }
 
-        Ok(Self(Arc::new(map)))
+        Ok(Self(map))
     }
 }
 
 impl From<DashMap<String, Cluster>> for ClusterMap {
     fn from(value: DashMap<String, Cluster>) -> Self {
-        Self(Arc::new(value))
+        Self(value)
     }
 }
 
@@ -289,11 +289,11 @@ impl FromIterator<Cluster> for ClusterMap {
     where
         T: IntoIterator<Item = Cluster>,
     {
-        Self(Arc::new(
+        Self(
             iter.into_iter()
                 .map(|cluster| (cluster.name.clone(), cluster))
                 .collect(),
-        ))
+        )
     }
 }
 
@@ -308,7 +308,7 @@ impl FromIterator<(String, Cluster)> for ClusterMap {
     where
         T: IntoIterator<Item = (String, Cluster)>,
     {
-        Self(Arc::new(iter.into_iter().collect()))
+        Self(iter.into_iter().collect())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ impl Config {
             ($($field:ident),+) => {
                 $(
                     if let Some(value) = map.get(stringify!($field)) {
-                        tracing::trace!(%value, "replacing {}", stringify!($field));
+                        tracing::debug!(%value, "replacing {}", stringify!($field));
                         self.$field.try_replace(serde_json::from_value(value.clone())?);
                     }
                 )+
@@ -89,17 +89,18 @@ impl Config {
 
         replace_if_present!(filters, id);
 
+        if let Some(new_clusters) = map
+            .get("clusters")
+            .map(|value| serde_json::from_value(value.clone()))
+            .transpose()?
         {
-            let clusters = self.clusters.value();
-
-            if let Some(value) = map.get("clusters") {
-                tracing::trace!(clusters=%value, "merging new clusters");
-                clusters.merge(serde_json::from_value(value.clone())?);
-            }
-
-            if let Some(locality) = locality {
-                clusters.update_unlocated_endpoints(&locality);
-            }
+            tracing::debug!(?new_clusters, old_clusters=?self.clusters, "merging new clusters");
+            self.clusters.modify(|clusters| {
+                clusters.merge(new_clusters);
+                if let Some(locality) = locality {
+                    clusters.update_unlocated_endpoints(&locality);
+                }
+            });
         }
 
         self.apply_metrics();
@@ -116,7 +117,7 @@ impl Config {
         let mut resources = Vec::new();
         match resource_type {
             ResourceType::Endpoint => {
-                for entry in self.clusters.value().iter() {
+                for entry in self.clusters.read().iter() {
                     resources.push(
                         resource_type
                             .encode_to_any(&ClusterLoadAssignment::try_from(entry.value())?)?,
@@ -132,7 +133,7 @@ impl Config {
             ResourceType::Cluster => {
                 let clusters: Vec<_> = if names.is_empty() {
                     self.clusters
-                        .value()
+                        .read()
                         .iter()
                         .map(|entry| entry.value().clone())
                         .collect()
@@ -141,7 +142,7 @@ impl Config {
                         .iter()
                         .filter_map(|name| {
                             self.clusters
-                                .value()
+                                .read()
                                 .get(name)
                                 .map(|entry| entry.value().clone())
                         })
@@ -171,7 +172,7 @@ impl Config {
         let apply_cluster = |cluster: Cluster| {
             tracing::trace!(endpoints = %serde_json::to_value(&cluster).unwrap(), "applying new endpoints");
             self.clusters
-                .value()
+                .write()
                 .default_entry(cluster.name.clone())
                 .merge(&cluster);
         };
@@ -208,7 +209,7 @@ impl Config {
     }
 
     pub fn apply_metrics(&self) {
-        let clusters = self.clusters.value();
+        let clusters = self.clusters.read();
         crate::cluster::active_clusters().set(clusters.localities().count() as i64);
         crate::cluster::active_endpoints().set(clusters.endpoints().count() as i64);
     }
@@ -396,7 +397,7 @@ id: server-proxy
         }))
         .unwrap();
 
-        let value = config.clusters.value();
+        let value = config.clusters.read();
         assert_eq!(
             &*value,
             &ClusterMap::new_with_default_cluster(vec![Endpoint::new(
@@ -436,7 +437,7 @@ id: server-proxy
         }))
         .unwrap_or_default();
 
-        let value = config.clusters.value();
+        let value = config.clusters.read();
         assert_eq!(
             &*value,
             &ClusterMap::new_with_default_cluster(vec![

--- a/src/config/providers/k8s.rs
+++ b/src/config/providers/k8s.rs
@@ -112,12 +112,12 @@ pub fn update_endpoints_from_gameservers(
                     match &locality {
                         Some(locality) => config
                             .clusters
-                            .value()
+                            .write()
                             .default_cluster_mut()
                             .insert((endpoint, locality.clone())),
                         None => config
                             .clusters
-                            .value()
+                            .write()
                             .default_cluster_mut()
                             .insert(endpoint),
                     };
@@ -141,14 +141,14 @@ pub fn update_endpoints_from_gameservers(
                         .collect();
                     let endpoints = LocalityEndpoints::from((servers, locality.clone()));
                     tracing::trace!(?endpoints, "Restarting with endpoints");
-                    config.clusters.value().insert_default(endpoints);
+                    config.clusters.write().insert_default(endpoints);
                 }
 
                 Event::Deleted(server) => {
                     let found = if let Some(endpoint) = server.endpoint() {
-                        config.clusters.value().remove_endpoint(&endpoint)
+                        config.clusters.write().remove_endpoint(&endpoint)
                     } else {
-                        config.clusters.value().remove_endpoint_if(|endpoint| {
+                        config.clusters.write().remove_endpoint_if(|endpoint| {
                             endpoint.metadata.unknown.get("name") == server.metadata.name.clone().map(From::from).as_ref()
                         })
                     };

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -162,7 +162,7 @@ impl DownstreamReceiveWorkerConfig {
         downstream_socket: Arc<UdpSocket>,
         sessions: SessionMap,
     ) -> Result<usize, PipelineError> {
-        let endpoints: Vec<_> = config.clusters.value().endpoints().collect();
+        let endpoints: Vec<_> = config.clusters.read().endpoints().collect();
         if endpoints.is_empty() {
             return Err(PipelineError::NoUpstreamEndpoints);
         }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -295,7 +295,7 @@ pub async fn create_socket() -> UdpSocket {
 pub fn config_with_dummy_endpoint() -> Config {
     let config = Config::default();
 
-    config.clusters.value().insert(Cluster {
+    config.clusters.write().insert(Cluster {
         name: "default".into(),
         localities: vec![LocalityEndpoints {
             locality: None,

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -345,7 +345,7 @@ mod tests {
                 local_addr,
                 config
                     .clusters
-                    .value()
+                    .read()
                     .get_default()
                     .unwrap()
                     .endpoints()


### PR DESCRIPTION
This should actually fix the issue with changes not being sent across three services, and removes the constant re-checking for changes by finally fixing the issue with watching clusters. The bug was devilishly subtle, the `Watch` struct watches for changes between two values and sends if they change, however `ClusterMap` had inner `Arc` and thus both the value being held and the value in the channel were always the same.

I also added a `ReadGuard` and split it into `read` and `write` methods, so that's more clear what the intent is.