### PR TITLE
Refactor sessions to use socket pool

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -418,7 +418,7 @@ mod tests {
             std::fs::write(endpoints_file.path(), {
                 config.clusters.write().insert_default(
                     [Endpoint::with_metadata(
-                        (std::net::Ipv4Addr::LOCALHOST, server_port).into(),
+                        (std::net::Ipv6Addr::LOCALHOST, server_port).into(),
                         crate::endpoint::Metadata {
                             tokens: vec![token.clone()].into_iter().collect(),
                         },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -436,7 +436,7 @@ mod tests {
 
             assert_eq!(
                 "hello",
-                timeout(Duration::from_secs(5), rx.recv())
+                timeout(Duration::from_millis(500), rx.recv())
                     .await
                     .expect("should have received a packet")
                     .unwrap()
@@ -449,7 +449,7 @@ mod tests {
             let msg = b"hello\xFF\xFF\xFF";
             socket.send_to(msg, &proxy_address).await.unwrap();
 
-            let result = timeout(Duration::from_secs(3), rx.recv()).await;
+            let result = timeout(Duration::from_millis(500), rx.recv()).await;
             assert!(result.is_err(), "should not have received a packet");
             tracing::info!(?token, "didn't receive bad packet");
         }

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -369,7 +369,6 @@ mod tests {
         );
 
         let mut context = WriteContext::new(
-            endpoints_fixture[0].clone(),
             endpoints_fixture[0].address.clone(),
             "127.0.0.1:70".parse().unwrap(),
             b"hello".to_vec(),
@@ -417,7 +416,6 @@ mod tests {
         );
 
         let mut context = WriteContext::new(
-            endpoints_fixture[0].clone(),
             endpoints_fixture[0].address.clone(),
             "127.0.0.1:70".parse().unwrap(),
             b"hello".to_vec(),

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -196,7 +196,6 @@ mod tests {
 
         // write decompress
         let mut write_context = WriteContext::new(
-            Endpoint::new("127.0.0.1:80".parse().unwrap()),
             "127.0.0.1:8080".parse().unwrap(),
             "127.0.0.1:8081".parse().unwrap(),
             read_context.contents.clone(),
@@ -223,7 +222,6 @@ mod tests {
 
         assert!(compression
             .write(&mut WriteContext::new(
-                Endpoint::new("127.0.0.1:80".parse().unwrap()),
                 "127.0.0.1:8080".parse().unwrap(),
                 "127.0.0.1:8081".parse().unwrap(),
                 b"hello".to_vec(),
@@ -270,7 +268,6 @@ mod tests {
         assert_eq!(b"hello", &*read_context.contents);
 
         let mut write_context = WriteContext::new(
-            Endpoint::new("127.0.0.1:80".parse().unwrap()),
             "127.0.0.1:8080".parse().unwrap(),
             "127.0.0.1:8081".parse().unwrap(),
             b"hello".to_vec(),
@@ -329,7 +326,6 @@ mod tests {
         let expected = contents_fixture();
         // write compress
         let mut write_context = WriteContext::new(
-            Endpoint::new("127.0.0.1:80".parse().unwrap()),
             "127.0.0.1:8080".parse().unwrap(),
             "127.0.0.1:8081".parse().unwrap(),
             expected.clone(),

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -50,8 +50,12 @@ impl Filter for Debug {
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
     async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
-        info!(id = ?self.config.id, endpoint = ?ctx.endpoint.address, source = ?&ctx.source,
-            dest = ?&ctx.dest, contents = ?String::from_utf8_lossy(&ctx.contents), "Write filter event");
+        info!(
+            id = ?self.config.id,
+            source = ?&ctx.source,
+            dest = ?&ctx.dest,
+            contents = ?String::from_utf8_lossy(&ctx.contents), "Write filter event"
+        );
         Ok(())
     }
 }

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -166,23 +166,13 @@ mod tests {
             }],
         };
 
-        let endpoint = Endpoint::new((Ipv4Addr::LOCALHOST, 80).into());
         let local_addr: crate::endpoint::EndpointAddress = (Ipv4Addr::LOCALHOST, 8081).into();
 
-        let mut ctx = WriteContext::new(
-            endpoint.clone(),
-            ([192, 168, 75, 20], 80).into(),
-            local_addr.clone(),
-            vec![],
-        );
+        let mut ctx =
+            WriteContext::new(([192, 168, 75, 20], 80).into(), local_addr.clone(), vec![]);
         assert!(firewall.write(&mut ctx).await.is_ok());
 
-        let mut ctx = WriteContext::new(
-            endpoint,
-            ([192, 168, 77, 20], 80).into(),
-            local_addr,
-            vec![],
-        );
+        let mut ctx = WriteContext::new(([192, 168, 77, 20], 80).into(), local_addr, vec![]);
         assert!(firewall.write(&mut ctx).await.is_err());
     }
 }

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -188,7 +188,6 @@ mod tests {
         // no config, so should make no change.
         filter
             .write(&mut WriteContext::new(
-                endpoint.clone(),
                 endpoint.address,
                 "127.0.0.1:70".parse().unwrap(),
                 contents.clone(),

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -113,7 +113,7 @@ mod tests {
             .await
             .is_ok());
         assert!(filter
-            .write(&mut WriteContext::new(endpoint, addr.clone(), addr, vec![],))
+            .write(&mut WriteContext::new(addr.clone(), addr, vec![],))
             .await
             .is_ok());
     }

--- a/src/filters/write.rs
+++ b/src/filters/write.rs
@@ -16,10 +16,7 @@
 
 use std::collections::HashMap;
 
-use crate::{
-    endpoint::{Endpoint, EndpointAddress},
-    metadata::DynamicMetadata,
-};
+use crate::{endpoint::EndpointAddress, metadata::DynamicMetadata};
 
 #[cfg(doc)]
 use crate::filters::Filter;
@@ -27,8 +24,6 @@ use crate::filters::Filter;
 /// The input arguments to [`Filter::write`].
 #[non_exhaustive]
 pub struct WriteContext {
-    /// The upstream endpoint that we're expecting packets from.
-    pub endpoint: Endpoint,
     /// The source of the received packet.
     pub source: EndpointAddress,
     /// The destination of the received packet.
@@ -41,14 +36,8 @@ pub struct WriteContext {
 
 impl WriteContext {
     /// Creates a new [`WriteContext`]
-    pub fn new(
-        endpoint: Endpoint,
-        source: EndpointAddress,
-        dest: EndpointAddress,
-        contents: Vec<u8>,
-    ) -> Self {
+    pub fn new(source: EndpointAddress, dest: EndpointAddress, contents: Vec<u8>) -> Self {
         Self {
-            endpoint,
             source,
             dest,
             contents,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -70,7 +70,8 @@ impl DownstreamReceiveWorkerConfig {
                 tokio::select! {
                     result = socket.recv_from(&mut buf) => {
                         match result {
-                            Ok((size, source)) => {
+                            Ok((size, mut source)) => {
+                                crate::utils::net::to_canonical(&mut source);
                                 let packet = DownstreamPacket {
                                     received_at: chrono::Utc::now().timestamp_nanos_opt().unwrap(),
                                     asn_info: crate::maxmind_db::MaxmindDb::lookup(source.ip()),

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -115,11 +115,12 @@ impl SessionPool {
                                 tracing::trace!(%error, "error receiving packet");
                                 crate::metrics::errors_total(crate::metrics::WRITE, &error.to_string(), None).inc();
                             },
-                            Ok((size, recv_addr)) => {
+                            Ok((size, mut recv_addr)) => {
                                 let received_at = chrono::Utc::now().timestamp_nanos_opt().unwrap();
                                 tracing::trace!(%recv_addr, %size, "received packet");
                                 let (downstream_addr, asn_info): (SocketAddr, Option<IpNetEntry>) = {
                                     let storage = pool.storage.read();
+                                    to_canonical(&mut recv_addr);
                                     let Some(downstream_addr) = storage.destination_to_sources.get(&(recv_addr, port)) else {
                                         tracing::warn!(address=%recv_addr, "received traffic from a server that has no downstream");
                                         continue;
@@ -314,10 +315,11 @@ impl SessionPool {
     /// Sends packet data to the appropiate session based on its `key`.
     pub async fn send(
         self: &Arc<Self>,
-        key: SessionKey,
+        mut key: SessionKey,
         asn_info: Option<IpNetEntry>,
         packet: &[u8],
     ) -> Result<usize, super::PipelineError> {
+        to_canonical(&mut key.source);
         self.get(key, asn_info)
             .await?
             .send(packet)
@@ -480,6 +482,21 @@ impl Loggable for Error {
             }
         }
     }
+}
+
+fn to_canonical(addr: &mut SocketAddr) {
+    let ip = match addr.ip() {
+        std::net::IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                std::net::IpAddr::V4(mapped)
+            } else {
+                std::net::IpAddr::V6(ip)
+            }
+        }
+        addr => addr,
+    };
+
+    addr.set_ip(ip);
 }
 
 #[cfg(test)]

--- a/src/proxy/sessions.rs
+++ b/src/proxy/sessions.rs
@@ -658,20 +658,12 @@ mod tests {
         let mut t = TestHelper::default();
         let dest = t.run_echo_server(&AddressType::Ipv6).await;
         let mut dest = dest.to_socket_addr().await.unwrap();
+        crate::test_utils::map_addr_to_localhost(&mut dest);
         let source = available_addr(&AddressType::Ipv6).await;
         let socket = tokio::net::UdpSocket::bind(source).await.unwrap();
         let mut source = socket.local_addr().unwrap();
+        crate::test_utils::map_addr_to_localhost(&mut source);
         let (pool, _sender) = new_pool(None).await;
-
-        match &mut dest {
-            std::net::SocketAddr::V4(addr) => addr.set_ip(std::net::Ipv4Addr::LOCALHOST),
-            std::net::SocketAddr::V6(addr) => addr.set_ip(std::net::Ipv6Addr::LOCALHOST),
-        };
-
-        match &mut source {
-            std::net::SocketAddr::V4(addr) => addr.set_ip(std::net::Ipv4Addr::LOCALHOST),
-            std::net::SocketAddr::V6(addr) => addr.set_ip(std::net::Ipv6Addr::LOCALHOST),
-        };
 
         let key: SessionKey = (source, dest).into();
         let msg = b"helloworld";

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -239,7 +239,8 @@ impl TestHelper {
     {
         let socket = create_socket().await;
         // sometimes give ipv6, sometimes ipv4.
-        let addr = get_address(address_type, &socket);
+        let mut addr = get_address(address_type, &socket);
+        crate::test_utils::map_addr_to_localhost(&mut addr);
         let mut shutdown = self.get_shutdown_subscriber().await;
         let local_addr = addr;
         tokio::spawn(async move {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -333,13 +333,15 @@ where
 
 pub async fn map_to_localhost(address: &mut EndpointAddress) {
     let mut socket_addr = address.to_socket_addr().await.unwrap();
+    map_addr_to_localhost(&mut socket_addr);
+    *address = socket_addr.into();
+}
 
-    match &mut socket_addr {
+pub fn map_addr_to_localhost(address: &mut SocketAddr) {
+    match address {
         SocketAddr::V4(addr) => addr.set_ip(std::net::Ipv4Addr::LOCALHOST),
         SocketAddr::V6(addr) => addr.set_ip(std::net::Ipv6Addr::LOCALHOST),
     }
-
-    *address = socket_addr.into();
 }
 
 /// Opens a new socket bound to an ephemeral port

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -250,6 +250,7 @@ impl TestHelper {
                     recvd = socket.recv_from(&mut buf) => {
                         let (size, sender) = recvd.unwrap();
                         let packet = &buf[..size];
+                        tracing::trace!(%sender, %size, "echo server received and returning packet");
                         tap(sender, packet, local_addr);
                         socket.send_to(packet, sender).await.unwrap();
                     },

--- a/src/ttl_map.rs
+++ b/src/ttl_map.rs
@@ -310,6 +310,19 @@ where
 {
     /// Returns a reference to the entry's value.
     /// The value will be reset to expire at the configured TTL after the time of retrieval.
+    pub fn into_ref(self) -> Ref<'a, K, Value<V>> {
+        match self.inner {
+            DashMapEntry::Occupied(entry) => {
+                let value = entry.into_ref();
+                value.value().update_expiration(self.ttl);
+                value.downgrade()
+            }
+            _ => unreachable!("BUG: entry type should be occupied"),
+        }
+    }
+
+    /// Returns a reference to the entry's value.
+    /// The value will be reset to expire at the configured TTL after the time of retrieval.
     pub fn get(&self) -> &Value<V> {
         match &self.inner {
             DashMapEntry::Occupied(entry) => {

--- a/src/ttl_map.rs
+++ b/src/ttl_map.rs
@@ -73,6 +73,15 @@ impl<V> Value<V> {
     }
 }
 
+impl<V: std::fmt::Debug> std::fmt::Debug for Value<V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Value")
+            .field("value", &self.value)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
+}
+
 impl<V> std::ops::Deref for Value<V> {
     type Target = V;
 
@@ -87,6 +96,18 @@ struct Map<K, V> {
     ttl: Duration,
     clock: Clock,
     shutdown_tx: Option<Sender<()>>,
+}
+
+impl<K: std::fmt::Debug + std::hash::Hash + std::cmp::Eq, V: std::fmt::Debug> std::fmt::Debug
+    for Map<K, V>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Map")
+            .field("inner", &self.inner)
+            .field("ttl", &self.ttl)
+            .field("shutdown_tx", &self.shutdown_tx)
+            .finish()
+    }
 }
 
 impl<K, V> Drop for Map<K, V> {
@@ -211,6 +232,11 @@ where
             .map(|value| value.value)
     }
 
+    /// Removes a key-value pair from the map.
+    pub fn remove(&self, key: K) -> bool {
+        self.0.inner.remove(&key).is_some()
+    }
+
     /// Returns an entry for in-place updates of the specified key-value pair.
     /// Note: This acquires a write lock on the map's shard that corresponds
     /// to the entry.
@@ -228,6 +254,14 @@ where
                 clock: self.0.clock.clone(),
             }),
         }
+    }
+}
+
+impl<K: std::fmt::Debug + std::hash::Hash + std::cmp::Eq, V: std::fmt::Debug> std::fmt::Debug
+    for TtlMap<K, V>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TtlMap").field("inner", &self.0).finish()
     }
 }
 

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -22,14 +22,12 @@ use std::{
 use socket2::{Protocol, Socket, Type};
 use tokio::{net::ToSocketAddrs, net::UdpSocket};
 
-use crate::Result;
-
 /// returns a UdpSocket with address and port reuse, on Ipv6Addr::UNSPECIFIED
-fn socket_with_reuse(port: u16) -> Result<UdpSocket> {
+fn socket_with_reuse(port: u16) -> std::io::Result<UdpSocket> {
     socket_with_reuse_and_address((Ipv6Addr::UNSPECIFIED, port).into())
 }
 
-fn socket_with_reuse_and_address(addr: SocketAddr) -> Result<UdpSocket> {
+fn socket_with_reuse_and_address(addr: SocketAddr) -> std::io::Result<UdpSocket> {
     let domain = match addr {
         SocketAddr::V4(_) => socket2::Domain::IPV4,
         SocketAddr::V6(_) => socket2::Domain::IPV6,
@@ -43,7 +41,7 @@ fn socket_with_reuse_and_address(addr: SocketAddr) -> Result<UdpSocket> {
         sock.set_only_v6(false)?;
     }
     sock.bind(&addr.into())?;
-    UdpSocket::from_std(sock.into()).map_err(|error| eyre::eyre!(error))
+    UdpSocket::from_std(sock.into())
 }
 
 #[cfg(not(target_family = "windows"))]
@@ -60,19 +58,26 @@ fn enable_reuse(sock: &Socket) -> io::Result<()> {
 
 /// An ipv6 socket that can accept and send data from either a local ipv4 address or ipv6 address
 /// with port reuse enabled and only_v6 set to false.
+#[derive(Debug)]
 pub struct DualStackLocalSocket {
     socket: UdpSocket,
 }
 
 impl DualStackLocalSocket {
-    pub fn new(port: u16) -> Result<DualStackLocalSocket> {
+    pub fn new(port: u16) -> std::io::Result<DualStackLocalSocket> {
         Ok(Self {
             socket: socket_with_reuse(port)?,
         })
     }
 
+    pub fn bind_local(port: u16) -> std::io::Result<DualStackLocalSocket> {
+        Ok(Self {
+            socket: socket_with_reuse_and_address((Ipv6Addr::LOCALHOST, port).into())?,
+        })
+    }
+
     /// Primarily used for testing of ipv4 vs ipv6 addresses.
-    pub(crate) fn new_with_address(addr: SocketAddr) -> Result<DualStackLocalSocket> {
+    pub(crate) fn new_with_address(addr: SocketAddr) -> std::io::Result<DualStackLocalSocket> {
         Ok(Self {
             socket: socket_with_reuse_and_address(addr)?,
         })

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -223,4 +223,3 @@ pub fn to_canonical(addr: &mut SocketAddr) {
 
     addr.set_ip(ip);
 }
-

--- a/src/utils/net.rs
+++ b/src/utils/net.rs
@@ -205,3 +205,22 @@ mod tests {
         );
     }
 }
+
+/// Converts a a socket address to its canonical version.
+/// This is just a copy of the method available in std but that is currently
+/// nightly only.
+pub fn to_canonical(addr: &mut SocketAddr) {
+    let ip = match addr.ip() {
+        std::net::IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                std::net::IpAddr::V4(mapped)
+            } else {
+                std::net::IpAddr::V6(ip)
+            }
+        }
+        addr => addr,
+    };
+
+    addr.set_ip(ip);
+}
+

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -157,8 +157,9 @@ mod tests {
         let mut helper = crate::test_utils::TestHelper::default();
         let token = "mytoken";
         let address = {
-            let mut addr = Endpoint::new(helper.run_echo_server(&AddressType::Random).await);
+            let mut addr = Endpoint::new(helper.run_echo_server(&AddressType::Ipv6).await);
             addr.metadata.known.tokens.insert(token.into());
+            crate::test_utils::map_to_localhost(&mut addr.address).await;
             addr
         };
         let clusters = crate::cluster::ClusterMap::default();
@@ -275,10 +276,7 @@ mod tests {
 
         client
             .socket
-            .send_to(
-                &packet,
-                (std::net::Ipv4Addr::UNSPECIFIED, client_addr.port()),
-            )
+            .send_to(&packet, (std::net::Ipv6Addr::LOCALHOST, client_addr.port()))
             .await
             .unwrap();
         let response = tokio::time::timeout(std::time::Duration::from_secs(1), client.packet_rx)
@@ -315,7 +313,7 @@ mod tests {
         // Each time, we create a new upstream endpoint and send a cluster update for it.
         let concat_bytes = vec![("b", "c,"), ("d", "e")];
         for (b1, b2) in concat_bytes.into_iter() {
-            let socket = std::net::UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)).unwrap();
+            let socket = std::net::UdpSocket::bind((std::net::Ipv6Addr::LOCALHOST, 0)).unwrap();
             let local_addr: crate::endpoint::EndpointAddress = socket.local_addr().unwrap().into();
 
             config.clusters.modify(|clusters| {

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -31,7 +31,8 @@ use quilkin::{
 #[tokio::test]
 async fn token_router() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server(&AddressType::Random).await;
+    let mut echo = t.run_echo_server(&AddressType::Random).await;
+    quilkin::test_utils::map_to_localhost(&mut echo).await;
     let server_port = 12348;
     let server_proxy = quilkin::cli::Proxy {
         port: server_port,

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -88,7 +88,7 @@ async fn token_router() {
 
     assert_eq!(
         "helloabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(500), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()
@@ -98,6 +98,6 @@ async fn token_router() {
     let msg = b"helloxyz";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    let result = timeout(Duration::from_secs(3), recv_chan.recv()).await;
+    let result = timeout(Duration::from_millis(500), recv_chan.recv()).await;
     assert!(result.is_err(), "should not have received a packet");
 }

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -29,7 +29,8 @@ async fn client_and_server() {
     let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration as
-    let server_addr = available_addr(&AddressType::Random).await;
+    let mut server_addr = available_addr(&AddressType::Random).await;
+    quilkin::test_utils::map_addr_to_localhost(&mut server_addr);
     let yaml = "
 on_read: DECOMPRESS
 on_write: COMPRESS
@@ -84,7 +85,7 @@ on_write: DECOMPRESS
     let (mut rx, tx) = t.open_socket_and_recv_multiple_packets().await;
 
     tx.send_to(b"hello", &client_addr).await.unwrap();
-    let expected = timeout(Duration::from_secs(5), rx.recv())
+    let expected = timeout(Duration::from_millis(500), rx.recv())
         .await
         .expect("should have received a packet")
         .unwrap();

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -44,7 +44,7 @@ on_read: COMPRESS
 on_write: DECOMPRESS
 ";
 
-    let echo = t
+    let mut echo = t
         .run_echo_server_with_tap(&AddressType::Random, move |_, bytes, _| {
             assert!(
                 from_utf8(bytes).is_err(),
@@ -53,6 +53,7 @@ on_write: DECOMPRESS
         })
         .await;
 
+    quilkin::test_utils::map_to_localhost(&mut echo).await;
     let server_port = 12346;
     let server_proxy = quilkin::cli::Proxy {
         port: server_port,
@@ -94,7 +95,7 @@ on_write: DECOMPRESS
 
     assert_eq!(
         "helloxyzabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(500), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -125,6 +125,7 @@ async fn debug_filter() {
     // create an echo server as an endpoint.
     let echo = t.run_echo_server(&AddressType::Random).await;
 
+    tracing::trace!(%echo, "running echo server");
     // create server configuration
     let server_port = 12247;
     let server_config = std::sync::Arc::new(quilkin::Config::default());

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -51,7 +51,7 @@ on_write:
 
     assert_eq!(
         "hello",
-        timeout(Duration::from_secs(5), rx.recv())
+        timeout(Duration::from_millis(500), rx.recv())
             .await
             .expect("should have received a packet")
             .unwrap()
@@ -81,7 +81,7 @@ on_write:
 
     assert_eq!(
         "hello",
-        timeout(Duration::from_secs(5), rx.recv())
+        timeout(Duration::from_millis(500), rx.recv())
             .await
             .expect("should have received a packet")
             .unwrap()
@@ -109,7 +109,7 @@ on_write:
 ";
     let mut rx = test(&mut t, port, yaml, &address_type).await;
 
-    let result = timeout(Duration::from_secs(3), rx.recv()).await;
+    let result = timeout(Duration::from_millis(500), rx.recv()).await;
     assert!(result.is_err(), "should not have received a packet");
 }
 
@@ -134,7 +134,7 @@ on_write:
 ";
     let mut rx = test(&mut t, port, yaml, &address_type).await;
 
-    let result = timeout(Duration::from_secs(3), rx.recv()).await;
+    let result = timeout(Duration::from_millis(500), rx.recv()).await;
     assert!(result.is_err(), "should not have received a packet");
 }
 
@@ -159,7 +159,7 @@ on_write:
 ";
     let mut rx = test(&mut t, port, yaml, &address_type).await;
 
-    let result = timeout(Duration::from_secs(3), rx.recv()).await;
+    let result = timeout(Duration::from_millis(500), rx.recv()).await;
     assert!(result.is_err(), "should not have received a packet");
 }
 
@@ -184,7 +184,7 @@ on_write:
 ";
     let mut rx = test(&mut t, port, yaml, &address_type).await;
 
-    let result = timeout(Duration::from_secs(3), rx.recv()).await;
+    let result = timeout(Duration::from_millis(500), rx.recv()).await;
     assert!(result.is_err(), "should not have received a packet");
 }
 

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -54,6 +54,7 @@ period: 1
         .unwrap(),
     );
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(Duration::from_millis(50)).await;
 
     let msg = "hello";
     let (mut rx, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -35,7 +35,8 @@ period: 1
 ";
     let echo = t.run_echo_server(&AddressType::Random).await;
 
-    let server_addr = available_addr(&AddressType::Random).await;
+    let mut server_addr = available_addr(&AddressType::Random).await;
+    quilkin::test_utils::map_addr_to_localhost(&mut server_addr);
     let server_proxy = quilkin::cli::Proxy {
         port: server_addr.port(),
         ..<_>::default()
@@ -53,20 +54,21 @@ period: 1
         .map(std::sync::Arc::new)
         .unwrap(),
     );
+    tracing::trace!("spawning server");
     t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(Duration::from_millis(50)).await;
 
     let msg = "hello";
     let (mut rx, socket) = t.open_socket_and_recv_multiple_packets().await;
 
     for _ in 0..3 {
+        tracing::trace!(%server_addr, %msg, "sending");
         socket.send_to(msg.as_bytes(), &server_addr).await.unwrap();
     }
 
     for _ in 0..2 {
         assert_eq!(
             msg,
-            timeout(Duration::from_secs(5), rx.recv())
+            timeout(Duration::from_millis(500), rx.recv())
                 .await
                 .unwrap()
                 .unwrap()
@@ -76,5 +78,7 @@ period: 1
     // Allow enough time to have received any response.
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Check that we do not get any response.
-    assert!(timeout(Duration::from_secs(1), rx.recv()).await.is_err());
+    assert!(timeout(Duration::from_millis(500), rx.recv())
+        .await
+        .is_err());
 }

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -95,7 +95,7 @@ on_read:
 
     assert_eq!(
         "helloxyz",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(500), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()
@@ -107,7 +107,7 @@ on_read:
 
     assert_eq!(
         "helloabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(500), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()
@@ -119,7 +119,7 @@ on_read:
 
     assert_eq!(
         "hellodef",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(500), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()
@@ -131,7 +131,7 @@ on_read:
 
     assert_eq!(
         "hellodef",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(500), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -32,7 +32,8 @@ async fn metrics_server() {
         .port();
 
     // create server configuration
-    let server_addr = quilkin::test_utils::available_addr(&AddressType::Random).await;
+    let mut server_addr = quilkin::test_utils::available_addr(&AddressType::Random).await;
+    quilkin::test_utils::map_addr_to_localhost(&mut server_addr);
     let server_proxy = quilkin::cli::Proxy {
         port: server_addr.port(),
         ..<_>::default()
@@ -44,7 +45,7 @@ async fn metrics_server() {
     t.run_server(
         server_config,
         server_proxy,
-        Some(Some((std::net::Ipv6Addr::UNSPECIFIED, metrics_port).into())),
+        Some(Some((std::net::Ipv4Addr::UNSPECIFIED, metrics_port).into())),
     );
 
     // create a local client

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -53,19 +53,19 @@ async fn echo() {
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
     socket.send_to(b"hello", &local_addr).await.unwrap();
-    let value = timeout(Duration::from_secs(5), recv_chan.recv())
+    let value = timeout(Duration::from_millis(500), recv_chan.recv())
         .await
         .unwrap()
         .unwrap();
     assert_eq!("hello", value);
-    let value = timeout(Duration::from_secs(5), recv_chan.recv())
+    let value = timeout(Duration::from_millis(500), recv_chan.recv())
         .await
         .unwrap()
         .unwrap();
     assert_eq!("hello", value);
 
     // should only be two returned items
-    assert!(timeout(Duration::from_secs(2), recv_chan.recv())
+    assert!(timeout(Duration::from_millis(500), recv_chan.recv())
         .await
         .is_err());
 }

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -31,7 +31,7 @@ use quilkin::{
 #[tokio::test]
 async fn token_router() {
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server(&AddressType::Random).await;
+    let echo = t.run_echo_server(&AddressType::Ipv6).await;
 
     let capture_yaml = "
 suffix:

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -30,7 +30,6 @@ use quilkin::{
 /// since they work in concert together.
 #[tokio::test]
 async fn token_router() {
-    quilkin::test_utils::enable_log("quilkin=trace");
     let mut t = TestHelper::default();
     let mut echo = t.run_echo_server(&AddressType::Ipv6).await;
     quilkin::test_utils::map_to_localhost(&mut echo).await;

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -82,7 +82,7 @@ quilkin.dev:
     // valid packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-    let local_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, server_port));
+    let local_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, server_port));
     let msg = b"helloabc";
     socket.send_to(msg, &local_addr).await.unwrap();
 

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv6Addr, SocketAddr};
 
 use tokio::time::{timeout, Duration};
 

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -90,7 +90,7 @@ quilkin.dev:
 
     assert_eq!(
         "hello",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(500), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()
@@ -100,6 +100,6 @@ quilkin.dev:
     let msg = b"helloxyz";
     socket.send_to(msg, &local_addr).await.unwrap();
 
-    let result = timeout(Duration::from_secs(3), recv_chan.recv()).await;
+    let result = timeout(Duration::from_millis(500), recv_chan.recv()).await;
     assert!(result.is_err(), "should not have received a packet");
 }

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -30,8 +30,10 @@ use quilkin::{
 /// since they work in concert together.
 #[tokio::test]
 async fn token_router() {
+    quilkin::test_utils::enable_log("quilkin=trace");
     let mut t = TestHelper::default();
-    let echo = t.run_echo_server(&AddressType::Ipv6).await;
+    let mut echo = t.run_echo_server(&AddressType::Ipv6).await;
+    quilkin::test_utils::map_to_localhost(&mut echo).await;
 
     let capture_yaml = "
 suffix:


### PR DESCRIPTION
This PR refactors how we handle upstream connections to the gameservers. When profiling quilkin I noticed that there was a lot of time (~10–15%) being spent dropping the upstream socket through its Arc implementation that happened whenever a session was dropped.

As I was thinking about how to solve this problem I also realised there was a second issue, which is that there is a limitation on how many connections Quilkin can hold at once, roughly ~16,383. Because after that we're likely to start encountering port exhaustion from the operating system, since each session is a unique socket.

This brought me to the solution in this PR, which is that while we need to give each connection to the gameserver a unique port, we don't need to give a unique port across gameservers. So I refactored how we create sessions to use what I've called a "SessionPool". This pools the sockets for sessions into a map that is keyed by their destination.

With this implementation this means that we now have a limit of ~16,000 connections per gameserver, which is far more than any gameserver could reasonably need.


### Future Work

Add a limitation of connections per gameserver, if for example, you know the most you're going to have is ~50 players, setting it to be something like 75 seems reasonable. This would help prevent a large scale DDoS from causing port exhaustion (though it would still flood the existing sockets, so it wouldn't prevent a DDoS.)