### PR TITLE
add cli option for log formatting (Closes #531)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,9 @@ kube.workspace = true
 trust-dns-resolver = { version = "0.23.0", features = ["tokio", "tokio-rustls", "dns-over-https-rustls"] }
 async-trait = "0.1.68"
 nom = "7.1.3"
+atty = "0.2.14"
+strum = "0.25.0"
+strum_macros = "0.25"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,10 +19,12 @@ use std::{
     sync::Arc,
 };
 
+use clap::builder::TypedValueParser;
 use clap::crate_version;
 use tokio::{signal, sync::watch};
 
 use crate::{admin::Mode, Config};
+use strum_macros::{Display, EnumString};
 
 pub use self::{
     agent::Agent, generate_config_schema::GenerateConfigSchema, manage::Manage, proxy::Proxy,
@@ -68,6 +70,26 @@ pub struct Cli {
     pub quiet: bool,
     #[clap(subcommand)]
     pub command: Commands,
+    #[clap(
+    long,
+    default_value_t = LogFormats::Detect,
+    value_parser = clap::builder::PossibleValuesParser::new(["detect", "json", "pretty", "ppretty"])
+    .map(|s| s.parse::<LogFormats>().unwrap()),
+    )]
+    pub log_format: LogFormats,
+}
+
+/// The various log format options
+#[derive(Copy, Clone, PartialEq, Eq, Debug, EnumString, Display)]
+pub enum LogFormats {
+    #[strum(serialize = "detect")]
+    Detect,
+    #[strum(serialize = "json")]
+    Json,
+    #[strum(serialize = "pretty")]
+    Pretty,
+    #[strum(serialize = "ppretty")]
+    PrettyPretty,
 }
 
 /// The various Quilkin commands.
@@ -101,11 +123,22 @@ impl Cli {
             let env_filter = tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
                 .from_env_lossy();
-            tracing_subscriber::fmt()
-                .json()
+            let subscriber = tracing_subscriber::fmt()
                 .with_file(true)
-                .with_env_filter(env_filter)
-                .init();
+                .with_env_filter(env_filter);
+
+            match self.log_format {
+                LogFormats::Detect => {
+                    if atty::isnt(atty::Stream::Stdout) {
+                        subscriber.json().init();
+                    } else {
+                        subscriber.init();
+                    }
+                }
+                LogFormats::Json => subscriber.json().init(),
+                LogFormats::Pretty => subscriber.init(),
+                LogFormats::PrettyPretty => subscriber.pretty().init(),
+            }
         }
 
         tracing::info!(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,8 +72,8 @@ pub struct Cli {
     pub command: Commands,
     #[clap(
     long,
-    default_value_t = LogFormats::Detect,
-    value_parser = clap::builder::PossibleValuesParser::new(["detect", "json", "pretty", "ppretty"])
+    default_value_t = LogFormats::Auto,
+    value_parser = clap::builder::PossibleValuesParser::new(["auto", "json", "plain", "pretty"])
     .map(|s| s.parse::<LogFormats>().unwrap()),
     )]
     pub log_format: LogFormats,
@@ -82,15 +82,15 @@ pub struct Cli {
 /// The various log format options
 #[derive(Copy, Clone, PartialEq, Eq, Debug, EnumString, Display, Default)]
 pub enum LogFormats {
-    #[strum(serialize = "detect")]
+    #[strum(serialize = "auto")]
     #[default]
-    Detect,
+    Auto,
     #[strum(serialize = "json")]
     Json,
+    #[strum(serialize = "plain")]
+    Plain,
     #[strum(serialize = "pretty")]
     Pretty,
-    #[strum(serialize = "ppretty")]
-    PrettyPretty,
 }
 
 /// The various Quilkin commands.
@@ -129,7 +129,7 @@ impl Cli {
                 .with_env_filter(env_filter);
 
             match self.log_format {
-                LogFormats::Detect => {
+                LogFormats::Auto => {
                     if atty::isnt(atty::Stream::Stdout) {
                         subscriber.json().init();
                     } else {
@@ -137,8 +137,8 @@ impl Cli {
                     }
                 }
                 LogFormats::Json => subscriber.json().init(),
-                LogFormats::Pretty => subscriber.init(),
-                LogFormats::PrettyPretty => subscriber.pretty().init(),
+                LogFormats::Plain => subscriber.init(),
+                LogFormats::Pretty => subscriber.pretty().init(),
             }
         }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,9 +80,10 @@ pub struct Cli {
 }
 
 /// The various log format options
-#[derive(Copy, Clone, PartialEq, Eq, Debug, EnumString, Display)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, EnumString, Display, Default)]
 pub enum LogFormats {
     #[strum(serialize = "detect")]
+    #[default]
     Detect,
     #[strum(serialize = "json")]
     Json,
@@ -340,6 +341,7 @@ mod tests {
                 }),
                 ..<_>::default()
             }),
+            log_format: LogFormats::default(),
         };
 
         let control_plane_admin_port = crate::test_utils::available_addr().await.port();
@@ -358,6 +360,7 @@ mod tests {
                     path: endpoints_file.path().to_path_buf(),
                 },
             }),
+            log_format: LogFormats::default(),
         };
 
         let proxy_admin_port = crate::test_utils::available_addr().await.port();
@@ -370,6 +373,7 @@ mod tests {
                 management_server: vec!["http://localhost:7800".parse().unwrap()],
                 ..<_>::default()
             }),
+            log_format: LogFormats::default(),
         };
 
         tokio::spawn(relay.drive());


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
/kind feature

**What this PR does / Why we need it**:
this pr adds an option to chose between the following formatting option:
* `auto` - default option, detects if running in an interactive terminal and will choose either "json" or "plain"
* `json` - outputs logs in json
* `plain` - uses default tracing_subscriber output
* `pretty` - uses _tracing_subscriber.pretty()_ output

<details>
  <summary>How the options look</summary>
  
### json
<img width="1996" alt="Bildschirmfoto 2023-09-09 um 19 10 04" src="https://github.com/googleforgames/quilkin/assets/3052396/6f4908db-6ef0-438d-9caa-ac7874c25bb9">

### plain
<img width="2286" alt="Bildschirmfoto 2023-09-09 um 19 09 47" src="https://github.com/googleforgames/quilkin/assets/3052396/e4e7d4ee-50a4-419f-9e8f-ca015f30b92b">

### pretty
<img width="1956" alt="Bildschirmfoto 2023-09-09 um 20 06 17" src="https://github.com/googleforgames/quilkin/assets/3052396/2715905d-09b7-4478-879a-7c3141a2fe0d">

</details>

**Which issue(s) this PR fixes**:
Closes #531

**Special notes for your reviewer**:
~Not sure about the naming, "detect" could also be "auto" or if "pretty" should be something like "debug". I am also not sure if the "ppretty" option is needed at all.~

*updated with renamed options*
