### PR TITLE
Remove built dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,6 @@ tonic-build = { version = "0.10.2", default_features = false, features = [
     "prost",
 ] }
 prost-build = "0.12.1"
-built = { version = "0.7.0", features = ["git2"] }
 protobuf-src = { version = "1.1.0", optional = true }
 
 [features]

--- a/src/net/endpoint/metadata.rs
+++ b/src/net/endpoint/metadata.rs
@@ -18,7 +18,7 @@ pub(crate) mod symbol;
 
 #[doc(hidden)]
 pub mod build {
-    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+    pub const GIT_COMMIT_HASH: Option<&str> = option_env!("GIT_COMMIT_HASH");
 }
 
 use std::{collections::HashMap, convert::TryFrom};


### PR DESCRIPTION
This was pulling in git2 and writing a lot of data that was never used
in the crate. This just changes build.rs to manually read the HEAD
commit information and set an env var.
AFAICT this is actually superior in every way to built since we no
longer have the extra dependencies, and we actually get up to date
information when the commit changes, which AFAICT was not the case with
built since it was not registering file changes.
