### PR TITLE
Add logging for what endpoints are added and removed

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -212,6 +212,9 @@ impl ClusterMap {
 
     pub fn merge(&self, map: Self) {
         for cluster in map.iter() {
+            let span = tracing::info_span!("applied_cluster", cluster = cluster.name,);
+            let _entered = span.enter();
+
             let cluster = cluster.value();
             self.default_entry(cluster.name.clone()).merge(cluster);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,7 +170,6 @@ impl Config {
         tracing::trace!(resource=?response, "applying resource");
 
         let apply_cluster = |cluster: Cluster| {
-            tracing::trace!(endpoints = %serde_json::to_value(&cluster).unwrap(), "applying new endpoints");
             self.clusters
                 .write()
                 .default_entry(cluster.name.clone())


### PR DESCRIPTION
This adds logging to the `merge` operation, now that #773 is merged we can add more logs without spamming the logs