### PR TITLE
Locally listen on IPv4 and IPv6 addresses

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -5,6 +5,7 @@ use std::time;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use once_cell::sync::Lazy;
+use quilkin::test_utils::AddressType;
 
 const MESSAGE_SIZE: usize = 0xffff;
 const DEFAULT_MESSAGE: [u8; 0xffff] = [0xff; 0xffff];
@@ -35,7 +36,7 @@ fn run_quilkin(port: u16, endpoint: SocketAddr) {
         let proxy = quilkin::cli::Proxy {
             port,
             qcmp_port: runtime
-                .block_on(quilkin::test_utils::available_addr())
+                .block_on(quilkin::test_utils::available_addr(&AddressType::Random))
                 .port(),
             ..<_>::default()
         };

--- a/build/Makefile
+++ b/build/Makefile
@@ -85,7 +85,9 @@ test-quilkin: ensure-build-image
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) clippy --tests -- -D warnings
 	docker run --rm $(common_rust_args) \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
-	docker run --rm $(common_rust_args) \
+	# --network=host because docker containers are not great at ipv6.
+	docker run --rm $(common_rust_args)  \
+			--network=host \
 			-e RUST_BACKTRACE=1 --entrypoint=cargo $(BUILD_IMAGE_TAG) test -- --nocapture
 
 # Run tests against the examples
@@ -241,8 +243,10 @@ docs:
 # Start an interactive shell inside the build image
 # Useful for testing, or adhoc cargo, gcloud, kubectl or terraform commands
 shell: ensure-gcloud-dirs ensure-kube-dirs ensure-build-image
+	# we --network=host because docker containers are not great at ipv6.
 	docker run --rm -it $(DOCKER_RUN_ARGS) $(common_rust_args) \
 		$(gcloud_mount_args) $(kube_mount_args) \
+		 --network=host \
 		 --entrypoint=bash $(BUILD_IMAGE_TAG)
 
 ensure-build-image: ensure-cargo-registry

--- a/docs/src/deployment/admin.md
+++ b/docs/src/deployment/admin.md
@@ -1,8 +1,8 @@
 # Administration
 
-| services | ports | Protocol |
-|----------|-------|-----------|
-| Administration | 8000 | HTTP (IPv4 OR IPv6) |
+| services       | ports | Protocol            |
+|----------------|-------|---------------------|
+| Administration | 8000  | HTTP (IPv4 OR IPv6) |
 
 ## Logging
 By default, Quilkin will log `INFO` level events, you can change this by setting

--- a/docs/src/services/agent.md
+++ b/docs/src/services/agent.md
@@ -2,7 +2,7 @@
 
 | services | ports | Protocol |
 |----------|-------|-----------|
-| QCMP | 7600 | UDP(IPv4 && IPv6) |
+| QCMP | 7600 | UDP(IPv4 OR IPv6) |
 
 > **Note:** This service is currently in active experimentation and development
   so there may be bugs which cause it to be unusable  for production, as always

--- a/docs/src/services/proxy.md
+++ b/docs/src/services/proxy.md
@@ -2,8 +2,8 @@
 
 | Services | Ports | Protocol           |
 |----------|-------|--------------------|
-| Proxy    | 7777  | UDP (IPv4)         |
-| QCMP     | 7600  | UDP (IPv4 && IPv6) |
+| Proxy    | 7777  | UDP (IPv4 OR IPv6) |
+| QCMP     | 7600  | UDP (IPv4 OR IPv6) |
 
 "Proxy" is the primary Quilkin service, which acts as a non-transparent UDP
 proxy.

--- a/docs/src/services/proxy/filters/firewall.md
+++ b/docs/src/services/proxy/filters/firewall.md
@@ -17,15 +17,17 @@ filters:
     config:
       on_read:
         - action: ALLOW
-          source: 192.168.51.0/24
+          sources:
+            - 192.168.51.0/24
           ports:
-             - 10
-             - 1000-7000
+            - 10
+            - 1000-7000
       on_write:
         - action: DENY
-          source: 192.168.51.0/24
+          sources:
+            - 192.168.51.0/24
           ports:
-             - 7000
+            - 7000
 clusters:
   default:
     localities:

--- a/docs/src/services/proxy/qcmp.md
+++ b/docs/src/services/proxy/qcmp.md
@@ -2,7 +2,7 @@
 
 | services | ports | Protocol |
 |----------|-------|-----------|
-| QCMP | 7600 | UDP (IPv4 && IPv6) |
+| QCMP | 7600 | UDP (IPv4 OR IPv6) |
 
 In addition to the TCP based administration API, Quilkin provides a meta API
 over UDP. The purpose of this API is to provide meta operations that can be

--- a/docs/src/services/xds.md
+++ b/docs/src/services/xds.md
@@ -1,8 +1,8 @@
 # xDS Control Plane
 
-| services | ports | Protocol   |
-|----------|-------|------------|
-| xDS      | 7800  | gRPC(IPv4) |
+| services | ports | Protocol            |
+|----------|-------|---------------------|
+| xDS      | 7800  | gRPC (IPv4 OR IPv6) |
 
 For multi-cluster integration, Quilkin provides a `manage` service, that can be
 used with a number of configuration discovery providers to provide cluster

--- a/proto/quilkin/filters/firewall/v1alpha1/firewall.proto
+++ b/proto/quilkin/filters/firewall/v1alpha1/firewall.proto
@@ -31,7 +31,7 @@ message Firewall {
 
   message Rule {
     Action action = 1;
-    string source = 2;
+    repeated string sources = 2;
     repeated PortRange ports = 3;
   }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -262,26 +262,21 @@ impl Cli {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::net::Ipv4Addr;
+    use std::net::{Ipv4Addr, SocketAddr};
 
-    use tokio::{
-        net::UdpSocket,
-        time::{timeout, Duration},
-    };
+    use tokio::time::{timeout, Duration};
 
     use crate::{
         config::{Filter, Providers},
         endpoint::{Endpoint, LocalityEndpoints},
         filters::{Capture, StaticFilter, TokenRouter},
+        test_utils::{create_socket, AddressType, TestHelper},
     };
 
     #[tokio::test]
     async fn relay_routing() {
-        let server_port = crate::test_utils::available_addr().await.port();
-        let server_socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, server_port))
-            .await
-            .map(Arc::new)
-            .unwrap();
+        let mut t = TestHelper::default();
+        let (mut rx, server_socket) = t.open_socket_and_recv_multiple_packets().await;
         let filters_file = tempfile::NamedTempFile::new().unwrap();
         let config = Config::default();
 
@@ -320,7 +315,11 @@ mod tests {
                 .write()
                 .default_cluster_mut()
                 .insert(LocalityEndpoints::from(vec![Endpoint::with_metadata(
-                    (std::net::Ipv4Addr::LOCALHOST, server_port).into(),
+                    (
+                        std::net::Ipv4Addr::LOCALHOST,
+                        server_socket.local_ipv4_addr().unwrap().port(),
+                    )
+                        .into(),
                     crate::endpoint::Metadata {
                         tokens: vec!["abc".into()].into_iter().collect(),
                     },
@@ -329,7 +328,9 @@ mod tests {
         })
         .unwrap();
 
-        let relay_admin_port = crate::test_utils::available_addr().await.port();
+        let relay_admin_port = crate::test_utils::available_addr(&AddressType::Random)
+            .await
+            .port();
         let relay = Cli {
             admin_address: Some((Ipv4Addr::LOCALHOST, relay_admin_port).into()),
             config: <_>::default(),
@@ -344,7 +345,9 @@ mod tests {
             log_format: LogFormats::default(),
         };
 
-        let control_plane_admin_port = crate::test_utils::available_addr().await.port();
+        let control_plane_admin_port = crate::test_utils::available_addr(&AddressType::Random)
+            .await
+            .port();
         let control_plane = Cli {
             no_admin: false,
             quiet: true,
@@ -363,7 +366,9 @@ mod tests {
             log_format: LogFormats::default(),
         };
 
-        let proxy_admin_port = crate::test_utils::available_addr().await.port();
+        let proxy_admin_port = crate::test_utils::available_addr(&AddressType::Random)
+            .await
+            .port();
         let proxy = Cli {
             no_admin: false,
             quiet: true,
@@ -381,12 +386,9 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         tokio::spawn(proxy.drive());
         tokio::time::sleep(Duration::from_millis(500)).await;
-        let local_addr = crate::test_utils::available_addr().await;
-        let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, local_addr.port()))
-            .await
-            .map(Arc::new)
-            .unwrap();
+        let socket = create_socket().await;
         let config = Config::default();
+        let proxy_address: SocketAddr = (std::net::Ipv4Addr::LOCALHOST, 7777).into();
 
         for _ in 0..5 {
             let token = random_three_characters();
@@ -398,7 +400,11 @@ mod tests {
                     .write()
                     .default_cluster_mut()
                     .insert(LocalityEndpoints::from(vec![Endpoint::with_metadata(
-                        (std::net::Ipv4Addr::LOCALHOST, server_port).into(),
+                        (
+                            std::net::Ipv4Addr::LOCALHOST,
+                            server_socket.local_ipv4_addr().unwrap().port(),
+                        )
+                            .into(),
                         crate::endpoint::Metadata {
                             tokens: vec![token.clone()].into_iter().collect(),
                         },
@@ -410,22 +416,14 @@ mod tests {
             let mut msg = Vec::from(*b"hello");
             msg.extend_from_slice(&token);
             tracing::info!(?token, "sending packet");
-            socket
-                .send_to(&msg, &(std::net::Ipv4Addr::LOCALHOST, 7777))
-                .await
-                .unwrap();
-
-            let recv = |socket: Arc<UdpSocket>| async move {
-                let mut buf = [0; u16::MAX as usize];
-                let length = socket.recv(&mut buf).await.unwrap();
-                buf[0..length].to_vec()
-            };
+            socket.send_to(&msg, &proxy_address).await.unwrap();
 
             assert_eq!(
-                b"hello",
-                &&*timeout(Duration::from_secs(5), (recv)(server_socket.clone()))
+                "hello",
+                timeout(Duration::from_secs(5), rx.recv())
                     .await
                     .expect("should have received a packet")
+                    .unwrap()
             );
 
             tracing::info!(?token, "received packet");
@@ -433,9 +431,9 @@ mod tests {
             tracing::info!(?token, "sending bad packet");
             // send an invalid packet
             let msg = b"hello\xFF\xFF\xFF";
-            socket.send_to(msg, &local_addr).await.unwrap();
+            socket.send_to(msg, &proxy_address).await.unwrap();
 
-            let result = timeout(Duration::from_secs(3), (recv)(server_socket.clone())).await;
+            let result = timeout(Duration::from_secs(3), rx.recv()).await;
             assert!(result.is_err(), "should not have received a packet");
             tracing::info!(?token, "didn't receive bad packet");
         }

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -16,7 +16,7 @@
 
 //! Types representing where the data is the sent.
 
-mod address;
+pub(crate) mod address;
 mod locality;
 
 use serde::{Deserialize, Serialize};

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -130,7 +130,7 @@ mod tests {
         let firewall = Firewall {
             on_read: vec![Rule {
                 action: Action::Allow,
-                source: "192.168.75.0/24".parse().unwrap(),
+                sources: vec!["192.168.75.0/24".parse().unwrap()],
                 ports: vec![PortRange::new(10, 100).unwrap()],
             }],
             on_write: vec![],
@@ -161,7 +161,7 @@ mod tests {
             on_read: vec![],
             on_write: vec![Rule {
                 action: Action::Allow,
-                source: "192.168.75.0/24".parse().unwrap(),
+                sources: vec!["192.168.75.0/24".parse().unwrap()],
                 ports: vec![PortRange::new(10, 100).unwrap()],
             }],
         };

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -17,10 +17,9 @@
 //! Logic for parsing and generating Quilkin Control Message Protocol (QCMP) messages.
 
 use nom::bytes::complete;
-use std::net::SocketAddr;
 use tracing::Instrument;
 
-use crate::utils::net;
+use crate::utils::net::DualStackLocalSocket;
 
 // Magic number to distinguish control packets from regular traffic.
 const MAGIC_NUMBER: &[u8] = b"QLKN";
@@ -34,29 +33,23 @@ const DISCRIMINANT_LEN: usize = 1;
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub async fn spawn(port: u16) -> crate::Result<()> {
-    let socket = net::DualStackLocalSocket::new(port)?;
+    let socket = DualStackLocalSocket::new(port)?;
     let v4_addr = socket.local_ipv4_addr()?;
-    let v6_addr = socket.local_ip6_addr()?;
+    let v6_addr = socket.local_ipv6_addr()?;
     tokio::spawn(
         async move {
             // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
             // packet, which is the maximum value of 16 a bit integer.
-            let mut v4_buf = vec![0; 1 << 16];
-            let mut v6_buf = vec![0; 1 << 16];
+            let mut buf = vec![0; 1 << 16];
             let mut output_buf = Vec::new();
 
             loop {
                 tracing::info!(%v4_addr, %v6_addr, "awaiting qcmp packets");
 
-                match socket.recv_from(&mut v4_buf, &mut v6_buf).await {
+                match socket.recv_from(&mut buf).await {
                     Ok((size, source)) => {
                         let received_at = chrono::Utc::now().timestamp_nanos();
-                        let contents = match source {
-                            SocketAddr::V4(_) => &v4_buf[..size],
-                            SocketAddr::V6(_) => &v6_buf[..size],
-                        };
-
-                        let command = match Protocol::parse(contents) {
+                        let command = match Protocol::parse(&buf[..size]) {
                             Ok(Some(command)) => command,
                             Ok(None) => {
                                 tracing::debug!("rejected non-qcmp packet");

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -149,21 +149,27 @@ mod tests {
 
     use std::sync::Arc;
 
+    use crate::test_utils::AddressType;
     use crate::{config::Config, endpoint::Endpoint, filters::*};
 
     #[tokio::test]
     async fn token_routing() {
         let mut helper = crate::test_utils::TestHelper::default();
-        let token = uuid::Uuid::new_v4().into_bytes();
+        let token = "mytoken";
         let address = {
-            let mut addr = Endpoint::new(helper.run_echo_server().await);
+            let mut addr = Endpoint::new(helper.run_echo_server(&AddressType::Random).await);
             addr.metadata.known.tokens.insert(token.into());
             addr
         };
         let localities = crate::endpoint::LocalityEndpoints::from(address.clone());
 
-        let xds_port = crate::test_utils::available_addr().await.port();
-        let xds_config: Arc<Config> = serde_json::from_value(serde_json::json!({
+        tracing::debug!(?address);
+        tracing::debug!(?localities);
+
+        let xds_port = crate::test_utils::available_addr(&AddressType::Random)
+            .await
+            .port();
+        let json = serde_json::json!({
             "version": "v1alpha1",
             "id": "test-proxy",
             "clusters": {
@@ -171,11 +177,10 @@ mod tests {
                     "localities": [localities]
                 }
             },
-        }))
-        .map(Arc::new)
-        .unwrap();
+        });
+        let xds_config: Arc<Config> = serde_json::from_value(json).map(Arc::new).unwrap();
 
-        let client_addr = crate::test_utils::available_addr().await;
+        let client_addr = crate::test_utils::available_addr(&AddressType::Random).await;
         let client_config = serde_json::from_value(serde_json::json!({
             "version": "v1alpha1",
             "id": "test-proxy",
@@ -191,7 +196,7 @@ mod tests {
         tokio::spawn(server::spawn(xds_port, xds_config.clone()));
         let client_proxy = crate::cli::Proxy {
             port: client_addr.port(),
-            management_server: vec![format!("http://0.0.0.0:{}", xds_port).parse().unwrap()],
+            management_server: vec![format!("http://[::1]:{}", xds_port).parse().unwrap()],
             ..<_>::default()
         };
 
@@ -258,32 +263,27 @@ mod tests {
             .unwrap(),
         ));
 
-        let client = tokio::net::UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0))
-            .await
-            .unwrap();
-
-        let data = "Hello World!".as_bytes();
+        let fixture = "Hello World!";
+        let data = fixture.as_bytes();
         let mut packet = data.to_vec();
-        packet.extend(token);
-        packet.push(1);
+        packet.extend(token.as_bytes());
+
+        let client = helper.open_socket_and_recv_single_packet().await;
 
         client
+            .socket
             .send_to(
                 &packet,
                 (std::net::Ipv4Addr::UNSPECIFIED, client_addr.port()),
             )
             .await
             .unwrap();
-        let mut buf = vec![0; 12];
-        tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            client.recv_from(&mut buf),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let response = tokio::time::timeout(std::time::Duration::from_secs(1), client.packet_rx)
+            .await
+            .unwrap()
+            .unwrap();
 
-        assert_eq!(data, buf);
+        assert_eq!(format!("{}{}", fixture, token), response);
     }
 
     #[tokio::test]

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -23,7 +23,7 @@ use quilkin::{
     endpoint::Endpoint,
     filters::{Capture, StaticFilter, TokenRouter},
     metadata::MetadataView,
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 /// This test covers both token_router and capture filters,
@@ -31,7 +31,7 @@ use quilkin::{
 #[tokio::test]
 async fn token_router() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
     let server_port = 12348;
     let server_proxy = quilkin::cli::Proxy {
         port: server_port,

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -16,21 +16,20 @@
 
 use tokio::time::{timeout, Duration};
 
-use quilkin::test_utils::available_addr;
 use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Compress, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{available_addr, AddressType, TestHelper},
 };
 
 #[tokio::test]
 async fn client_and_server() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration as
-    let server_addr = available_addr().await;
+    let server_addr = available_addr(&AddressType::Random).await;
     let yaml = "
 on_read: DECOMPRESS
 on_write: COMPRESS
@@ -56,7 +55,7 @@ on_write: COMPRESS
     t.run_server(server_config, server_proxy, None);
 
     // create a local client
-    let client_addr = available_addr().await;
+    let client_addr = available_addr(&AddressType::Random).await;
     let yaml = "
 on_read: COMPRESS
 on_write: DECOMPRESS

--- a/tests/concatenate_bytes.rs
+++ b/tests/concatenate_bytes.rs
@@ -22,7 +22,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{ConcatenateBytes, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -32,7 +32,7 @@ async fn concatenate_bytes() {
 on_read: APPEND
 bytes: YWJj #abc
 ";
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     let server_port = 12346;
     let server_proxy = quilkin::cli::Proxy {

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -22,7 +22,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Compress, ConcatenateBytes, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -45,7 +45,7 @@ on_write: DECOMPRESS
 ";
 
     let echo = t
-        .run_echo_server_with_tap(move |_, bytes, _| {
+        .run_echo_server_with_tap(&AddressType::Random, move |_, bytes, _| {
             assert!(
                 from_utf8(bytes).is_err(),
                 "Should be compressed, and therefore unable to be turned into a string"

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -24,7 +24,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Debug, StaticFilter},
-    test_utils::{load_test_filters, TestHelper},
+    test_utils::{load_test_filters, AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -33,7 +33,7 @@ async fn test_filter() {
     load_test_filters();
 
     // create an echo server as an endpoint.
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration
     let server_port = 12346;
@@ -120,7 +120,7 @@ async fn debug_filter() {
     let factory = Debug::factory();
 
     // create an echo server as an endpoint.
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration
     let server_port = 12247;

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -23,7 +23,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{LoadBalancer, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -39,7 +39,7 @@ policy: ROUND_ROBIN
     for _ in 0..2 {
         let selected_endpoint = selected_endpoint.clone();
         echo_addresses.insert(
-            t.run_echo_server_with_tap(move |_, _, echo_addr| {
+            t.run_echo_server_with_tap(&AddressType::Random, move |_, _, echo_addr| {
                 let _ = selected_endpoint.lock().unwrap().replace(echo_addr);
             })
             .await,

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -22,7 +22,7 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{LocalRateLimit, StaticFilter},
-    test_utils::{available_addr, TestHelper},
+    test_utils::{available_addr, AddressType, TestHelper},
 };
 
 #[tokio::test]
@@ -33,9 +33,9 @@ async fn local_rate_limit_filter() {
 max_packets: 2
 period: 1
 ";
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
-    let server_addr = available_addr().await;
+    let server_addr = available_addr(&AddressType::Random).await;
     let server_proxy = quilkin::cli::Proxy {
         port: server_addr.port(),
         ..<_>::default()

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -22,13 +22,13 @@ use quilkin::{
     config::Filter,
     endpoint::Endpoint,
     filters::{Capture, Match, StaticFilter},
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 #[tokio::test]
 async fn r#match() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     let capture_yaml = "
 suffix:

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -16,18 +16,23 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
-use quilkin::{endpoint::Endpoint, test_utils::TestHelper};
+use quilkin::{
+    endpoint::Endpoint,
+    test_utils::{AddressType, TestHelper},
+};
 
 #[tokio::test]
 async fn metrics_server() {
     let mut t = TestHelper::default();
 
     // create an echo server as an endpoint.
-    let echo = t.run_echo_server().await;
-    let metrics_port = quilkin::test_utils::available_addr().await.port();
+    let echo = t.run_echo_server(&AddressType::Random).await;
+    let metrics_port = quilkin::test_utils::available_addr(&AddressType::Random)
+        .await
+        .port();
 
     // create server configuration
-    let server_addr = quilkin::test_utils::available_addr().await;
+    let server_addr = quilkin::test_utils::available_addr(&AddressType::Random).await;
     let server_proxy = quilkin::cli::Proxy {
         port: server_addr.port(),
         ..<_>::default()

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -17,19 +17,21 @@
 use tokio::time::timeout;
 use tokio::time::Duration;
 
-use quilkin::test_utils::available_addr;
-use quilkin::{endpoint::Endpoint, test_utils::TestHelper};
+use quilkin::{
+    endpoint::Endpoint,
+    test_utils::{available_addr, AddressType, TestHelper},
+};
 
 #[tokio::test]
 async fn echo() {
     let mut t = TestHelper::default();
 
     // create two echo servers as endpoints
-    let server1 = t.run_echo_server().await;
-    let server2 = t.run_echo_server().await;
+    let server1 = t.run_echo_server(&AddressType::Random).await;
+    let server2 = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration
-    let local_addr = available_addr().await;
+    let local_addr = available_addr(&AddressType::Random).await;
     let server_proxy = quilkin::cli::Proxy {
         port: local_addr.port(),
         ..<_>::default()

--- a/tests/qcmp.rs
+++ b/tests/qcmp.rs
@@ -18,12 +18,17 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use tokio::time::Duration;
 
-use quilkin::{protocol::Protocol, test_utils::TestHelper};
+use quilkin::{
+    protocol::Protocol,
+    test_utils::{AddressType, TestHelper},
+};
 
 #[tokio::test]
 async fn proxy_ping() {
     let mut t = TestHelper::default();
-    let server_port = quilkin::test_utils::available_addr().await.port();
+    let server_port = quilkin::test_utils::available_addr(&AddressType::Random)
+        .await
+        .port();
     let server_proxy = quilkin::cli::Proxy {
         qcmp_port: server_port,
         to: vec![(Ipv4Addr::UNSPECIFIED, 0).into()],
@@ -36,7 +41,9 @@ async fn proxy_ping() {
 
 #[tokio::test]
 async fn agent_ping() {
-    let qcmp_port = quilkin::test_utils::available_addr().await.port();
+    let qcmp_port = quilkin::test_utils::available_addr(&AddressType::Random)
+        .await
+        .port();
     let agent = quilkin::cli::Agent {
         qcmp_port,
         ..<_>::default()

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -23,7 +23,7 @@ use quilkin::{
     endpoint::Endpoint,
     filters::{Capture, StaticFilter, TokenRouter},
     metadata::MetadataView,
-    test_utils::TestHelper,
+    test_utils::{AddressType, TestHelper},
 };
 
 /// This test covers both token_router and capture filters,
@@ -31,7 +31,7 @@ use quilkin::{
 #[tokio::test]
 async fn token_router() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server().await;
+    let echo = t.run_echo_server(&AddressType::Random).await;
 
     let capture_yaml = "
 suffix:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

Implemented the `DualStackLocalSocket` as a small newtype for IPv6 sockets that are configured to be able to send and receive ipv6 and ipv4 traffic on all platforms for the locally listening socket.

Updated the code base and docs and fixed several issues that existed for handling IPv6 addresses in the code base, including updates to the Firewall filter to be able to better manage ipv4 + ipv6 combo rule sets.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #666

**Special notes for your reviewer**:

Updated the `test_utils` framework to provide coverage in tests for both ipv4 and ipv6 by allowing for either an IPv4 or IPv6 address to be created from the framework.
