### PR TITLE
Refactor ClusterMap

### DIFF
--- a/agones/src/sidecar.rs
+++ b/agones/src/sidecar.rs
@@ -77,10 +77,8 @@ filters:
         on_write: DO_NOTHING
         bytes: c2lkZWNhcg== # sidecar
 clusters:
-  default:
-    localities:
-      - endpoints:
-          - address: 127.0.0.1:7654
+  - endpoints:
+    - address: 127.0.0.1:7654
 "#;
 
         let config_map = config_maps

--- a/agones/src/xds.rs
+++ b/agones/src/xds.rs
@@ -181,7 +181,6 @@ filters:
             .as_mut()
             .map(|annotations| annotations.remove(token_key).unwrap());
         gameservers.replace(name.as_str(), &pp, &gs).await.unwrap();
-
         // now we should send a packet, and not get a response.
         let mut failed = false;
         for i in 0..30 {
@@ -196,6 +195,10 @@ filters:
                 failed = true;
                 break;
             }
+        }
+        if !failed {
+            debug_pods(&client, "role=proxy".into()).await;
+            debug_pods(&client, "role=xds".into()).await;
         }
         assert!(failed, "Packet should have failed");
     }

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -30,7 +30,7 @@ fn run_quilkin(port: u16, endpoint: SocketAddr) {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let config = Arc::new(quilkin::Config::default());
         config.clusters.modify(|clusters| {
-            clusters.insert_default(vec![quilkin::endpoint::Endpoint::new(endpoint.into())])
+            clusters.insert_default([quilkin::endpoint::Endpoint::new(endpoint.into())].into())
         });
 
         let proxy = quilkin::cli::Proxy {

--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/data-plane-api/envoy/type/metadata/v3/metadata.proto",
         "proto/data-plane-api/envoy/type/tracing/v3/custom_tag.proto",
         "proto/quilkin/relay/v1alpha1/relay.proto",
+        "proto/quilkin/config/v1alpha1/config.proto",
         "proto/quilkin/filters/capture/v1alpha1/capture.proto",
         "proto/quilkin/filters/compress/v1alpha1/compress.proto",
         "proto/quilkin/filters/concatenate_bytes/v1alpha1/concatenate_bytes.proto",

--- a/docs/src/deployment/quickstarts/agones-xonotic-xds.md
+++ b/docs/src/deployment/quickstarts/agones-xonotic-xds.md
@@ -5,12 +5,12 @@
 
 ## 1. Overview
 
-In this quickstart, we'll be setting up an example [Xonotic](https://xonotic.org/) [Agones](https://agones.dev/) 
+In this quickstart, we'll be setting up an example [Xonotic](https://xonotic.org/) [Agones](https://agones.dev/)
 Fleet, that will only be accessible through Quilkin, via utilising the [TokenRouter]
-Filter to provide routing and access control to the Allocated `GameServer` instances.   
+Filter to provide routing and access control to the Allocated `GameServer` instances.
 
-To do this, we'll take advantage of the Quilkin [Agones xDS Provider](../../services/xds/providers/agones.md) to provide 
-an out-of-the-box control plane for integration between Agones and [Quilkin's xDS configuration API](../../services/xds.md) with 
+To do this, we'll take advantage of the Quilkin [Agones xDS Provider](../../services/xds/providers/agones.md) to provide
+an out-of-the-box control plane for integration between Agones and [Quilkin's xDS configuration API](../../services/xds.md) with
 minimal effort.
 
 ## 2. Install Quilkin Agones xDS Provider
@@ -26,11 +26,11 @@ kubectl apply -f https://raw.githubusercontent.com/googleforgames/quilkin/{{GITH
 
 This applies several resources to your cluster:
 
-1. A [ConfigMap] with a [Capture] and [TokenRouter] Filter set up to route packets to Endpoints, to be the base 
+1. A [ConfigMap] with a [Capture] and [TokenRouter] Filter set up to route packets to Endpoints, to be the base
    configuration for all the Quilkin proxies.
-2. Appropriate [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) permissions for the 
+2. Appropriate [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) permissions for the
    `quilkin manage agones` process to inspect Agones resources.
-3. A matching [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)  that runs the 
+3. A matching [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)  that runs the
    `quilkin manage process` xDS control plane and a
    [Service](https://kubernetes.io/docs/concepts/services-networking/service/) that the Quilkin proxies can connect to,
    to get their Filter and Endpoint configuration from.
@@ -44,7 +44,7 @@ quilkin-manage-agones-54b787654-9dbvp   1/1     Running   0          76s
 ```
 
 We can now run `kubectl get service quilkin-manage-agones` and see the
-service that is generated in front of the above Deployment for our Quilkin proxies to connect to and receive their 
+service that is generated in front of the above Deployment for our Quilkin proxies to connect to and receive their
 configuration information from.
 
 ```shell
@@ -55,20 +55,20 @@ quilkin-manage-agones   ClusterIP   10.104.2.72   <none>        80/TCP    1m23s
 
 ## 3. Install Quilkin Proxy Pool
 
-To install the Quilkin Proxy pool which connects to the above xDS provider, we can create a Deployment of Quilkin 
+To install the Quilkin Proxy pool which connects to the above xDS provider, we can create a Deployment of Quilkin
 proxy instances that point to the aforementioned Service, like so:
 
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/googleforgames/quilkin/{{GITHUB_REF_NAME}}/examples/agones-xonotic-xds/proxy-pool.yaml
 ```
 
-This will set up three instances of Quilkin running as `quilkin proxy --management-server http://quilkin-manage-agones:80` 
+This will set up three instances of Quilkin running as `quilkin proxy --management-server http://quilkin-manage-agones:80`
 all connected to the `quilkin-manage-agones` service.
 
 Now we can run `kubectl get pods` until we see that the Pods for the proxy Deployment is up and running.
 
 ```shell
-$ kubectl get pods                                                                                                          
+$ kubectl get pods
 NAME                                    READY   STATUS    RESTARTS   AGE
 quilkin-manage-agones-54b787654-9dbvp   1/1     Running   0          5m7s
 quilkin-proxies-78965c446d-dqvjg        1/1     Running   0          6s
@@ -76,34 +76,34 @@ quilkin-proxies-78965c446d-fr6zs        1/1     Running   0          6s
 quilkin-proxies-78965c446d-m4rr7        1/1     Running   0          6s
 ```
 
-Let's take this one step further, and check the configuration of the proxies that should have come from the `quilkin 
+Let's take this one step further, and check the configuration of the proxies that should have come from the `quilkin
 manage agones` instance.
 
 In another terminal, run:  `kubectl port-forward deployments/quilkin-proxies 8000`, to port forward the
 [admin endpoint](../admin.md) locally, which we can then query.
 
-Go back to your original terminal and run `curl -s http://localhost:8000/config` 
+Go back to your original terminal and run `curl -s http://localhost:8000/config`
 
 > If you have [jq](https://stedolan.github.io/jq/) installed, run `curl -s http://localhost:8000/config | jq` for a
 > nicely formatted JSON output.
 
 ```shell
 $ curl -s http://localhost:8000/config
-{"admin":{"address":"0.0.0.0:8000"},"clusters":{},"filters":[{"name":"quilkin.filters.capture.v1alpha1.Capture","config":{"metadataKey":"quilkin.dev/capture","suffix":{"size":3,"remove":true}}},{"name":"quilkin.filters.token_router.v1alpha1.TokenRouter","config":null}],"id":"quilkin-proxies-78965c446d-dqvjg","management_servers":[{"address":"http://quilkin-manage-agones:80"}],"port":7000,"version":"v1alpha1","maxmind_db":null}%       
+{"admin":{"address":"0.0.0.0:8000"},"clusters":{},"filters":[{"name":"quilkin.filters.capture.v1alpha1.Capture","config":{"metadataKey":"quilkin.dev/capture","suffix":{"size":3,"remove":true}}},{"name":"quilkin.filters.token_router.v1alpha1.TokenRouter","config":null}],"id":"quilkin-proxies-78965c446d-dqvjg","management_servers":[{"address":"http://quilkin-manage-agones:80"}],"port":7000,"version":"v1alpha1","maxmind_db":null}%
 ```
 
-This shows us the current configuration of the proxies coming from the xDS server created via `quilkin manage 
-agones`. The most interesting part that we see here, is that we have a matching set of 
-[Filters](../../services/proxy/filters.md) that are found in the `ConfigMap` in the 
+This shows us the current configuration of the proxies coming from the xDS server created via `quilkin manage
+agones`. The most interesting part that we see here, is that we have a matching set of
+[Filters](../../services/proxy/filters.md) that are found in the `ConfigMap` in the
 [xds-control-plane.yaml](https://github.com/googleforgames/quilkin/blob/{{GITHUB_REF_NAME}}/examples/agones-xonotic-xds/xds-control-plane.yaml)
 we installed earlier.
 
 ## 4. Create the Agones Fleet
 
-Now we will create an [Agones Fleet](https://agones.dev/site/docs/reference/fleet/) to spin up all our Xonotic 
+Now we will create an [Agones Fleet](https://agones.dev/site/docs/reference/fleet/) to spin up all our Xonotic
 game servers.
 
-Thankfully, Agones Fleets require no specific configuration to work with Quilkin proxies, so this yaml is a 
+Thankfully, Agones Fleets require no specific configuration to work with Quilkin proxies, so this yaml is a
 [standard Agones Fleet configuration](https://github.com/googleforgames/quilkin/blob/{{GITHUB_REF_NAME}}/examples/agones-xonotic-xds/fleet.yaml)
 
 ```shell
@@ -126,18 +126,18 @@ To let the Quilkin xDS provider know what token will route to which `GameServer`
 `quilkin.dev/tokens` annotation to an allocated `GameServer`, with the token content as its value.
 
 >  This token would normally get generated by some kind of  player authentication service and passed to the client
->  via the matchmaking service - but for demonstrative purposes, we've hardcoded it into the example 
+>  via the matchmaking service - but for demonstrative purposes, we've hardcoded it into the example
 > `GameServerAllocation`.
 
-Since you can add annotations to `GameServers` at 
-[allocation time](https://agones.dev/site/docs/reference/gameserverallocation/), we can both allocate a `GameServer` 
+Since you can add annotations to `GameServers` at
+[allocation time](https://agones.dev/site/docs/reference/gameserverallocation/), we can both allocate a `GameServer`
 and apply the annotation at the same time!
 
 ```shell
 kubectl create -f https://raw.githubusercontent.com/googleforgames/quilkin/{{GITHUB_REF_NAME}}/examples/agones-xonotic-xds/gameserverallocation.yaml
 ```
 
-If we check our `GameServers` now, we should see that one of them has moved to the `Allocated` state, marking it as 
+If we check our `GameServers` now, we should see that one of them has moved to the `Allocated` state, marking it as
 having players playing on it, and therefore it is protected by Agones until the game session ends.
 
 ```shell
@@ -150,7 +150,7 @@ xonotic-d7rfx-sn5d6   Ready       34.168.170.51   7036   gke-agones-default-534a
 
 > Don't do this more than once, as then multiple allocated `GameServers` will have the same routing token!
 
-If we `kubectl describe gameserver <allocated-gameserver>` and have a look at the annotations section, we 
+If we `kubectl describe gameserver <allocated-gameserver>` and have a look at the annotations section, we
 should see something similar to this:
 
 ```shell
@@ -168,7 +168,7 @@ Kind:         GameServer
 ...
 ```
 
-Where we can see that there is now an annotation of `quilkin.dev/tokens` with the base64 encoded version of `456` as 
+Where we can see that there is now an annotation of `quilkin.dev/tokens` with the base64 encoded version of `456` as
 our authentication and routing token ("NDU2").
 
 > You should use something more cryptographically random than `456` in your application.
@@ -177,22 +177,22 @@ Let's run `curl -s http://localhost:8000/config` again, so we can see what has c
 
 ```shell
 $ curl -s http://localhost:8000/config
-{"admin":{"address":"0.0.0.0:8000"},"clusters":{"default":{"localities":[{"locality":null,"endpoints":[{"address":"34.168.170.51:7226","metadata":{"quilkin.dev":{"tokens":["NDU2"]}}}]}]}},"filters":[{"name":"quilkin.filters.capture.v1alpha1.Capture","config":{"metadataKey":"quilkin.dev/capture","suffix":{"size":3,"remove":true}}},{"name":"quilkin.filters.token_router.v1alpha1.TokenRouter","config":null}],"id":"quilkin-proxies-78965c446d-tfgsj","management_servers":[{"address":"http://quilkin-manage-agones:80"}],"port":7000,"version":"v1alpha1","maxmind_db":null}%
+{"admin":{"address":"0.0.0.0:8000"},"clusters": [{"locality":null,"endpoints":[{"address":"34.168.170.51:7226","metadata":{"quilkin.dev":{"tokens":["NDU2"]}}}]}],"filters":[{"name":"quilkin.filters.capture.v1alpha1.Capture","config":{"metadataKey":"quilkin.dev/capture","suffix":{"size":3,"remove":true}}},{"name":"quilkin.filters.token_router.v1alpha1.TokenRouter","config":null}],"id":"quilkin-proxies-78965c446d-tfgsj","management_servers":[{"address":"http://quilkin-manage-agones:80"}],"port":7000,"version":"v1alpha1","maxmind_db":null}%
 ```
 
-Looking under `clusters` > `localities` > `endpoints` we can see an address and token that matches up with the 
+Looking under `clusters` > `endpoints` we can see an address and token that matches up with the
 `GameServer` record we created above!
 
-The xDS process saw that allocated `GameServer`, turned it into a Quilkin `Endpoint` and applied the set routing 
-token appropriately -- without you having to write a line of xDS compliant code! 
+The xDS process saw that allocated `GameServer`, turned it into a Quilkin `Endpoint` and applied the set routing
+token appropriately -- without you having to write a line of xDS compliant code!
 
 ## Connecting Client Side
 
 Instead of connecting to Xonotic or an Agones `GameServer` directly, we'll want to grab the IP and exposed port of
-the `Service` that fronts all our Quilkin proxies and connect to that instead -- but we'll have to append our 
+the `Service` that fronts all our Quilkin proxies and connect to that instead -- but we'll have to append our
 routing token `456` from before, to ensure our traffic gets routed to the correct Xonotic `GameServer` address.
 
-Run `kubectl get service quilkin-proxies` to get the `EXTERNAL-IP` of the Service you created. 
+Run `kubectl get service quilkin-proxies` to get the `EXTERNAL-IP` of the Service you created.
 
 ```shell
 $ kubectl get service quilkin-proxies
@@ -201,14 +201,14 @@ quilkin-proxies   LoadBalancer   10.109.0.12   35.246.94.14    7000:30174/UDP   
 ```
 
 We have a [Quilkin config yaml](https://github.com/googleforgames/quilkin/blob/{{GITHUB_REF_NAME}}/examples/agones-xonotic-xds/client-token.yaml)
-file all ready for you, that is configured to append the routing token `456` to each 
-packet that passes through it, via the power of a 
+file all ready for you, that is configured to append the routing token `456` to each
+packet that passes through it, via the power of a
 [ConcatenateBytes](../../services/proxy/filters/concatenate_bytes.md) Filter.
 
 Download `client-token.yaml` locally, so you can edit it:
 
 ```shell
-curl https://raw.githubusercontent.com/googleforgames/quilkin/{{GITHUB_REF_NAME}}/examples/agones-xonotic-xds/client-token.yaml --output client-token.yaml  
+curl https://raw.githubusercontent.com/googleforgames/quilkin/{{GITHUB_REF_NAME}}/examples/agones-xonotic-xds/client-token.yaml --output client-token.yaml
 ```
 
 We then take the EXTERNAL-IP and port from the `quilkin-proxies` service, and replace the`${LOADBALANCER_IP}`

--- a/docs/src/services/proxy.md
+++ b/docs/src/services/proxy.md
@@ -8,7 +8,7 @@
 "Proxy" is the primary Quilkin service, which acts as a non-transparent UDP
 proxy.
 
-To view all the options for the `proxy` subcommand, run: 
+To view all the options for the `proxy` subcommand, run:
 
 ```shell
 $ quilkin proxy --help
@@ -17,51 +17,49 @@ $ quilkin proxy --help
 
 ## Endpoints
 
-An Endpoint represents an address that Quilkin forwards packets to that it has received from the 
+An Endpoint represents an address that Quilkin forwards packets to that it has received from the
 source port.
 
-It is represented by an IP address and port. An Endpoint can optionally be associated with an arbitrary set of 
+It is represented by an IP address and port. An Endpoint can optionally be associated with an arbitrary set of
 [metadata](#endpoint-metadata) as well.
 
 ## Proxy Filters
 
 Filters are the way for a Quilkin proxy to intercept UDP packet traffic from the
 source and [Endpoints][Endpoint] in either direction, and be able to inspect,
-manipulate, and route the packets as desired. 
+manipulate, and route the packets as desired.
 
-See [Filters]  for a deeper dive into Filters, as well as the list of build in Filters that come with 
+See [Filters]  for a deeper dive into Filters, as well as the list of build in Filters that come with
 Quilkin.
 
 ## Endpoint Metadata
 
 Endpoint metadata is an arbitrary set of key value pairs that are associated with an Endpoint.
 
-These are visible to Filters when processing packets and can be used to provide more context about endpoints (e.g 
+These are visible to Filters when processing packets and can be used to provide more context about endpoints (e.g
 whether or not to route a packet to an endpoint). Keys must be of type string otherwise the configuration is rejected.
 
 Metadata associated with an endpoint contain arbitrary key value pairs which [Filters] can consult when processing packets (e.g they can contain information that determine whether or not to route a particular packet to an endpoint).
 
 ### Specialist Endpoint Metadata
 
-Access tokens that can be associated with an endpoint are simply a special piece of metadata well known to Quilkin 
+Access tokens that can be associated with an endpoint are simply a special piece of metadata well known to Quilkin
 and utilised by the built-in [TokenRouter] filter to route packets.
 
-Such well known values are placed within an object in the endpoint metadata, under the special key `quilkin.dev`. 
+Such well known values are placed within an object in the endpoint metadata, under the special key `quilkin.dev`.
 Currently, only the `tokens` key is in use.
 
 As an example, the following shows the configuration for an endpoint with its metadata:
 ```yaml
 clusters:
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:26000
-          metadata:
-            canary: false
-            quilkin.dev: # This object is extracted by Quilkin and is usually reserved for built-in features
-                tokens:
-                - MXg3aWp5Ng== # base64 for 1x7ijy6
-                - OGdqM3YyaQ== # base64 for 8gj3v2i
+  - endpoints:
+    - address: 127.0.0.1:26000
+      metadata:
+        canary: false
+        quilkin.dev: # This object is extracted by Quilkin and is usually reserved for built-in features
+            tokens:
+            - MXg3aWp5Ng== # base64 for 1x7ijy6
+            - OGdqM3YyaQ== # base64 for 8gj3v2i
 ```
 
 An endpoint's metadata can be specified alongside the endpoint in [static configuration][file-configuration] or using the [xDS endpoint metadata][xds-endpoint-metadata] field when using [dynamic configuration][dynamic-configuration-doc] via xDS.
@@ -74,17 +72,17 @@ Quilkin uses the "Session" concept to track traffic flowing through the proxy be
 Session serves the same purpose, and can be thought of as a lightweight version of a `TCP` session in that, while a
 TCP session requires a protocol to establish and teardown:
 
-- A Quilkin session is automatically created upon receiving the first packet from a client via the [Local Port] to be 
+- A Quilkin session is automatically created upon receiving the first packet from a client via the [Local Port] to be
   sent to an upstream [Endpoint].
-- The session is automatically deleted after a period of inactivity (where no packet was sent between either 
+- The session is automatically deleted after a period of inactivity (where no packet was sent between either
   party) - currently 60 seconds.
 
-A session is identified by the 4-tuple `(client IP, client Port, server IP, server Port)` where the client is the 
-downstream endpoint which initiated the communication with Quilkin and the server is one of the upstream Endpoints 
+A session is identified by the 4-tuple `(client IP, client Port, server IP, server Port)` where the client is the
+downstream endpoint which initiated the communication with Quilkin and the server is one of the upstream Endpoints
 that Quilkin proxies traffic to.
 
-Sessions are established *after* the filter chain completes. The destination Endpoint of a packet is determined by 
-the [filter chain][Filters], so a Session can only be created after filter chain completion. For example, if the 
+Sessions are established *after* the filter chain completes. The destination Endpoint of a packet is determined by
+the [filter chain][Filters], so a Session can only be created after filter chain completion. For example, if the
 filter chain drops all packets, then no session will ever be created.
 
 [Endpoint]: #endpoints

--- a/docs/src/services/proxy/configuration.md
+++ b/docs/src/services/proxy/configuration.md
@@ -22,14 +22,14 @@ endpoint configuration to specify two endpoints with `token` metadata attached t
 {{#include ../../../../examples/proxy.yaml:17:100}}
 ```
 
-This is a great use of a static configuration file, as we only get a singular `--to` endpoint address via the 
+This is a great use of a static configuration file, as we only get a singular `--to` endpoint address via the
 command line arguments.
 
 We can also configure [Filters](./filters.md) via the configuration file. See that section for documentation.
 
 ## Dynamic Configuration
 
-If you need to dynamically change either Filters and/or Endpoints at runtime, see the [Control Plane](../xds.md) 
+If you need to dynamically change either Filters and/or Endpoints at runtime, see the [Control Plane](../xds.md)
 documentation on the configuration API surface, and built in dynamic management providers.
 
 ## Json Schema
@@ -66,58 +66,33 @@ properties:
     items:
       '$ref': {} # Refer to the Filter documentation for a filter configuration schema.
   clusters:
-    type: object
-    description: |
-      grouping of clusters, each with a key for a name
-    additionalProperties:
-      type: object
-      description: |
-        An individual cluster
-      properties:
-        localities:          
-          type: array
-          description: |
-            grouping of endpoints, per cluster.
-          items:
-            type: object
-            properties:
-              endpoints:
-                type: array
-                description: |
-                  A list of upstream endpoints to forward packets to.
-                items:
-                  type: object
-                  description: |
-                    An upstream endpoint
-                  properties:
-                    address:
-                      type: string
-                      description: |
-                        Socket address of the endpoint. This must be of the ´IP:Port` form e.g `192.168.1.1:7001`
-                      metadata:
-                        type: object
-                        description: |
-                          Arbitrary key value pairs that is associated with the endpoint.
-                          These are visible to Filters when processing packets and can be used to provide more context about endpoints (e.g whether or not to route a packet to an endpoint).
-                          Keys must be of type string otherwise the configuration is rejected.
-                  required:
-                    - address
-  management_servers:
     type: array
     description: |
-      A list of XDS management servers to fetch configuration from.
-      Multiple servers can be provided for redundancy for the proxy to
-      fall back to upon error.
+      grouping of endpoints, per cluster.
     items:
       type: object
-      description: |
-        Configuration for a management server.
-    properties:
-      address:
-        type: string
-        description: |
-          Address of the management server. This must have the `http(s)` scheme prefix.
-          Example: `http://example.com`
+      properties:
+        endpoints:
+          type: array
+          description: |
+            A list of upstream endpoints to forward packets to.
+          items:
+            type: object
+            description: |
+              An upstream endpoint
+            properties:
+              address:
+                type: string
+                description: |
+                  Socket address of the endpoint. This must be of the ´IP:Port` form e.g `192.168.1.1:7001`
+                metadata:
+                  type: object
+                  description: |
+                    Arbitrary key value pairs that is associated with the endpoint.
+                    These are visible to Filters when processing packets and can be used to provide more context about endpoints (e.g whether or not to route a packet to an endpoint).
+                    Keys must be of type string otherwise the configuration is rejected.
+            required:
+              - address
 ```
 
 [examples]: https://github.com/googleforgames/quilkin/blob/{{GITHUB_REF_NAME}}/examples

--- a/docs/src/services/proxy/filters.md
+++ b/docs/src/services/proxy/filters.md
@@ -50,10 +50,8 @@ filters:
       max_packets: 10
       period: 1
 clusters:
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:7001
+  - endpoints:
+    - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 2);

--- a/docs/src/services/proxy/filters/capture.md
+++ b/docs/src/services/proxy/filters/capture.md
@@ -41,10 +41,8 @@ filters:
         size: 3
         remove: false
 clusters:
-  default:
-    localities:
-        - endpoints:
-            - address: 127.0.0.1:7001
+  - endpoints:
+      - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/docs/src/services/proxy/filters/compress.md
+++ b/docs/src/services/proxy/filters/compress.md
@@ -19,10 +19,8 @@ filters:
         on_write: DECOMPRESS
         mode: SNAPPY
 clusters:
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:7001
+  - endpoints:
+    - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/docs/src/services/proxy/filters/concatenate_bytes.md
+++ b/docs/src/services/proxy/filters/concatenate_bytes.md
@@ -19,10 +19,8 @@ filters:
         on_write: DO_NOTHING
         bytes: MXg3aWp5Ng==
 clusters:
-  default:
-    localities:
-        - endpoints:
-            - address: 127.0.0.1:7001
+  - endpoints:
+      - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/docs/src/services/proxy/filters/debug.md
+++ b/docs/src/services/proxy/filters/debug.md
@@ -18,10 +18,8 @@ filters:
     config:
       id: debug-1
 clusters:
-  default:
-    localities:
-        - endpoints:
-            - address: 127.0.0.1:7001
+  - endpoints:
+      - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/docs/src/services/proxy/filters/firewall.md
+++ b/docs/src/services/proxy/filters/firewall.md
@@ -29,10 +29,8 @@ filters:
           ports:
             - 7000
 clusters:
-  default:
-    localities:
-        - endpoints:
-            - address: 127.0.0.1:7001
+  - endpoints:
+      - address: 127.0.0.1:7001
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/docs/src/services/proxy/filters/load_balancer.md
+++ b/docs/src/services/proxy/filters/load_balancer.md
@@ -18,10 +18,8 @@ filters:
     config:
       policy: ROUND_ROBIN
 clusters:
-  default:
-    localities:
-        - endpoints:
-            - address: 127.0.0.1:7001
+  - endpoints:
+      - address: 127.0.0.1:7001
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/docs/src/services/proxy/filters/local_rate_limit.md
+++ b/docs/src/services/proxy/filters/local_rate_limit.md
@@ -22,10 +22,8 @@ filters:
       max_packets: 1000
       period: 1
 clusters:
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:7001
+  - endpoints:
+    - address: 127.0.0.1:7001
 # ";
 #   let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/docs/src/services/proxy/filters/match.md
+++ b/docs/src/services/proxy/filters/match.md
@@ -15,11 +15,9 @@ quilkin.filters.match.v1alpha1.Match
 # let yaml = "
 version: v1alpha1
 clusters: 
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:26000
-        - address: 127.0.0.1:26001
+  - endpoints:
+    - address: 127.0.0.1:26000
+    - address: 127.0.0.1:26001
 filters:
   - name: quilkin.filters.capture.v1alpha1.Capture
     config:

--- a/docs/src/services/proxy/filters/timestamp.md
+++ b/docs/src/services/proxy/filters/timestamp.md
@@ -24,10 +24,8 @@ filters:
     config:
         metadataKey: example.com/session_duration
 clusters:
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:26000
+  - endpoints:
+    - address: 127.0.0.1:26000
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 ```

--- a/docs/src/services/proxy/filters/token_router.md
+++ b/docs/src/services/proxy/filters/token_router.md
@@ -20,20 +20,18 @@ filters:
     config:
         metadataKey: myapp.com/myownkey
 clusters:
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:26000
-          metadata:
-            quilkin.dev:
-              tokens:
-                - MXg3aWp5Ng== # Authentication is provided by these ids, and matched against
-                - OGdqM3YyaQ== # the value stored in Filter dynamic metadata
-        - address: 127.0.0.1:26001
-          metadata:
-            quilkin.dev:
-              tokens:
-                - bmt1eTcweA==
+  - endpoints:
+    - address: 127.0.0.1:26000
+      metadata:
+        quilkin.dev:
+          tokens:
+            - MXg3aWp5Ng== # Authentication is provided by these ids, and matched against
+            - OGdqM3YyaQ== # the value stored in Filter dynamic metadata
+    - address: 127.0.0.1:26001
+      metadata:
+        quilkin.dev:
+          tokens:
+            - bmt1eTcweA==
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);
@@ -84,20 +82,18 @@ filters:
           remove: true
   - name: quilkin.filters.token_router.v1alpha1.TokenRouter
 clusters:
-  default:
-    localities:
-      - endpoints:
-        - address: 127.0.0.1:26000
-          metadata:
-            quilkin.dev:
-              tokens:
-                - MXg3aWp5Ng== # Authentication is provided by these ids, and matched against
-                - OGdqM3YyaQ== # the value stored in Filter dynamic metadata
-        - address: 127.0.0.1:26001
-          metadata:
-            quilkin.dev:
-              tokens:
-                - bmt1eTcweA==
+  - endpoints:
+    - address: 127.0.0.1:26000
+      metadata:
+        quilkin.dev:
+          tokens:
+            - MXg3aWp5Ng== # Authentication is provided by these ids, and matched against
+            - OGdqM3YyaQ== # the value stored in Filter dynamic metadata
+    - address: 127.0.0.1:26001
+      metadata:
+        quilkin.dev:
+          tokens:
+             - bmt1eTcweA==
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 2);

--- a/docs/src/services/proxy/filters/writing_custom_filters.md
+++ b/docs/src/services/proxy/filters/writing_custom_filters.md
@@ -105,10 +105,8 @@ version: v1alpha1
 filters:
   - name: greet.v1
 clusters:
-  default:
-    localities:
-        - endpoints:
-            - address: 127.0.0.1:4321
+  - endpoints:
+      - address: 127.0.0.1:4321
 ```
 
 Next we to setup our network of services, for this example we're going to use

--- a/docs/src/services/relay.md
+++ b/docs/src/services/relay.md
@@ -37,10 +37,8 @@ example works with any configuration provider.
 # quilkin.yaml
 version: v1alpha1
 clusters:
-  default:
-    localities:
-      - endpoints:
-          - address: 127.0.0.1:8888
+  - endpoints:
+    - address: 127.0.0.1:8888
 ```
 
 To start the relay, run the `relay` command:
@@ -91,10 +89,8 @@ set of data that the proxies can query using xDS discovery requests.
 # quilkin2.yaml
 version: v1alpha1
 clusters:
-  default:
-    localities:
-      - endpoints:
-          - address: 127.0.0.1:9999
+  - endpoints:
+    - address: 127.0.0.1:9999
 ```
 
 ```

--- a/docs/src/services/xds/providers/filesystem.md
+++ b/docs/src/services/xds/providers/filesystem.md
@@ -25,14 +25,12 @@ filters:
     config:
       id: hello
 clusters:
-  cluster-a:
-    localities:
-      - endpoints:
-          - address: 123.0.0.1:29
-            metadata:
-              'quilkin.dev':
-                tokens:
-                  - 'MXg3aWp5Ng=='
+  - endpoints:
+     - address: 123.0.0.1:29
+       metadata:
+         'quilkin.dev':
+           tokens:
+             - 'MXg3aWp5Ng=='
 # ";
 # let config = quilkin::config::Config::from_reader(yaml.as_bytes()).unwrap();
 # assert_eq!(config.filters.load().len(), 1);

--- a/examples/agones-xonotic-sidecar/client-compress.yaml
+++ b/examples/agones-xonotic-sidecar/client-compress.yaml
@@ -22,7 +22,5 @@ filters:
       on_write: DECOMPRESS
       mode: SNAPPY
 clusters:
-  default:
-    localities:
-      - endpoints:
-          - address: ${GAMESERVER_IP}:${GAMESERVER_PORT}
+  - endpoints:
+    - address: ${GAMESERVER_IP}:${GAMESERVER_PORT}

--- a/examples/agones-xonotic-sidecar/sidecar-compress.yaml
+++ b/examples/agones-xonotic-sidecar/sidecar-compress.yaml
@@ -28,10 +28,8 @@ data:
           on_write: COMPRESS
           mode: SNAPPY
     clusters:
-      default:
-        localities:
-          - endpoints:
-              - address: 127.0.0.1:26000
+      - endpoints:
+        - address: 127.0.0.1:26000
 ---
 apiVersion: "agones.dev/v1"
 kind: Fleet

--- a/examples/agones-xonotic-xds/client-token.yaml
+++ b/examples/agones-xonotic-xds/client-token.yaml
@@ -22,7 +22,5 @@ filters:
       on_write: DO_NOTHING
       bytes: NDU2 # 456
 clusters:
-  default:
-    localities:
-      - endpoints:
-          - address: ${LOADBALANCER_IP}:7777
+  - endpoints:
+    - address: ${LOADBALANCER_IP}:7777

--- a/examples/iperf3/proxy.yaml
+++ b/examples/iperf3/proxy.yaml
@@ -21,7 +21,5 @@
 version: v1alpha1
 id: iperf3
 clusters:
-  default:
-    localities:
-      - endpoints:
-          - address: 127.0.0.1:8001
+  - endpoints:
+    - address: 127.0.0.1:8001

--- a/examples/proxy.yaml
+++ b/examples/proxy.yaml
@@ -21,17 +21,15 @@
 version: v1alpha1
 id: my-proxy # An identifier for the proxy instance.
 clusters: # grouping of clusters
-  default:
-    localities: # grouping of endpoints within a cluster
-      - endpoints: # array of potential endpoints to send on traffic to
-          - address: 127.0.0.1:26000
-            metadata: # Metadata associated with the endpoint
-              quilkin.dev:
-                tokens:
-                  - MXg3aWp5Ng== # the connection byte array to route to, encoded as base64 (string value: 1x7ijy6)
-                  - OGdqM3YyaQ== # (string value: 8gj3v2i)
-          - address: 127.0.0.1:26001
-            metadata: # Metadata associated with the endpoint
-              quilkin.dev:
-                tokens:
-                  - bmt1eTcweA== # (string value: nkuy70x)
+  - endpoints: # array of potential endpoints to send on traffic to
+    - address: 127.0.0.1:26000
+      metadata: # Metadata associated with the endpoint
+        quilkin.dev:
+          tokens:
+            - MXg3aWp5Ng== # the connection byte array to route to, encoded as base64 (string value: 1x7ijy6)
+            - OGdqM3YyaQ== # (string value: 8gj3v2i)
+    - address: 127.0.0.1:26001
+      metadata: # Metadata associated with the endpoint
+        quilkin.dev:
+          tokens:
+            - bmt1eTcweA== # (string value: nkuy70x)

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -105,9 +105,12 @@ async fn main() -> quilkin::Result<()> {
         .try_into()?,
     ));
     config.clusters.modify(|map| {
-        map.insert_default(vec![quilkin::endpoint::Endpoint::new(
-            (std::net::Ipv4Addr::LOCALHOST, 4321).into(),
-        )])
+        map.insert_default(
+            [quilkin::endpoint::Endpoint::new(
+                (std::net::Ipv4Addr::LOCALHOST, 4321).into(),
+            )]
+            .into(),
+        )
     });
 
     proxy.run(config.into(), shutdown_rx).await

--- a/proto/quilkin/config/v1alpha1/config.proto
+++ b/proto/quilkin/config/v1alpha1/config.proto
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+
+package quilkin.config.v1alpha1;
+
+message ClusterMap {
+    repeated Cluster clusters = 1;
+}
+
+message Cluster {
+    Locality locality = 1;
+    repeated Endpoint endpoints = 2;
+}
+
+message Locality {
+    string region = 1;
+    string zone = 2;
+    string sub_zone = 3;
+}
+
+message Endpoint {
+    string host = 1;
+    uint32 port = 2;
+    google.protobuf.Struct metadata = 3;
+}

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -149,12 +149,10 @@ mod tests {
         let response = super::check_proxy_readiness(&config);
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
-        let cluster = crate::cluster::Cluster::new_default(vec![vec![Endpoint::new(
-            (std::net::Ipv4Addr::LOCALHOST, 25999).into(),
-        )]
-        .into()]);
-
-        config.clusters.write().insert(cluster);
+        config
+            .clusters
+            .write()
+            .insert_default([Endpoint::new((std::net::Ipv4Addr::LOCALHOST, 25999).into())].into());
 
         let response = super::check_proxy_readiness(&config);
         assert_eq!(response.status(), StatusCode::OK);

--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -61,7 +61,7 @@ impl Manage {
         if let Some(locality) = &locality {
             config
                 .clusters
-                .modify(|map| map.update_unlocated_endpoints(locality));
+                .modify(|map| map.update_unlocated_endpoints(locality.clone()));
         }
 
         let provider_task = self.provider.spawn(config.clone(), locality.clone());

--- a/src/config/providers/k8s/agones.rs
+++ b/src/config/providers/k8s/agones.rs
@@ -299,18 +299,6 @@ impl TryFrom<GameServer> for Endpoint {
     }
 }
 
-impl TryFrom<Vec<GameServer>> for crate::endpoint::LocalityEndpoints {
-    type Error = tonic::Status;
-
-    fn try_from(servers: Vec<GameServer>) -> Result<Self, Self::Error> {
-        Ok(servers
-            .into_iter()
-            .map(Endpoint::try_from)
-            .collect::<Result<std::collections::BTreeSet<_>, _>>()?
-            .into())
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct Health {
     /// Whether health checking is disabled or not

--- a/src/config/watch/fs.rs
+++ b/src/config/watch/fs.rs
@@ -87,14 +87,15 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         source.clusters.modify(|clusters| {
-            clusters
-                .default_cluster_mut()
-                .insert(crate::endpoint::Endpoint::with_metadata(
+            clusters.insert_default(
+                [crate::endpoint::Endpoint::with_metadata(
                     (std::net::Ipv4Addr::LOCALHOST, 4321).into(),
                     crate::endpoint::Metadata {
                         tokens: <_>::from([Vec::from(*b"1x7ijy6")]),
                     },
-                ));
+                )]
+                .into(),
+            );
         });
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/src/endpoint/address.rs
+++ b/src/endpoint/address.rs
@@ -206,6 +206,12 @@ impl From<(String, u16)> for EndpointAddress {
     }
 }
 
+impl From<(AddressKind, u16)> for EndpointAddress {
+    fn from((host, port): (AddressKind, u16)) -> Self {
+        Self { host, port }
+    }
+}
+
 impl From<EndpointAddress> for EnvoySocketAddress {
     fn from(address: EndpointAddress) -> Self {
         use crate::xds::config::core::v3::socket_address::{PortSpecifier, Protocol};

--- a/src/endpoint/locality.rs
+++ b/src/endpoint/locality.rs
@@ -14,14 +14,9 @@
  *  limitations under the License.
  */
 
-use std::collections::BTreeSet;
-
 use serde::{Deserialize, Serialize};
 
-use super::Endpoint;
-use crate::xds::config::endpoint::v3::LocalityLbEndpoints;
-
-/// The location of an [`Endpoint`].
+/// The location of an [`Endpoint`][super::Endpoint].
 #[derive(
     Clone,
     Default,
@@ -94,80 +89,40 @@ impl Locality {
     }
 }
 
-/// A set of endpoints optionally grouped by a [`Locality`].
-#[derive(
-    Clone,
-    Default,
-    Debug,
-    Eq,
-    PartialEq,
-    PartialOrd,
-    Ord,
-    Deserialize,
-    Serialize,
-    schemars::JsonSchema,
-)]
-pub struct LocalityEndpoints {
-    pub locality: Option<Locality>,
-    pub endpoints: BTreeSet<Endpoint>,
-}
-
-impl LocalityEndpoints {
-    /// Creates a new set of endpoints with no [`Locality`].
-    pub fn new(endpoints: BTreeSet<Endpoint>) -> Self {
-        Self::from(endpoints)
-    }
-
-    /// Adds a [`Locality`] to the set of endpoints.
-    pub fn with_locality(mut self, locality: impl Into<Option<Locality>>) -> Self {
-        self.locality = locality.into();
-        self
-    }
-
-    /// Removes an endpoint.
-    pub fn remove(&mut self, endpoint: &Endpoint) {
-        self.endpoints.remove(endpoint);
+impl std::fmt::Display for Locality {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.colon_separated_string().fmt(f)
     }
 }
 
-impl From<Endpoint> for LocalityEndpoints {
-    fn from(endpoint: Endpoint) -> Self {
-        Self {
-            endpoints: [endpoint].into_iter().collect(),
-            ..Self::default()
-        }
+impl std::str::FromStr for Locality {
+    type Err = eyre::Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let vec: Vec<_> = input.split(':').collect();
+
+        Ok(match vec.len() {
+            1 => Self {
+                region: vec[0].into(),
+                ..<_>::default()
+            },
+            2 => Self {
+                region: vec[0].into(),
+                zone: vec[1].into(),
+                ..<_>::default()
+            },
+            3 => Self {
+                region: vec[0].into(),
+                zone: vec[1].into(),
+                sub_zone: vec[2].into(),
+            },
+            _ => return Err(eyre::eyre!("invalid locality identifier")),
+        })
     }
 }
 
-impl From<Vec<Endpoint>> for LocalityEndpoints {
-    fn from(endpoints: Vec<Endpoint>) -> Self {
-        Self {
-            endpoints: endpoints.into_iter().collect(),
-            ..Self::default()
-        }
-    }
-}
-
-impl From<Vec<std::net::SocketAddr>> for LocalityEndpoints {
-    fn from(endpoints: Vec<std::net::SocketAddr>) -> Self {
-        Self {
-            endpoints: endpoints.into_iter().map(From::from).collect(),
-            ..Self::default()
-        }
-    }
-}
-
-impl From<BTreeSet<Endpoint>> for LocalityEndpoints {
-    fn from(endpoints: BTreeSet<Endpoint>) -> Self {
-        Self {
-            endpoints,
-            ..Self::default()
-        }
-    }
-}
-
-impl From<crate::xds::config::core::v3::Locality> for Locality {
-    fn from(value: crate::xds::config::core::v3::Locality) -> Self {
+impl From<crate::cluster::proto::Locality> for Locality {
+    fn from(value: crate::cluster::proto::Locality) -> Self {
         Self {
             region: value.region,
             zone: value.zone,
@@ -176,212 +131,12 @@ impl From<crate::xds::config::core::v3::Locality> for Locality {
     }
 }
 
-impl From<Locality> for crate::xds::config::core::v3::Locality {
+impl From<Locality> for crate::cluster::proto::Locality {
     fn from(value: Locality) -> Self {
         Self {
             region: value.region,
             zone: value.zone,
             sub_zone: value.sub_zone,
         }
-    }
-}
-
-impl TryFrom<LocalityLbEndpoints> for LocalityEndpoints {
-    type Error = <Endpoint as TryFrom<crate::xds::config::endpoint::v3::LbEndpoint>>::Error;
-    fn try_from(value: LocalityLbEndpoints) -> Result<Self, Self::Error> {
-        Ok(Self {
-            endpoints: value
-                .lb_endpoints
-                .into_iter()
-                .map(TryFrom::try_from)
-                .collect::<Result<_, Self::Error>>()?,
-            locality: value.locality.map(From::from),
-        })
-    }
-}
-
-impl From<(Vec<Endpoint>, Option<Locality>)> for LocalityEndpoints {
-    fn from((endpoints, locality): (Vec<Endpoint>, Option<Locality>)) -> Self {
-        Self::from(endpoints).with_locality(locality)
-    }
-}
-
-impl From<(Endpoint, Locality)> for LocalityEndpoints {
-    fn from((endpoint, locality): (Endpoint, Locality)) -> Self {
-        Self::from(endpoint).with_locality(locality)
-    }
-}
-
-impl From<(Endpoint, Option<Locality>)> for LocalityEndpoints {
-    fn from((endpoint, locality): (Endpoint, Option<Locality>)) -> Self {
-        Self::from(endpoint).with_locality(locality)
-    }
-}
-
-impl From<LocalityEndpoints> for LocalityLbEndpoints {
-    fn from(value: LocalityEndpoints) -> Self {
-        Self {
-            lb_endpoints: value.endpoints.into_iter().map(From::from).collect(),
-            locality: value.locality.map(From::from),
-            ..Self::default()
-        }
-    }
-}
-
-/// Set around [`LocalityEndpoints`] to ensure that all unique localities are
-/// different entries. Any duplicate localities provided are merged.
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
-pub struct LocalitySet(std::collections::HashMap<Option<Locality>, LocalityEndpoints>);
-
-impl LocalitySet {
-    /// Creates a new set from the provided localities.
-    pub fn new(set: Vec<LocalityEndpoints>) -> Self {
-        Self::from_iter(set)
-    }
-
-    /// Inserts a new locality of endpoints.
-    pub fn insert(&mut self, mut locality: LocalityEndpoints) {
-        let entry = self.0.entry(locality.locality.clone()).or_default();
-        entry.locality = locality.locality;
-        entry.endpoints.append(&mut locality.endpoints);
-    }
-
-    /// Returns a reference to endpoints associated with the specified locality.
-    pub fn get(&self, key: &Option<Locality>) -> Option<&LocalityEndpoints> {
-        self.0.get(key)
-    }
-
-    /// Returns a mutable reference to endpoints associated with the specified locality.
-    pub fn get_mut(&mut self, key: &Option<Locality>) -> Option<&mut LocalityEndpoints> {
-        self.0.get_mut(key)
-    }
-
-    /// Removes the specified locality or all endpoints with no locality.
-    pub fn remove(&mut self, key: &Option<Locality>) -> Option<LocalityEndpoints> {
-        self.0.remove(key)
-    }
-
-    /// Removes all localities.
-    pub fn clear(&mut self) {
-        self.0.clear();
-    }
-
-    /// Returns an iterator over the set of localities.
-    pub fn iter(&self) -> impl Iterator<Item = &LocalityEndpoints> + '_ {
-        self.0.values()
-    }
-
-    /// Returns a mutable iterator over the set of localities.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut LocalityEndpoints> + '_ {
-        self.0.values_mut()
-    }
-
-    pub fn merge(&mut self, cluster: &Self) {
-        for (key, value) in &cluster.0 {
-            if tracing::enabled!(tracing::Level::INFO) {
-                let span = tracing::info_span!(
-                    "applied_locality",
-                    locality = &*key
-                        .as_ref()
-                        .map(|locality| locality.colon_separated_string())
-                        .unwrap_or_else(|| String::from("<none>"))
-                );
-
-                let _entered = span.enter();
-                if value.endpoints.is_empty() {
-                    tracing::info!("removing all endpoints");
-                } else if let Some(original_endpoints) = self.0.get(key) {
-                    for endpoint in &original_endpoints.endpoints {
-                        if !value.endpoints.contains(endpoint) {
-                            tracing::info!(%endpoint.address, ?endpoint.metadata.known.tokens, "removing endpoint");
-                        }
-                    }
-                }
-
-                for endpoint in &value.endpoints {
-                    tracing::info!(%endpoint.address, ?endpoint.metadata.known.tokens, "applying endpoint");
-                }
-            }
-
-            let entry = self.0.entry(key.clone()).or_default();
-            *entry = value.clone();
-        }
-    }
-}
-
-impl Serialize for LocalitySet {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        self.0.values().collect::<Vec<_>>().serialize(serializer)
-    }
-}
-
-impl<'de> Deserialize<'de> for LocalitySet {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        <Vec<LocalityEndpoints>>::deserialize(deserializer).map(Self::new)
-    }
-}
-
-impl schemars::JsonSchema for LocalitySet {
-    fn schema_name() -> String {
-        <Vec<LocalityEndpoints>>::schema_name()
-    }
-    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-        <Vec<LocalityEndpoints>>::json_schema(gen)
-    }
-
-    fn is_referenceable() -> bool {
-        <Vec<LocalityEndpoints>>::is_referenceable()
-    }
-}
-
-impl std::ops::Index<&Option<Locality>> for LocalitySet {
-    type Output = LocalityEndpoints;
-
-    fn index(&self, index: &Option<Locality>) -> &Self::Output {
-        self.get(index).unwrap()
-    }
-}
-
-impl std::ops::IndexMut<&Option<Locality>> for LocalitySet {
-    fn index_mut(&mut self, index: &Option<Locality>) -> &mut Self::Output {
-        self.get_mut(index).unwrap()
-    }
-}
-
-impl<T> From<T> for LocalitySet
-where
-    T: Into<Vec<LocalityEndpoints>>,
-{
-    fn from(value: T) -> Self {
-        Self::new(value.into())
-    }
-}
-
-impl FromIterator<LocalityEndpoints> for LocalitySet {
-    fn from_iter<I: IntoIterator<Item = LocalityEndpoints>>(iter: I) -> Self {
-        let mut map = Self(<_>::default());
-
-        for locality in iter {
-            map.insert(locality);
-        }
-
-        map
-    }
-}
-
-impl IntoIterator for LocalitySet {
-    type Item = LocalityEndpoints;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        // Have to convert to vec to avoid `Values`'s lifetime parameter.
-        // Remove once GAT's are stable.
-        self.0.into_values().collect::<Vec<_>>().into_iter()
     }
 }

--- a/src/prost.rs
+++ b/src/prost.rs
@@ -55,12 +55,9 @@ pub fn value_from_kind(kind: Kind) -> Value {
     }
 }
 
-pub fn struct_from_json(value: Value) -> Option<prost_types::Struct> {
-    match from_json(value) {
-        prost_types::Value {
-            kind: Some(Kind::StructValue(r#struct)),
-        } => Some(r#struct),
-        _ => None,
+pub fn value_from_struct(value: prost_types::Struct) -> prost_types::Value {
+    prost_types::Value {
+        kind: Some(prost_types::value::Kind::StructValue(value)),
     }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -22,9 +22,8 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tracing_subscriber::EnvFilter;
 
 use crate::{
-    cluster::Cluster,
     config::Config,
-    endpoint::{Endpoint, EndpointAddress, LocalityEndpoints},
+    endpoint::{Endpoint, EndpointAddress},
     filters::{prelude::*, FilterRegistry},
     metadata::Value,
     utils::net::DualStackLocalSocket,
@@ -344,19 +343,14 @@ pub async fn create_socket() -> DualStackLocalSocket {
 pub fn config_with_dummy_endpoint() -> Config {
     let config = Config::default();
 
-    config.clusters.write().insert(Cluster {
-        name: "default".into(),
-        localities: vec![LocalityEndpoints {
-            locality: None,
-            endpoints: [Endpoint {
-                address: (std::net::Ipv4Addr::LOCALHOST, 8080).into(),
-                ..<_>::default()
-            }]
-            .into(),
+    config.clusters.write().insert(
+        None,
+        [Endpoint {
+            address: (std::net::Ipv4Addr::LOCALHOST, 8080).into(),
+            ..<_>::default()
         }]
-        .into_iter()
-        .collect(),
-    });
+        .into(),
+    );
 
     config
 }

--- a/src/xds/server.rs
+++ b/src/xds/server.rs
@@ -118,7 +118,6 @@ impl ControlPlane {
                     if let Err(error) = watcher.changed().await {
                         tracing::error!(%error, "error watching changes");
                     }
-                    this.push_update(ResourceType::Endpoint);
                     this.push_update(ResourceType::Cluster);
                 }
             }
@@ -397,7 +396,7 @@ mod tests {
 
     #[tokio::test]
     async fn valid_response() {
-        const RESOURCE: ResourceType = ResourceType::Endpoint;
+        const RESOURCE: ResourceType = ResourceType::Cluster;
         const LISTENER_TYPE: ResourceType = ResourceType::Listener;
 
         let mut response = DiscoveryResponse {

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -62,15 +62,18 @@ async fn token_router() {
     );
 
     server_config.clusters.modify(|clusters| {
-        clusters.insert_default(vec![Endpoint::with_metadata(
-            echo.clone(),
-            serde_json::from_value::<MetadataView<_>>(serde_json::json!({
-                "quilkin.dev": {
-                    "tokens": ["YWJj"]
-                }
-            }))
-            .unwrap(),
-        )])
+        clusters.insert_default(
+            [Endpoint::with_metadata(
+                echo.clone(),
+                serde_json::from_value::<MetadataView<_>>(serde_json::json!({
+                    "quilkin.dev": {
+                        "tokens": ["YWJj"]
+                    }
+                }))
+                .unwrap(),
+            )]
+            .into(),
+        )
     });
 
     t.run_server(server_config, server_proxy, None);

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -37,7 +37,7 @@ on_write: COMPRESS
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {
             name: Compress::factory().name().into(),
@@ -63,7 +63,7 @@ on_write: DECOMPRESS
     let client_config = std::sync::Arc::new(quilkin::Config::default());
     client_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(server_addr.into())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(server_addr.into())].into()));
     client_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {
             name: Compress::factory().name().into(),

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -42,7 +42,7 @@ bytes: YWJj #abc
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {
             name: ConcatenateBytes::factory().name().into(),

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -61,7 +61,7 @@ on_write: DECOMPRESS
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![
             Filter {

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -54,7 +54,7 @@ async fn test_filter() {
 
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
 
     t.run_server(server_config, server_proxy, None);
 
@@ -66,9 +66,12 @@ async fn test_filter() {
     };
     let client_config = std::sync::Arc::new(quilkin::Config::default());
     client_config.clusters.modify(|clusters| {
-        clusters.insert_default(vec![Endpoint::new(
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port).into(),
-        )])
+        clusters.insert_default(
+            [Endpoint::new(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port).into(),
+            )]
+            .into(),
+        )
     });
     client_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {
@@ -131,7 +134,7 @@ async fn debug_filter() {
     };
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {
             name: factory.name().into(),
@@ -152,9 +155,12 @@ async fn debug_filter() {
     };
     let client_config = std::sync::Arc::new(quilkin::Config::default());
     client_config.clusters.modify(|clusters| {
-        clusters.insert_default(vec![Endpoint::new(
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port).into(),
-        )])
+        clusters.insert_default(
+            [Endpoint::new(
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port).into(),
+            )]
+            .into(),
+        )
     });
     client_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -230,7 +230,7 @@ async fn test(
 
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
 
     t.run_server(server_config, server_proxy, None);
 

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -33,7 +33,7 @@ async fn health_server() {
     };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.clusters.modify(|clusters| {
-        clusters.insert_default(vec!["127.0.0.1:0".parse::<Endpoint>().unwrap()])
+        clusters.insert_default(["127.0.0.1:0".parse::<Endpoint>().unwrap()].into())
     });
     t.run_server(
         server_config,

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -49,13 +49,7 @@ policy: ROUND_ROBIN
     let server_port = 12346;
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.clusters.modify(|clusters| {
-        clusters.insert_default(
-            echo_addresses
-                .iter()
-                .cloned()
-                .map(Endpoint::new)
-                .collect::<Vec<_>>(),
-        )
+        clusters.insert_default(echo_addresses.iter().cloned().map(Endpoint::new).collect())
     });
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -43,7 +43,7 @@ period: 1
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {
             name: LocalRateLimit::factory().name().into(),

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -65,7 +65,7 @@ on_read:
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![
             Filter {

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -40,7 +40,7 @@ async fn metrics_server() {
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(echo.clone())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
     t.run_server(
         server_config,
         server_proxy,
@@ -56,7 +56,7 @@ async fn metrics_server() {
     let client_config = std::sync::Arc::new(quilkin::Config::default());
     client_config
         .clusters
-        .modify(|clusters| clusters.insert_default(vec![Endpoint::new(server_addr.into())]));
+        .modify(|clusters| clusters.insert_default([Endpoint::new(server_addr.into())].into()));
     t.run_server(client_config, client_proxy, None);
 
     // let's send the packet

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -38,10 +38,13 @@ async fn echo() {
     };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.clusters.modify(|clusters| {
-        clusters.insert_default(vec![
-            Endpoint::new(server1.clone()),
-            Endpoint::new(server2.clone()),
-        ])
+        clusters.insert_default(
+            [
+                Endpoint::new(server1.clone()),
+                Endpoint::new(server2.clone()),
+            ]
+            .into(),
+        )
     });
 
     t.run_server(server_config, server_proxy, None);

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -51,10 +51,13 @@ quilkin.dev:
     };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.clusters.modify(|clusters| {
-        clusters.insert_default(vec![Endpoint::with_metadata(
-            echo.clone(),
-            serde_yaml::from_str::<MetadataView<_>>(endpoint_metadata).unwrap(),
-        )])
+        clusters.insert_default(
+            [Endpoint::with_metadata(
+                echo.clone(),
+                serde_yaml::from_str::<MetadataView<_>>(endpoint_metadata).unwrap(),
+            )]
+            .into(),
+        )
     });
 
     server_config.filters.store(


### PR DESCRIPTION
This PR refactors our internal storage of transmission of clusters over xDS to be more focused on endpoints rather than mimicking Envoys layout. We weren't using basically any of it, and having all of those extra fields was creating a lot of extra bytes and made the encoding logic more complicated.

This PR moves to using a simpler map of locality -> endpoints, as that was the only part we were using, and uses our own proto types for xDS discovery. We still use the core discovery request and response wrapper, it's just the types inside are now Quilkin types rather than envoy types.

We don't have a xDS benchmark, but I wrote a small micro benchmark of just the time and size of discovery responses, and there's a significant improvement to using this implementation, being roughly 30%-250% faster depending on the endpoint amounts (being faster for smaller amounts of endpoints where the message size overhead is more noticeable), and being 12% smaller.

### Old
endpoints | time (seconds) | size (bytes)
-|-|-
0 | 0.001 | 53
100 | 0.005 | 5537
1000 | 0.028 | 55013
10000 | 0.117 | 550013
65535 | 0.721 | 3653593

### New
endpoints | time (seconds) | size (bytes)
-|-|-
0 | 0.001 | 53
100 | 0.002 | 4910
1000 | 0.011 | 48984
10000 | 0.085 | 489984
65535 | 0.539 | 3260352



### Diff
endpoints | time (faster) | size (smaller)
-|-|-
100 | 2.5x | 12%
1000 | 2.5x | 12%
10000 | 37% | 12%
65535 | 33% | 12%

```rust
#[test]
fn protobuf_test() {
    let measure = |count: u16| {
        let config = Config::default();
        if count != 0 {
            config.clusters.write().insert_default(crate::endpoint::LocalityEndpoints::from((0..count).map(|i| Endpoint::from((std::net::Ipv4Addr::UNSPECIFIED, i))).collect::<Vec<_>>()));
        }
        let response_creation = std::time::Instant::now();
        let response = config.discovery_request("", ResourceType::Cluster, &[]).unwrap();
        let time = response_creation.elapsed().as_secs_f64();
        let size = crate::prost::encode(&response).unwrap().len();
        println!("count: {count}, time: {time}, size: {size}");
    };

    (measure)(0);
    (measure)(100);
    (measure)(1000);
    (measure)(10000);
    (measure)(u16::MAX);
    panic!();
}
```
