### PR TITLE
Add --idle-request-interval-secs

### DIFF
--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -45,6 +45,10 @@ pub struct Proxy {
     /// One or more socket addresses to forward packets to.
     #[clap(short, long, env = "QUILKIN_DEST")]
     pub to: Vec<SocketAddr>,
+    /// The interval in seconds at which the relay will send a discovery request
+    /// to an management server after receiving no updates.
+    #[clap(long, env = "QUILKIN_IDLE_REQUEST_INTERVAL_SECS", default_value_t = crate::xds::server::IDLE_REQUEST_INTERVAL_SECS)]
+    pub idle_request_interval_secs: u64,
 }
 
 impl Default for Proxy {
@@ -55,6 +59,7 @@ impl Default for Proxy {
             port: PORT,
             qcmp_port: QCMP_PORT,
             to: <_>::default(),
+            idle_request_interval_secs: crate::xds::server::IDLE_REQUEST_INTERVAL_SECS,
         }
     }
 }
@@ -106,7 +111,8 @@ impl Proxy {
             let client =
                 crate::xds::AdsClient::connect(String::clone(&id), self.management_server.clone())
                     .await?;
-            let mut stream = client.xds_client_stream(config.clone());
+            let mut stream =
+                client.xds_client_stream(config.clone(), self.idle_request_interval_secs);
 
             tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
             stream

--- a/src/cli/relay.rs
+++ b/src/cli/relay.rs
@@ -34,6 +34,10 @@ pub struct Relay {
     /// Port for xDS management_server service
     #[clap(short, long, env = super::PORT_ENV_VAR, default_value_t = super::manage::PORT)]
     pub xds_port: u16,
+    /// The interval in seconds at which the relay will send a discovery request
+    /// to an management server after receiving no updates.
+    #[clap(long, env = "QUILKIN_IDLE_REQUEST_INTERVAL_SECS", default_value_t = crate::xds::server::IDLE_REQUEST_INTERVAL_SECS)]
+    pub idle_request_interval_secs: u64,
     #[clap(subcommand)]
     pub providers: Option<Providers>,
 }
@@ -43,6 +47,7 @@ impl Default for Relay {
         Self {
             mds_port: PORT,
             xds_port: super::manage::PORT,
+            idle_request_interval_secs: crate::xds::server::IDLE_REQUEST_INTERVAL_SECS,
             providers: None,
         }
     }
@@ -57,6 +62,7 @@ impl Relay {
         let xds_server = crate::xds::server::spawn(self.xds_port, config.clone());
         let mds_server = tokio::spawn(crate::xds::server::control_plane_discovery_server(
             self.mds_port,
+            self.idle_request_interval_secs,
             config.clone(),
         ));
 

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -302,7 +302,10 @@ mod tests {
         )
         .await
         .unwrap();
-        let mut stream = client.xds_client_stream(config.clone());
+        let mut stream = client.xds_client_stream(
+            config.clone(),
+            crate::xds::server::IDLE_REQUEST_INTERVAL_SECS,
+        );
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         // Each time, we create a new upstream endpoint and send a cluster update for it.


### PR DESCRIPTION
This PR adds a new flag to both relay and load balancer services.

`--idle-request-interval-secs` adds a timeout for waiting for responses, so that if the service hasn't heard back from a management server in the specified time it will send a request for new resources. This should help catch any spurious errors where a service is unresponsive but the HTTP connection is active, since the request failing will trigger a new HTTP connection.