### PR TITLE
Fix version issue when publishing release docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
       - run: mkdir -p ${{ env.docs_dir }}
       - run: |
           export GITHUB_REF_NAME=${{ github.ref_name }}
+          [[ $GITHUB_REF_NAME = v* ]] && export QUILKIN_RELEASE=1
           export QUILKIN_VERSION=$(make --directory=./build version --no-print-directory)
           echo GITHUB_REF_NAME=${GITHUB_REF_NAME}
           echo QUILKIN_VERSION=${QUILKIN_VERSION}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

In `.github/docs.yaml` we never set `QUILKIN_RELEASE` when an actual release version was being created, so the version of the published docs still had the image hash on it - this fixes that by checking if the Git ref starts with 'v', e.g. v0.7.0, and therefore setting the QUILKIN_RELEASE environment variable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #786

**Special notes for your reviewer**:

N/A