### PR TITLE
Move maxmind information log to debug and per-session

### DIFF
--- a/src/maxmind_db.rs
+++ b/src/maxmind_db.rs
@@ -68,19 +68,7 @@ impl MaxmindDb {
         };
 
         match mmdb.lookup::<IpNetEntry>(ip) {
-            Ok(asn) => {
-                tracing::info!(
-                    number = asn.r#as,
-                    organization = asn.as_name,
-                    country_code = asn.as_cc,
-                    prefix = asn.prefix,
-                    prefix_entity = asn.prefix_entity,
-                    prefix_name = asn.prefix_name,
-                    "maxmind information"
-                );
-
-                Some(asn)
-            }
+            Ok(asn) => Some(asn),
             Err(error) => {
                 tracing::warn!(%ip, %error, "ip not found in maxmind database");
                 None

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -97,6 +97,18 @@ impl Session {
 
         tracing::debug!(source = %s.source, dest = ?s.dest, "Session created");
 
+        if let Some(asn) = &s.asn_info {
+            tracing::debug!(
+                number = asn.r#as,
+                organization = asn.as_name,
+                country_code = asn.as_cc,
+                prefix = asn.prefix,
+                prefix_entity = asn.prefix_entity,
+                prefix_name = asn.prefix_name,
+                "maxmind information"
+            );
+        }
+
         self::metrics::total_sessions().inc();
         s.active_session_metric().inc();
         s.run(downstream_socket, shutdown_rx);


### PR DESCRIPTION
Previously this was being triggered on every packet after we moved the maxmind lookup to the start.