### PR TITLE
Fix dead lock in SessionPool

### DIFF
--- a/src/ttl_map.rs
+++ b/src/ttl_map.rs
@@ -310,19 +310,6 @@ where
 {
     /// Returns a reference to the entry's value.
     /// The value will be reset to expire at the configured TTL after the time of retrieval.
-    pub fn into_ref(self) -> Ref<'a, K, Value<V>> {
-        match self.inner {
-            DashMapEntry::Occupied(entry) => {
-                let value = entry.into_ref();
-                value.value().update_expiration(self.ttl);
-                value.downgrade()
-            }
-            _ => unreachable!("BUG: entry type should be occupied"),
-        }
-    }
-
-    /// Returns a reference to the entry's value.
-    /// The value will be reset to expire at the configured TTL after the time of retrieval.
     pub fn get(&self) -> &Value<V> {
         match &self.inner {
             DashMapEntry::Occupied(entry) => {


### PR DESCRIPTION
The problem was that in dashmap we were occasionally getting unlucky and having sessions sometimes end up in the same shard, which would cause a deadlock since one would be trying to insert into a shard while we still hold a reference to one.

Fortunately this is a pretty simple fix of not returning a reference at all and instead just returning the socket, since that was the only thing that was used out of the session struct.