### PR TITLE
Release aarch64-apple-darwin binary

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -55,6 +55,7 @@ gcloud_mount_args := -v $(build_path)/.config/gcloud:/root/.config/gcloud
 
 cargo_build_x86_64_linux := build --release --target x86_64-unknown-linux-gnu
 cargo_build_x86_64_apple := build --release --target x86_64-apple-darwin
+cargo_build_aarch64-apple := build --release --target aarch64-apple-darwin
 cargo_build_x86_64_windows := build --release --target x86_64-pc-windows-gnu
 
 #   _____                    _
@@ -144,11 +145,12 @@ else
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) $(cargo_build_x86_64_windows)
 endif
 
-# Build binary for x86_64-apple-darwin
+# Build binary for x86_64-apple-darwin and aarch64-apple-darwin
 # Use BUILD_LOCAL=1 to build through local cargo rather than through the build container.
 build-macos-binary:
 ifdef BUILD_LOCAL
 	cargo $(cargo_build_x86_64_apple)
+	cargo $(cargo_build_aarch64-apple)
 else
 	docker run --rm -v $(project_path):/workspace -w /workspace \
 		-v $(CARGO_HOME)/registry:/root/.cargo/registry \
@@ -156,7 +158,8 @@ else
 		-e "CC=o64-clang" -e "CXX=o64-clang++" \
 		-e "PROTOC=/opt/protoc/bin/protoc" \
 		joseluisq/rust-linux-darwin-builder:$(rust_toolchain) \
-			sh -c "/workspace/build/darwin-builder/setup.sh && cargo $(cargo_build_x86_64_apple) --no-default-features"
+			sh -c "/workspace/build/darwin-builder/setup.sh && cargo $(cargo_build_x86_64_apple) --no-default-features && \
+			CC=oa64-clang CXX=oa64-clang++ LIBZ_SYS_STATIC=1 cargo $(cargo_build_aarch64-apple) --no-default-features"
 endif
 
 # Build container image.

--- a/build/darwin-builder/setup.sh
+++ b/build/darwin-builder/setup.sh
@@ -27,3 +27,4 @@ unzip protoc.zip
 popd
 /opt/protoc/bin/protoc --version
 rustup target add x86_64-apple-darwin
+rustup target add aarch64-apple-darwin


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind feature

> /kind hotfix

**What this PR does / Why we need it**:

We started getting more Mac M1 and M2 users, and it's while it's possible to run the x86_64-apple-darwin version, and we're not sure if it's causing network issues.

Since the prerequisites of doing this got release in https://github.com/joseluisq/rust-linux-darwin-builder/releases/tag/v1.65.0 this is relatively easy to do now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #610

**Special notes for your reviewer**:

N/A
