### PR TITLE
Loadtesting fixes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -366,9 +366,9 @@ mod tests {
 
         tokio::spawn(relay.drive());
         tokio::spawn(control_plane.drive());
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
         tokio::spawn(proxy.drive());
-        tokio::time::sleep(Duration::from_millis(500)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
         let socket = create_socket().await;
         let config = Config::default();
         let proxy_address: SocketAddr = (std::net::Ipv4Addr::LOCALHOST, 7777).into();
@@ -399,7 +399,7 @@ mod tests {
 
             assert_eq!(
                 "hello",
-                timeout(Duration::from_millis(500), rx.recv())
+                timeout(Duration::from_millis(100), rx.recv())
                     .await
                     .expect("should have received a packet")
                     .unwrap()
@@ -412,7 +412,7 @@ mod tests {
             let msg = b"hello\xFF\xFF\xFF";
             socket.send_to(msg, &proxy_address).await.unwrap();
 
-            let result = timeout(Duration::from_millis(500), rx.recv()).await;
+            let result = timeout(Duration::from_millis(50), rx.recv()).await;
             assert!(result.is_err(), "should not have received a packet");
             tracing::info!(?token, "didn't receive bad packet");
         }

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -470,18 +470,17 @@ mod tests {
         let endpoint = t.open_socket_and_recv_single_packet().await;
         let mut local_addr = available_addr(&AddressType::Ipv6).await;
         crate::test::map_addr_to_localhost(&mut local_addr);
+        let mut dest = endpoint.socket.local_ipv6_addr().unwrap();
+        crate::test::map_addr_to_localhost(&mut dest);
+
         let proxy = crate::cli::Proxy {
             port: local_addr.port(),
             ..<_>::default()
         };
+
         let config = Arc::new(Config::default());
         config.clusters.modify(|clusters| {
-            clusters.insert_default(
-                [Endpoint::new(
-                    endpoint.socket.local_ipv6_addr().unwrap().into(),
-                )]
-                .into(),
-            );
+            clusters.insert_default([Endpoint::new(dest.into())].into());
         });
         t.run_server(config, proxy, None);
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
@@ -509,6 +508,8 @@ mod tests {
         load_test_filters();
         let endpoint = t.open_socket_and_recv_single_packet().await;
         let local_addr = available_addr(&AddressType::Random).await;
+        let mut dest = endpoint.socket.local_ipv4_addr().unwrap();
+        crate::test::map_addr_to_localhost(&mut dest);
         let config = Arc::new(Config::default());
         config.filters.store(
             crate::filters::FilterChain::try_from(vec![config::Filter {
@@ -520,12 +521,7 @@ mod tests {
             .unwrap(),
         );
         config.clusters.modify(|clusters| {
-            clusters.insert_default(
-                [Endpoint::new(
-                    endpoint.socket.local_ipv4_addr().unwrap().into(),
-                )]
-                .into(),
-            );
+            clusters.insert_default([Endpoint::new(dest.into())].into());
         });
         t.run_server(
             config,

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -44,7 +44,7 @@ pub async fn spawn(port: u16) -> crate::Result<()> {
             let mut output_buf = Vec::new();
 
             loop {
-                tracing::info!(%v4_addr, %v6_addr, "awaiting qcmp packets");
+                tracing::debug!("awaiting qcmp packets");
 
                 match socket.recv_from(&mut buf).await {
                     Ok((size, source)) => {
@@ -83,7 +83,7 @@ pub async fn spawn(port: u16) -> crate::Result<()> {
                 }
             }
         }
-        .instrument(tracing::info_span!("qcmp_task", %v4_addr, %v6_addr)),
+        .instrument(tracing::debug_span!("qcmp_task", %v4_addr, %v6_addr)),
     );
     Ok(())
 }

--- a/src/net/xds.rs
+++ b/src/net/xds.rs
@@ -190,7 +190,6 @@ mod tests {
         // Test that the client can handle the manager dropping out.
         let handle = tokio::spawn(server::spawn(xds_port, xds_config.clone()));
 
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
         tokio::spawn(server::spawn(xds_port, xds_config.clone()));
         let client_proxy = crate::cli::Proxy {
@@ -207,7 +206,6 @@ mod tests {
         });
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         handle.abort();
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         tokio::spawn(server::spawn(xds_port, xds_config.clone()));
@@ -279,10 +277,11 @@ mod tests {
             .send_to(&packet, (std::net::Ipv6Addr::LOCALHOST, client_addr.port()))
             .await
             .unwrap();
-        let response = tokio::time::timeout(std::time::Duration::from_secs(1), client.packet_rx)
-            .await
-            .unwrap()
-            .unwrap();
+        let response =
+            tokio::time::timeout(std::time::Duration::from_millis(100), client.packet_rx)
+                .await
+                .unwrap()
+                .unwrap();
 
         assert_eq!(format!("{}{}", fixture, token), response);
     }
@@ -308,7 +307,7 @@ mod tests {
             config.clone(),
             crate::cli::admin::IDLE_REQUEST_INTERVAL_SECS,
         );
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // Each time, we create a new upstream endpoint and send a cluster update for it.
         let concat_bytes = vec![("b", "c,"), ("d", "e")];
@@ -322,7 +321,6 @@ mod tests {
                 cluster.clear();
                 cluster.insert(Endpoint::new(local_addr.clone()));
             });
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
             let filters = crate::filters::FilterChain::try_from(vec![
                 Concatenate::as_filter_config(concatenate::Config {
@@ -346,7 +344,7 @@ mod tests {
                 .discovery_request(ResourceType::Cluster, &[])
                 .await
                 .unwrap();
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             assert_eq!(
                 local_addr,
                 config
@@ -364,7 +362,7 @@ mod tests {
                 .discovery_request(ResourceType::Listener, &[])
                 .await
                 .unwrap();
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             let changed_filters = config.filters.load();
 
             assert_eq!(changed_filters.len(), 2);


### PR DESCRIPTION
This commit makes three changes

* Moves QCMP logs to debug
* Removed the retry function on the command level This is because if it starts failing we'd prefer if k8s restarts it than it restart itself continously.
* Removed the asserts and unwraps in `release_socket`. This was never a problem while running, but could cause issues during teardown when can't rely on how things are being freed.