### PR TITLE
Late initialise upstream socket to prevent session map lock

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,8 @@ exceptions = [
     # Each entry is the crate and version constraint, and its specific allow
     # list
     { name ="webpki-roots", version = "0.25.0", allow = ["MPL-2.0"] },
-    { name ="webpki-roots", version = "0.23.0", allow = ["MPL-2.0"] }
+    { name ="webpki-roots", version = "0.23.0", allow = ["MPL-2.0"] },
+    { name ="option-ext", version = "0.2.0", allow = ["MPL-2.0"] }
 ]
 
 [[licenses.clarify]]

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -60,6 +60,7 @@ impl Timestamp {
         };
 
         // Create a normal DateTime from the NaiveDateTime
+        #[allow(deprecated)]
         let datetime: DateTime<Utc> = DateTime::from_utc(naive, Utc);
 
         let now = Utc::now();


### PR DESCRIPTION
I thought I had already done this, but this moves the upstream socket initialisation to on use rather than in the `Session::new` initialisation. This removes the await point from session creation, preventing session map locking, as such I also removed the `try_get`, and then also removed `SessionArgs` as it was unneeded redirection.