### PR TITLE
Locally listen on IPv4 and IPv6 addresses

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -5,6 +5,7 @@ use std::time;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use once_cell::sync::Lazy;
+use quilkin::test_utils::AddressType;
 
 const MESSAGE_SIZE: usize = 0xffff;
 const DEFAULT_MESSAGE: [u8; 0xffff] = [0xff; 0xffff];
@@ -35,7 +36,7 @@ fn run_quilkin(port: u16, endpoint: SocketAddr) {
         let proxy = quilkin::cli::Proxy {
             port,
             qcmp_port: runtime
-                .block_on(quilkin::test_utils::available_addr())
+                .block_on(quilkin::test_utils::available_addr(&AddressType::Random))
                 .port(),
             ..<_>::default()
         };

--- a/docs/src/deployment/admin.md
+++ b/docs/src/deployment/admin.md
@@ -1,8 +1,8 @@
 # Administration
 
-| services | ports | Protocol |
-|----------|-------|-----------|
-| Administration | 8000 | HTTP (IPv4 OR IPv6) |
+| services       | ports | Protocol            |
+|----------------|-------|---------------------|
+| Administration | 8000  | HTTP (IPv4 OR IPv6) |
 
 ## Logging
 By default, Quilkin will log `INFO` level events, you can change this by setting

--- a/docs/src/services/agent.md
+++ b/docs/src/services/agent.md
@@ -2,7 +2,7 @@
 
 | services | ports | Protocol |
 |----------|-------|-----------|
-| QCMP | 7600 | UDP(IPv4 && IPv6) |
+| QCMP | 7600 | UDP(IPv4 OR IPv6) |
 
 > **Note:** This service is currently in active experimentation and development
   so there may be bugs which cause it to be unusable  for production, as always

--- a/docs/src/services/proxy.md
+++ b/docs/src/services/proxy.md
@@ -2,8 +2,8 @@
 
 | Services | Ports | Protocol           |
 |----------|-------|--------------------|
-| Proxy    | 7777  | UDP (IPv4)         |
-| QCMP     | 7600  | UDP (IPv4 && IPv6) |
+| Proxy    | 7777  | UDP (IPv4 OR IPv6) |
+| QCMP     | 7600  | UDP (IPv4 OR IPv6) |
 
 "Proxy" is the primary Quilkin service, which acts as a non-transparent UDP
 proxy.

--- a/docs/src/services/proxy/qcmp.md
+++ b/docs/src/services/proxy/qcmp.md
@@ -2,7 +2,7 @@
 
 | services | ports | Protocol |
 |----------|-------|-----------|
-| QCMP | 7600 | UDP (IPv4 && IPv6) |
+| QCMP | 7600 | UDP (IPv4 OR IPv6) |
 
 In addition to the TCP based administration API, Quilkin provides a meta API
 over UDP. The purpose of this API is to provide meta operations that can be

--- a/docs/src/services/xds.md
+++ b/docs/src/services/xds.md
@@ -1,8 +1,8 @@
 # xDS Control Plane
 
-| services | ports | Protocol   |
-|----------|-------|------------|
-| xDS      | 7800  | gRPC(IPv4) |
+| services | ports | Protocol            |
+|----------|-------|---------------------|
+| xDS      | 7800  | gRPC (IPv4 OR IPv6) |
 
 For multi-cluster integration, Quilkin provides a `manage` service, that can be
 used with a number of configuration discovery providers to provide cluster

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -16,7 +16,7 @@
 
 //! Types representing where the data is the sent.
 
-mod address;
+pub(crate) mod address;
 mod locality;
 
 use serde::{Deserialize, Serialize};

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -16,7 +16,7 @@
 
 pub(crate) mod metrics;
 
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use tokio::{net::UdpSocket, select, sync::watch, time::Instant};
 
@@ -24,7 +24,7 @@ use crate::{
     endpoint::{Endpoint, EndpointAddress},
     filters::{Filter, WriteContext},
     maxmind_db::IpNetEntry,
-    utils::Loggable,
+    utils::{net::DualStackLocalSocket, Loggable},
 };
 
 pub type SessionMap = crate::ttl_map::TtlMap<SessionKey, Session>;
@@ -71,7 +71,7 @@ struct ReceivedPacketContext<'a> {
 pub struct SessionArgs {
     pub config: Arc<crate::Config>,
     pub source: EndpointAddress,
-    pub downstream_socket: Arc<UdpSocket>,
+    pub downstream_socket: Arc<DualStackLocalSocket>,
     pub dest: Endpoint,
     pub asn_info: Option<IpNetEntry>,
 }
@@ -88,8 +88,13 @@ impl Session {
     /// internal constructor for a Session from SessionArgs
     #[tracing::instrument(skip_all)]
     async fn new(args: SessionArgs) -> Result<Self, super::PipelineError> {
-        let addr = (std::net::Ipv4Addr::UNSPECIFIED, 0);
-        let upstream_socket = Arc::new(UdpSocket::bind(addr).await?);
+        let dest_addr = args.dest.address.to_socket_addr().await?;
+
+        let bind_addr: SocketAddr = match dest_addr {
+            SocketAddr::V4(_) => (std::net::Ipv4Addr::UNSPECIFIED, 0).into(),
+            SocketAddr::V6(_) => (std::net::Ipv6Addr::UNSPECIFIED, 0).into(),
+        };
+        let upstream_socket = Arc::new(UdpSocket::bind(bind_addr).await?);
         upstream_socket
             .connect(args.dest.address.to_socket_addr().await?)
             .await?;
@@ -115,7 +120,11 @@ impl Session {
 
     /// run starts processing receiving upstream udp packets
     /// and sending them back downstream
-    fn run(&self, downstream_socket: Arc<UdpSocket>, mut shutdown_rx: watch::Receiver<()>) {
+    fn run(
+        &self,
+        downstream_socket: Arc<DualStackLocalSocket>,
+        mut shutdown_rx: watch::Receiver<()>,
+    ) {
         let source = self.source.clone();
         let config = self.config.clone();
         let endpoint = self.dest.clone();
@@ -185,7 +194,7 @@ impl Session {
 
     /// process_recv_packet processes a packet that is received by this session.
     async fn process_recv_packet(
-        downstream_socket: &Arc<UdpSocket>,
+        downstream_socket: &Arc<DualStackLocalSocket>,
         packet_ctx: ReceivedPacketContext<'_>,
     ) -> Result<usize, Error> {
         let ReceivedPacketContext {
@@ -211,7 +220,7 @@ impl Session {
         let packet = context.contents.as_ref();
         tracing::trace!(%from, dest = %addr, contents = %crate::utils::base64_encode(packet), "sending packet downstream");
         downstream_socket
-            .send_to(packet, addr)
+            .send_to(packet, &addr)
             .await
             .map_err(Error::SendTo)
     }
@@ -275,6 +284,7 @@ mod tests {
 
     use tokio::time::timeout;
 
+    use crate::test_utils::AddressType;
     use crate::{
         endpoint::{Endpoint, EndpointAddress},
         proxy::sessions::{ReceivedPacketContext, SessionArgs},
@@ -284,7 +294,7 @@ mod tests {
     #[tokio::test]
     async fn session_send_and_receive() {
         let mut t = TestHelper::default();
-        let addr = t.run_echo_server().await;
+        let addr = t.run_echo_server(&AddressType::Random).await;
         let endpoint = Endpoint::new(addr.clone());
         let socket = Arc::new(create_socket().await);
         let msg = "hello";
@@ -301,14 +311,19 @@ mod tests {
 
         sess.send(msg.as_bytes()).await.unwrap();
 
-        let mut buf = vec![0; 1024];
-        let (size, recv_addr) = timeout(Duration::from_secs(5), socket.recv_from(&mut buf))
-            .await
-            .unwrap()
-            .unwrap();
-        let packet = &buf[..size];
-        assert_eq!(msg, from_utf8(packet).unwrap());
-        assert_eq!(addr.port(), recv_addr.port());
+        let mut v4_buf = vec![0; 1024];
+        let mut v6_buf = vec![0; 1024];
+        let recv = timeout(
+            Duration::from_secs(5),
+            socket.recv_from(&mut v4_buf, &mut v6_buf),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let contents = DualStackLocalSocket::contents(&v4_buf, &v6_buf, recv);
+        assert_eq!(msg, from_utf8(contents).unwrap());
+        assert_eq!(addr.port(), recv.1.port());
     }
 
     #[tokio::test]
@@ -317,7 +332,7 @@ mod tests {
 
         let socket = Arc::new(create_socket().await);
         let endpoint = Endpoint::new("127.0.1.1:80".parse().unwrap());
-        let dest: EndpointAddress = socket.local_addr().unwrap().into();
+        let dest: EndpointAddress = socket.local_ipv4_addr().unwrap().into();
 
         // first test with no filtering
         let msg = "hello";
@@ -334,13 +349,21 @@ mod tests {
         .await
         .unwrap();
 
-        let mut buf = vec![0; 1024];
-        let (size, recv_addr) = timeout(Duration::from_secs(5), socket.recv_from(&mut buf))
-            .await
-            .expect("Should receive a packet")
-            .unwrap();
-        assert_eq!(msg, from_utf8(&buf[..size]).unwrap());
-        assert_eq!(dest.port(), recv_addr.port());
+        let mut v4_buf = vec![0; 1024];
+        let mut v6_buf = vec![0; 1024];
+
+        let recv = timeout(
+            Duration::from_secs(5),
+            socket.recv_from(&mut v4_buf, &mut v6_buf),
+        )
+        .await
+        .expect("Should receive a packet")
+        .unwrap();
+
+        let contents = DualStackLocalSocket::contents(&v4_buf, &v6_buf, recv);
+
+        assert_eq!(msg, from_utf8(contents).unwrap());
+        assert_eq!(dest.port(), recv.1.port());
 
         // add filter
         let config = Arc::new(new_test_config());
@@ -357,13 +380,18 @@ mod tests {
         .await
         .unwrap();
 
-        let (size, recv_addr) = timeout(Duration::from_secs(5), socket.recv_from(&mut buf))
-            .await
-            .expect("Should receive a packet")
-            .unwrap();
+        let result = timeout(
+            Duration::from_secs(5),
+            socket.recv_from(&mut v4_buf, &mut v6_buf),
+        )
+        .await
+        .expect("Should receive a packet")
+        .unwrap();
+        let contents = DualStackLocalSocket::contents(&v4_buf, &v6_buf, result);
+        let (_, recv_addr) = result;
         assert_eq!(
             format!("{}:our:{}:{}", msg, endpoint.address, dest),
-            from_utf8(&buf[..size]).unwrap()
+            from_utf8(contents).unwrap()
         );
         assert_eq!(dest.port(), recv_addr.port());
     }

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -23,7 +23,7 @@ use quilkin::{
     endpoint::Endpoint,
     filters::{Capture, StaticFilter, TokenRouter},
     metadata::MetadataView,
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 /// This test covers both token_router and capture filters,
@@ -31,7 +31,7 @@ use quilkin::{
 #[tokio::test]
 async fn token_router() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
     let server_port = 12348;
     let server_proxy = quilkin::cli::Proxy {
         port: server_port,

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -16,21 +16,20 @@
 
 use tokio::time::{timeout, Duration};
 
-use quilkin::test_utils::available_addr;
 use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Compress, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{available_addr, AddressType, TestHelper},
 };
 
 #[tokio::test]
 async fn client_and_server() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration as
-    let server_addr = available_addr().await;
+    let server_addr = available_addr(&AddressType::Random).await;
     let yaml = "
 on_read: DECOMPRESS
 on_write: COMPRESS
@@ -56,7 +55,7 @@ on_write: COMPRESS
     t.run_server(server_config, server_proxy, None);
 
     // create a local client
-    let client_addr = available_addr().await;
+    let client_addr = available_addr(&AddressType::Random).await;
     let yaml = "
 on_read: COMPRESS
 on_write: DECOMPRESS

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -22,7 +22,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{ConcatenateBytes, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -32,7 +32,7 @@ async fn concatenate_bytes() {
 on_read: APPEND
 bytes: YWJj #abc
 ";
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     let server_port = 12346;
     let server_proxy = quilkin::cli::Proxy {

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -22,7 +22,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Compress, ConcatenateBytes, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -45,7 +45,7 @@ on_write: DECOMPRESS
 ";
 
     let echo = t
-        .run_echo_server_with_tap(move |_, bytes, _| {
+        .run_echo_server_with_tap(&AddressType::Random, move |_, bytes, _| {
             assert!(
                 from_utf8(bytes).is_err(),
                 "Should be compressed, and therefore unable to be turned into a string"

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -24,7 +24,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Debug, StaticFilter},
-    test_utils::{load_test_filters, TestHelper},
+    test_utils::{load_test_filters, AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -33,7 +33,7 @@ async fn test_filter() {
     load_test_filters();
 
     // create an echo server as an endpoint.
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration
     let server_port = 12346;
@@ -120,7 +120,7 @@ async fn debug_filter() {
     let factory = Debug::factory();
 
     // create an echo server as an endpoint.
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration
     let server_port = 12247;

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::net::SocketAddr;
+use std::net::{Ipv6Addr, SocketAddr};
 
 use tokio::{
     sync::oneshot,
@@ -25,12 +25,14 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Firewall, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{available_addr, AddressType, TestHelper},
 };
 
 #[tokio::test]
-async fn firewall_allow() {
+async fn ipv4_firewall_allow() {
     let mut t = TestHelper::default();
+    let address_type = AddressType::Ipv4;
+    let port = available_addr(&address_type).await.port();
     let yaml = "
 on_read:
   - action: ALLOW
@@ -43,7 +45,7 @@ on_write:
     ports:
        - %2
 ";
-    let recv = test(&mut t, 12354, yaml).await;
+    let recv = test(&mut t, port, yaml, &address_type).await;
 
     assert_eq!(
         "hello",
@@ -55,8 +57,38 @@ on_write:
 }
 
 #[tokio::test]
-async fn firewall_read_deny() {
+async fn ipv6_firewall_allow() {
     let mut t = TestHelper::default();
+    let address_type = AddressType::Ipv6;
+    let port = available_addr(&address_type).await.port();
+    let yaml = "
+on_read:
+  - action: ALLOW
+    source: ::1/128
+    ports:
+       - %1
+on_write:
+  - action: ALLOW
+    source: ::1/64
+    ports:
+       - %2
+";
+    let recv = test(&mut t, port, yaml, &address_type).await;
+
+    assert_eq!(
+        "hello",
+        timeout(Duration::from_secs(5), recv)
+            .await
+            .expect("should have received a packet")
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn ipv4_firewall_read_deny() {
+    let mut t = TestHelper::default();
+    let address_type = AddressType::Ipv4;
+    let port = available_addr(&address_type).await.port();
     let yaml = "
 on_read:
   - action: DENY
@@ -69,15 +101,40 @@ on_write:
     ports:
        - %2
 ";
-    let recv = test(&mut t, 12355, yaml).await;
+    let recv = test(&mut t, port, yaml, &address_type).await;
 
     let result = timeout(Duration::from_secs(3), recv).await;
     assert!(result.is_err(), "should not have received a packet");
 }
 
 #[tokio::test]
-async fn firewall_write_deny() {
+async fn ipv6_firewall_read_deny() {
     let mut t = TestHelper::default();
+    let address_type = AddressType::Ipv6;
+    let port = available_addr(&address_type).await.port();
+    let yaml = "
+on_read:
+  - action: DENY
+    source: ::1/128
+    ports:
+       - %1
+on_write:
+  - action: ALLOW
+    source: ::1/64
+    ports:
+       - %2
+";
+    let recv = test(&mut t, port, yaml, &address_type).await;
+
+    let result = timeout(Duration::from_secs(3), recv).await;
+    assert!(result.is_err(), "should not have received a packet");
+}
+
+#[tokio::test]
+async fn ipv4_firewall_write_deny() {
+    let mut t = TestHelper::default();
+    let address_type = AddressType::Ipv4;
+    let port = available_addr(&address_type).await.port();
     let yaml = "
 on_read:
   - action: ALLOW
@@ -90,17 +147,50 @@ on_write:
     ports:
        - %2
 ";
-    let recv = test(&mut t, 12356, yaml).await;
+    let recv = test(&mut t, port, yaml, &address_type).await;
 
     let result = timeout(Duration::from_secs(3), recv).await;
     assert!(result.is_err(), "should not have received a packet");
 }
 
-async fn test(t: &mut TestHelper, server_port: u16, yaml: &str) -> oneshot::Receiver<String> {
-    let echo = t.run_echo_server().await;
+#[tokio::test]
+async fn ipv6_firewall_write_deny() {
+    let mut t = TestHelper::default();
+    let address_type = AddressType::Ipv6;
+    let port = available_addr(&address_type).await.port();
+    let yaml = "
+on_read:
+  - action: ALLOW
+    source: ::1/128
+    ports:
+       - %1
+on_write:
+  - action: DENY
+    source: ::1/64
+    ports:
+       - %2
+";
+    let recv = test(&mut t, port, yaml, &address_type).await;
+
+    let result = timeout(Duration::from_secs(3), recv).await;
+    assert!(result.is_err(), "should not have received a packet");
+}
+
+async fn test(
+    t: &mut TestHelper,
+    server_port: u16,
+    yaml: &str,
+    address_type: &AddressType,
+) -> oneshot::Receiver<String> {
+    let echo = t.run_echo_server(address_type).await;
 
     let recv = t.open_socket_and_recv_single_packet().await;
-    let client_addr = recv.socket.local_addr().unwrap();
+    let client_addr = match address_type {
+        AddressType::Ipv4 => recv.socket.local_ipv4_addr().unwrap(),
+        AddressType::Ipv6 => recv.socket.local_ipv6_addr().unwrap(),
+        AddressType::Random => unreachable!(),
+    };
+
     let yaml = yaml
         .replace("%1", client_addr.port().to_string().as_str())
         .replace("%2", echo.port().to_string().as_str());
@@ -127,7 +217,11 @@ async fn test(t: &mut TestHelper, server_port: u16, yaml: &str) -> oneshot::Rece
 
     t.run_server(server_config, server_proxy, None);
 
-    let local_addr: SocketAddr = (std::net::Ipv4Addr::LOCALHOST, server_port).into();
+    let local_addr: SocketAddr = match address_type {
+        AddressType::Ipv4 => (std::net::Ipv4Addr::LOCALHOST, server_port).into(),
+        AddressType::Ipv6 => (Ipv6Addr::LOCALHOST, server_port).into(),
+        AddressType::Random => unreachable!(), // don't do this.
+    };
     tracing::info!(source = %client_addr, address = %local_addr, "Sending hello");
     recv.socket.send_to(b"hello", &local_addr).await.unwrap();
 

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -23,7 +23,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{LoadBalancer, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -39,7 +39,7 @@ policy: ROUND_ROBIN
     for _ in 0..2 {
         let selected_endpoint = selected_endpoint.clone();
         echo_addresses.insert(
-            t.run_echo_server_with_tap(move |_, _, echo_addr| {
+            t.run_echo_server_with_tap(&AddressType::Random, move |_, _, echo_addr| {
                 let _ = selected_endpoint.lock().unwrap().replace(echo_addr);
             })
             .await,

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -22,7 +22,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{LocalRateLimit, StaticFilter},
-    test_utils::{available_addr, TestHelper},
+    test_utils::{available_addr, AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -33,9 +33,9 @@ async fn local_rate_limit_filter() {
 max_packets: 2
 period: 1
 ";
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
-    let server_addr = available_addr().await;
+    let server_addr = available_addr(&AddressType::Random).await;
     let server_proxy = quilkin::cli::Proxy {
         port: server_addr.port(),
         ..<_>::default()

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -22,13 +22,13 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Capture, Match, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
 async fn r#match() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     let capture_yaml = "
 suffix:

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -16,18 +16,23 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use quilkin::{endpoint::Endpoint, test_utils::TestHelper};
+use quilkin::{
+    endpoint::Endpoint,
+    test_utils::{AddressType, TestHelper},
+};
 
 #[tokio::test]
 async fn metrics_server() {
     let mut t = TestHelper::default();
 
     // create an echo server as an endpoint.
-    let echo = t.run_echo_server().await;
-    let metrics_port = quilkin::test_utils::available_addr().await.port();
+    let echo = t.run_echo_server(&AddressType::Random).await;
+    let metrics_port = quilkin::test_utils::available_addr(&AddressType::Random)
+        .await
+        .port();
 
     // create server configuration
-    let server_addr = quilkin::test_utils::available_addr().await;
+    let server_addr = quilkin::test_utils::available_addr(&AddressType::Random).await;
     let server_proxy = quilkin::cli::Proxy {
         port: server_addr.port(),
         ..<_>::default()

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -17,19 +17,21 @@
 use tokio::time::timeout;
 use tokio::time::Duration;
 
-use quilkin::test_utils::available_addr;
-use quilkin::{endpoint::Endpoint, test_utils::TestHelper};
+use quilkin::{
+    endpoint::Endpoint,
+    test_utils::{available_addr, AddressType, TestHelper},
+};
 
 #[tokio::test]
 async fn echo() {
     let mut t = TestHelper::default();
 
     // create two echo servers as endpoints
-    let server1 = t.run_echo_server().await;
-    let server2 = t.run_echo_server().await;
+    let server1 = t.run_echo_server(&AddressType::Random).await;
+    let server2 = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration
-    let local_addr = available_addr().await;
+    let local_addr = available_addr(&AddressType::Random).await;
     let server_proxy = quilkin::cli::Proxy {
         port: local_addr.port(),
         ..<_>::default()

--- a/tests/qcmp.rs
+++ b/tests/qcmp.rs
@@ -18,12 +18,17 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use tokio::time::Duration;
 
-use quilkin::{protocol::Protocol, test_utils::TestHelper};
+use quilkin::{
+    protocol::Protocol,
+    test_utils::{AddressType, TestHelper},
+};
 
 #[tokio::test]
 async fn proxy_ping() {
     let mut t = TestHelper::default();
-    let server_port = quilkin::test_utils::available_addr().await.port();
+    let server_port = quilkin::test_utils::available_addr(&AddressType::Random)
+        .await
+        .port();
     let server_proxy = quilkin::cli::Proxy {
         qcmp_port: server_port,
         to: vec![(Ipv4Addr::UNSPECIFIED, 0).into()],
@@ -36,7 +41,9 @@ async fn proxy_ping() {
 
 #[tokio::test]
 async fn agent_ping() {
-    let qcmp_port = quilkin::test_utils::available_addr().await.port();
+    let qcmp_port = quilkin::test_utils::available_addr(&AddressType::Random)
+        .await
+        .port();
     let agent = quilkin::cli::Agent {
         qcmp_port,
         ..<_>::default()

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -23,7 +23,7 @@ use quilkin::{
     endpoint::Endpoint,
     filters::{Capture, StaticFilter, TokenRouter},
     metadata::MetadataView,
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 /// This test covers both token_router and capture filters,
@@ -31,7 +31,7 @@ use quilkin::{
 #[tokio::test]
 async fn token_router() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     let capture_yaml = "
 suffix:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Implemented the `DualStackLocalSocket` for the locally listening socket, and updated the code base and fixed several issues that existed for handling IPv6 addresses in the code base.

This included updating the `test_utils` framework to provide coverage in tests for both ipv4 and ipv6 by allowing for either an IPv4 or IPv6 address to be created from the framework.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #666

**Special notes for your reviewer**:

Let me know what you think of the `Random` address type approach. Felt like the easiest way to get general coverage and force testing of both paths, without having to have some kind of dual-run test harness.
