### PR TITLE
Move game traffic sockets to io-uring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,9 +128,12 @@ async-trait = "0.1.73"
 nom = "7.1.3"
 strum = "0.25.0"
 strum_macros = "0.25.2"
+async-channel = "1.9.0"
+cfg-if = "1.0.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.1"
+tokio-uring = { version = "0.4.0", features = ["bytes"] }
 
 [dev-dependencies]
 divan = "0.1.2"

--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -341,7 +341,7 @@ impl QuilkinLoop {
 
             runtime.block_on(async move {
                 let admin = quilkin::cli::Admin::Proxy(<_>::default());
-                proxy.run(config, admin, shutdown_rx).await.unwrap();
+                proxy.run(config, admin, None, shutdown_rx).await.unwrap();
             });
         });
 

--- a/docs/src/services/proxy/filters/writing_custom_filters.md
+++ b/docs/src/services/proxy/filters/writing_custom_filters.md
@@ -19,9 +19,10 @@ struct Greet;
 > As a convention within Quilkin: Filter names are singular, they also tend to
 > be a verb, rather than an adjective.
 >
->  **Examples**
->  - **Greet** not "Greets"
->  - **Compress** not "Compressor".
+> **Examples**
+>
+> - **Greet** not "Greets"
+> - **Compress** not "Compressor".
 
 ## `Filter`
 
@@ -39,14 +40,15 @@ sent to a downstream client.
 # struct Greet;
 use quilkin::filters::prelude::*;
 
+/// Appends data to each packet
 #[async_trait::async_trait]
 impl Filter for Greet {
     async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
-        ctx.contents.extend(b"Hello");
+        ctx.contents.extend_from_slice(b"Hello");
         Ok(())
     }
     async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
-        ctx.contents.extend(b"Goodbye");
+        ctx.contents.extend_from_slice(b"Goodbye");
         Ok(())
     }
 }
@@ -210,7 +212,6 @@ To include the generated code, we'll use [`tonic::include_proto`], then we just
 need to implement [std::convert::TryFrom] for converting the protobuf message to
 equivalvent configuration.
 
-
 ```rust,no_run,noplayground,ignore
 // src/main.rs
 {{#include ../../../../../examples/quilkin-filter-example/src/main.rs:include_proto}}
@@ -234,30 +235,18 @@ filter. Try it out with the following configuration:
 {{#include ../../../../../examples/quilkin-filter-example/config.yaml:yaml}}
 ```
 
-[FilterInstance]: ../../../../api/quilkin/filters/prelude/struct.FilterInstance.html
-[Filter]: ../../../../api/quilkin/filters/trait.Filter.html
-[FilterFactory]: ../../../../api/quilkin/filters/trait.FilterFactory.html
-[filter-factory-name]: ../../../../api/quilkin/filters/trait.FilterFactory.html#tymethod.name
-[FilterRegistry]: ../../../../api/quilkin/filters/struct.FilterRegistry.html
 [FilterRegistry::register]: ../../../../api/quilkin/filters/struct.FilterRegistry.html#method.register
-[CreateFilterArgs::config]: ../../../api/quilkin/filters/prelude/struct.CreateFilterArgs.html#structfield.config
-[ConfigType::dynamic]: ../../../../api/quilkin/config/enum.ConfigType.html#variant.Dynamic
-[ConfigType::static]: ../../../../api/quilkin/config/enum.ConfigType.html#variant.Static
-[ConfigType::deserialize]: ../../../../api/quilkin/config/enum.ConfigType.html#method.deserialize
 [std::convert::TryFrom]: https://doc.rust-lang.org/std/convert/trait.TryFrom.html
 
 [Filters]: ../filters.md
 [filter chain]: ../filters.md#filters-and-filter-chain
 [built-in-filters]: ../filters.md#built-in-filters
-[filter configuration]: ../filters.md#filter-config
-[proxy-config]: ../../deployment/configuration.md
 [management server]: ../../xds.md
 [tokio]: https://docs.rs/tokio
 [tonic]: https://docs.rs/tonic
 [prost]: https://docs.rs/prost
 [Protobuf]: https://protobuf.dev
 [Serde]: https://docs.serde.rs/serde_yaml/index.html
-[prost-any]: https://docs.rs/prost-types/0.7.0/prost_types/struct.Any.html
 [prost_build]: https://docs.rs/prost-build/0.7.0/prost_build/
 [build-script]: https://doc.rust-lang.org/cargo/reference/build-scripts.html
 [example]: https://github.com/googleforgames/quilkin/tree/{{GITHUB_REF_NAME}}/examples/quilkin-filter-example

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -61,12 +61,12 @@ struct Greet {
 impl Filter for Greet {
     async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         ctx.contents
-            .splice(0..0, format!("{} ", self.config.greeting).into_bytes());
+            .prepend_from_slice(format!("{} ", self.config.greeting).as_bytes());
         Ok(())
     }
     async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         ctx.contents
-            .splice(0..0, format!("{} ", self.config.greeting).into_bytes());
+            .prepend_from_slice(format!("{} ", self.config.greeting).as_bytes());
         Ok(())
     }
 }
@@ -115,6 +115,6 @@ async fn main() -> quilkin::Result<()> {
 
     let admin = quilkin::cli::Admin::Proxy(<_>::default());
 
-    proxy.run(config.into(), admin, shutdown_rx).await
+    proxy.run(config.into(), admin, None, shutdown_rx).await
 }
 // ANCHOR_END: run

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -294,7 +294,7 @@ mod tests {
 
         let endpoints_file = tempfile::NamedTempFile::new().unwrap();
         let config = Config::default();
-        let server_port = server_socket.local_ipv4_addr().unwrap().port();
+        let server_port = server_socket.local_addr().unwrap().port();
         std::fs::write(endpoints_file.path(), {
             config.clusters.write().insert_default(
                 [Endpoint::with_metadata(
@@ -374,11 +374,11 @@ mod tests {
         let config = Config::default();
         let proxy_address: SocketAddr = (std::net::Ipv4Addr::LOCALHOST, 7777).into();
 
+        let server_port = server_socket.local_addr().unwrap().port();
         for _ in 0..5 {
             let token = random_three_characters();
 
             tracing::info!(?token, "writing new config");
-            let server_port = server_socket.local_ipv4_addr().unwrap().port();
             std::fs::write(endpoints_file.path(), {
                 config.clusters.write().insert_default(
                     [Endpoint::with_metadata(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,7 +132,7 @@ impl Cli {
     /// Drives the main quilkin application lifecycle using the command line
     /// arguments.
     #[tracing::instrument(skip_all)]
-    pub async fn drive(self) -> crate::Result<()> {
+    pub async fn drive(self, tx: Option<tokio::sync::oneshot::Sender<u16>>) -> crate::Result<()> {
         if !self.quiet {
             let env_filter = tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
@@ -207,7 +207,7 @@ impl Cli {
             Commands::Agent(agent) => agent.run(config.clone(), mode, shutdown_rx.clone()).await,
             Commands::Proxy(runner) => {
                 runner
-                    .run(config.clone(), mode.clone(), shutdown_rx.clone())
+                    .run(config.clone(), mode.clone(), tx, shutdown_rx.clone())
                     .await
             }
             Commands::Manage(manager) => {
@@ -365,11 +365,16 @@ mod tests {
             log_format: LogFormats::default(),
         };
 
-        tokio::spawn(relay.drive());
-        tokio::spawn(control_plane.drive());
+        tokio::spawn(relay.drive(None));
+        tokio::spawn(control_plane.drive(None));
         tokio::time::sleep(Duration::from_millis(50)).await;
-        tokio::spawn(proxy.drive());
-        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let (tx, proxy_init) = tokio::sync::oneshot::channel();
+
+        tokio::spawn(proxy.drive(Some(tx)));
+
+        proxy_init.await.unwrap();
+
         let socket = create_socket().await;
         let config = Config::default();
         let proxy_address: SocketAddr = (std::net::Ipv4Addr::LOCALHOST, 7777).into();

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -120,8 +120,8 @@ impl Proxy {
 
         if !config.clusters.read().has_endpoints() && self.management_server.is_empty() {
             return Err(eyre::eyre!(
-                    "`quilkin proxy` requires at least one `to` address or `management_server` endpoint."
-                ));
+                "`quilkin proxy` requires at least one `to` address or `management_server` endpoint."
+            ));
         }
 
         let id = config.id.load();
@@ -461,8 +461,7 @@ impl DownstreamReceiveWorkerConfig {
         config: &Arc<Config>,
         sessions: &Arc<SessionPool>,
     ) -> Result<(), PipelineError> {
-        let endpoints: Vec<_> = config.clusters.read().endpoints().collect();
-        if endpoints.is_empty() {
+        if !config.clusters.read().has_endpoints() {
             return Err(PipelineError::NoUpstreamEndpoints);
         }
 

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -29,14 +29,14 @@ use tokio::sync::mpsc;
 use tonic::transport::Endpoint;
 
 use super::Admin;
-use sessions::{SessionKey, SessionPool};
+use sessions::{DownstreamReceiver, SessionKey, SessionPool};
 
 #[cfg(doc)]
 use crate::filters::FilterFactory;
 
 use crate::{
     filters::{Filter, ReadContext},
-    net::{xds::ResourceType, DualStackLocalSocket},
+    net::{maxmind_db::IpNetEntry, xds::ResourceType, DualStackLocalSocket},
     Config, Result, ShutdownRx,
 };
 
@@ -128,8 +128,10 @@ impl Proxy {
         tracing::info!(port = self.port, proxy_id = &*id, "Starting");
 
         let runtime_config = mode.unwrap_proxy();
-        let shared_socket = Arc::new(DualStackLocalSocket::new(self.port)?);
-        let sessions = SessionPool::new(config.clone(), shared_socket.clone(), shutdown_rx.clone());
+
+        let (upstream_sender, upstream_receiver) =
+            async_channel::unbounded::<(Vec<u8>, Option<IpNetEntry>, SocketAddr)>();
+        let sessions = SessionPool::new(config.clone(), upstream_sender, shutdown_rx.clone());
 
         let _xds_stream = if !self.management_server.is_empty() {
             {
@@ -158,8 +160,12 @@ impl Proxy {
             None
         };
 
-        self.run_recv_from(&config, &sessions, shared_socket)?;
+        let worker_notifications = self.run_recv_from(&config, &sessions, upstream_receiver)?;
         crate::codec::qcmp::spawn(self.qcmp_port).await?;
+        for notification in worker_notifications {
+            notification.notified().await;
+        }
+
         tracing::info!("Quilkin is ready");
 
         shutdown_rx
@@ -188,8 +194,8 @@ impl Proxy {
         &self,
         config: &Arc<Config>,
         sessions: &Arc<SessionPool>,
-        shared_socket: Arc<DualStackLocalSocket>,
-    ) -> Result<()> {
+        upstream_receiver: DownstreamReceiver,
+    ) -> Result<Vec<Arc<tokio::sync::Notify>>> {
         // The number of worker tasks to spawn. Each task gets a dedicated queue to
         // consume packets off.
         let num_workers = num_cpus::get();
@@ -199,7 +205,8 @@ impl Proxy {
         let mut workers = Vec::with_capacity(num_workers);
         workers.push(DownstreamReceiveWorkerConfig {
             worker_id: 0,
-            socket: shared_socket,
+            upstream_receiver: upstream_receiver.clone(),
+            port: self.port,
             config: config.clone(),
             sessions: sessions.clone(),
             error_sender: error_sender.clone(),
@@ -208,17 +215,19 @@ impl Proxy {
         for worker_id in 1..num_workers {
             workers.push(DownstreamReceiveWorkerConfig {
                 worker_id,
-                socket: Arc::new(DualStackLocalSocket::new(self.port)?),
+                upstream_receiver: upstream_receiver.clone(),
+                port: self.port,
                 config: config.clone(),
                 sessions: sessions.clone(),
                 error_sender: error_sender.clone(),
             })
         }
 
+        let mut worker_notifications = Vec::new();
         // Start the worker tasks that pick up received packets from their queue
         // and processes them.
         for worker in workers {
-            worker.spawn();
+            worker_notifications.push(worker.spawn());
         }
 
         tokio::spawn(async move {
@@ -246,7 +255,7 @@ impl Proxy {
             }
         });
 
-        Ok(())
+        Ok(worker_notifications)
     }
 }
 
@@ -282,66 +291,129 @@ pub(crate) struct DownstreamReceiveWorkerConfig {
     /// ID of the worker.
     pub worker_id: usize,
     /// Socket with reused port from which the worker receives packets.
-    pub socket: Arc<DualStackLocalSocket>,
+    pub upstream_receiver: DownstreamReceiver,
+    pub port: u16,
     pub config: Arc<Config>,
     pub sessions: Arc<SessionPool>,
     pub error_sender: mpsc::UnboundedSender<PipelineError>,
 }
 
 impl DownstreamReceiveWorkerConfig {
-    pub fn spawn(self) {
+    pub fn spawn(self) -> Arc<tokio::sync::Notify> {
         let Self {
             worker_id,
-            socket,
+            upstream_receiver,
+            port,
             config,
             sessions,
             error_sender,
         } = self;
+        let notify = Arc::new(tokio::sync::Notify::new());
+        let is_ready = notify.clone();
 
-        tokio::spawn(async move {
+        uring_spawn!(async move {
             // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
             // packet, which is the maximum value of 16 a bit integer.
-            let mut buf = vec![0; 1 << 16];
+            let mut recv_buf = vec![0; 1 << 16];
             let mut last_received_at = None;
-            loop {
-                tracing::trace!(
-                    id = worker_id,
-                    port = ?socket.local_ipv6_addr().map(|addr| addr.port()),
-                    "Awaiting packet"
-                );
+            cfg_if::cfg_if! {
+                if #[cfg(target_os = "linux")] {
+                    let socket = std::rc::Rc::new(DualStackLocalSocket::new(port).unwrap());
+                } else {
+                    let socket = std::sync::Arc::new(DualStackLocalSocket::new(port).unwrap());
+                }
+            }
+            let send_socket = socket.clone();
 
-                tokio::select! {
-                    result = socket.recv_from(&mut buf) => {
-                        match result {
-                            Ok((size, mut source)) => {
-                                crate::net::to_canonical(&mut source);
-                                let packet = DownstreamPacket {
-                                    received_at: chrono::Utc::now().timestamp_nanos_opt().unwrap(),
-                                    asn_info: crate::net::maxmind_db::MaxmindDb::lookup(source.ip()),
-                                    contents: buf[..size].to_vec(),
-                                    source,
-                                };
-
-                                if let Some(last_received_at) = last_received_at {
-                                    crate::metrics::packet_jitter(
-                                        crate::metrics::READ,
-                                        packet.asn_info.as_ref(),
-                                    )
-                                        .set(packet.received_at - last_received_at);
+            uring_inner_spawn!(async move {
+                is_ready.notify_one();
+                loop {
+                    tokio::select! {
+                        result = upstream_receiver.recv() => {
+                            match result {
+                                Err(error) => {
+                                    tracing::trace!(%error, "error receiving packet");
+                                    crate::metrics::errors_total(
+                                        crate::metrics::WRITE,
+                                        &error.to_string(),
+                                        None,
+                                        )
+                                        .inc();
                                 }
-                                last_received_at = Some(packet.received_at);
-
-                                Self::process_task(packet, source, worker_id, &config, &sessions, &error_sender).await;
-                            }
-                            Err(error) => {
-                                tracing::error!(%error, "error receiving packet");
-                                return;
+                                Ok((data, asn_info, send_addr)) => {
+                                    let (result, _) = send_socket.send_to(data, send_addr).await;
+                                    let asn_info = asn_info.as_ref();
+                                    match result {
+                                        Ok(size) => {
+                                            crate::metrics::packets_total(crate::metrics::WRITE, asn_info)
+                                                .inc();
+                                            crate::metrics::bytes_total(crate::metrics::WRITE, asn_info)
+                                                .inc_by(size as u64);
+                                        }
+                                        Err(error) => {
+                                            let source = error.to_string();
+                                            crate::metrics::errors_total(
+                                                crate::metrics::WRITE,
+                                                &source,
+                                                asn_info,
+                                                )
+                                                .inc();
+                                            crate::metrics::packets_dropped_total(
+                                                crate::metrics::WRITE,
+                                                &source,
+                                                asn_info,
+                                                )
+                                                .inc();
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
                 }
+            });
+
+            loop {
+                let (result, new_buf) = socket.recv_from(recv_buf).await;
+                recv_buf = new_buf;
+                match result {
+                    Ok((size, mut source)) => {
+                        crate::net::to_canonical(&mut source);
+                        let packet = DownstreamPacket {
+                            received_at: chrono::Utc::now().timestamp_nanos_opt().unwrap(),
+                            asn_info: crate::net::maxmind_db::MaxmindDb::lookup(source.ip()),
+                            contents: recv_buf[..size].to_vec(),
+                            source,
+                        };
+
+                        if let Some(last_received_at) = last_received_at {
+                            crate::metrics::packet_jitter(
+                                crate::metrics::READ,
+                                packet.asn_info.as_ref(),
+                            )
+                            .set(packet.received_at - last_received_at);
+                        }
+                        last_received_at = Some(packet.received_at);
+
+                        Self::process_task(
+                            packet,
+                            source,
+                            worker_id,
+                            &config,
+                            &sessions,
+                            &error_sender,
+                        )
+                        .await;
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "error receiving packet");
+                        return;
+                    }
+                }
             }
         });
+
+        notify
     }
 
     #[inline]
@@ -362,14 +434,10 @@ impl DownstreamReceiveWorkerConfig {
         );
 
         let timer = crate::metrics::processing_time(crate::metrics::READ).start_timer();
-
         let asn_info = packet.asn_info.clone();
         let asn_info = asn_info.as_ref();
         match Self::process_downstream_received_packet(packet, config, sessions).await {
-            Ok(size) => {
-                crate::metrics::packets_total(crate::metrics::READ, asn_info).inc();
-                crate::metrics::bytes_total(crate::metrics::READ, asn_info).inc_by(size as u64);
-            }
+            Ok(()) => {}
             Err(error) => {
                 let discriminant = PipelineErrorDiscriminants::from(&error).to_string();
                 crate::metrics::errors_total(crate::metrics::READ, &discriminant, asn_info).inc();
@@ -392,8 +460,9 @@ impl DownstreamReceiveWorkerConfig {
         packet: DownstreamPacket,
         config: &Arc<Config>,
         sessions: &Arc<SessionPool>,
-    ) -> Result<usize, PipelineError> {
-        if !config.clusters.read().has_endpoints() {
+    ) -> Result<(), PipelineError> {
+        let endpoints: Vec<_> = config.clusters.read().endpoints().collect();
+        if endpoints.is_empty() {
             return Err(PipelineError::NoUpstreamEndpoints);
         }
 
@@ -404,7 +473,6 @@ impl DownstreamReceiveWorkerConfig {
             packet.contents,
         );
         filters.read(&mut context).await?;
-        let mut bytes_written = 0;
 
         for endpoint in context.destinations.iter() {
             let session_key = SessionKey {
@@ -412,12 +480,16 @@ impl DownstreamReceiveWorkerConfig {
                 dest: endpoint.address.to_socket_addr().await?,
             };
 
-            bytes_written += sessions
-                .send(session_key, packet.asn_info.clone(), &context.contents)
+            sessions
+                .send(
+                    session_key,
+                    packet.asn_info.clone(),
+                    context.contents.clone(),
+                )
                 .await?;
         }
 
-        Ok(bytes_written)
+        Ok(())
     }
 }
 
@@ -432,6 +504,8 @@ pub enum PipelineError {
     Session(#[from] eyre::Error),
     #[error("OS level error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Channel closed")]
+    ChannelClosed,
 }
 
 #[cfg(test)]
@@ -463,14 +537,15 @@ mod tests {
         config.clusters.modify(|clusters| {
             clusters.insert_default(
                 [
-                    Endpoint::new(endpoint1.socket.local_ipv4_addr().unwrap().into()),
-                    Endpoint::new(endpoint2.socket.local_ipv6_addr().unwrap().into()),
+                    Endpoint::new(endpoint1.socket.local_addr().unwrap().into()),
+                    Endpoint::new(endpoint2.socket.local_addr().unwrap().into()),
                 ]
                 .into(),
             );
         });
 
         t.run_server(config, proxy, None);
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         tracing::trace!(%local_addr, "sending hello");
         let msg = "hello";
@@ -515,7 +590,7 @@ mod tests {
             clusters.insert_default([Endpoint::new(dest.into())].into());
         });
         t.run_server(config, proxy, None);
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let msg = "hello";
         tracing::debug!(%local_addr, "sending packet");
@@ -563,6 +638,7 @@ mod tests {
             },
             None,
         );
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         let msg = "hello";
         endpoint
@@ -585,35 +661,28 @@ mod tests {
         let t = TestHelper::default();
 
         let (error_sender, _error_receiver) = mpsc::unbounded_channel();
-        let socket = Arc::new(create_socket().await);
-        let addr = socket.local_ipv6_addr().unwrap();
+        let addr = crate::test::available_addr(&AddressType::Random).await;
         let endpoint = t.open_socket_and_recv_single_packet().await;
         let msg = "hello";
         let config = Arc::new(Config::default());
         config.clusters.modify(|clusters| {
-            clusters.insert_default([endpoint.socket.local_ipv6_addr().unwrap().into()].into())
+            clusters.insert_default([endpoint.socket.local_addr().unwrap().into()].into())
         });
+        let (tx, rx) = async_channel::unbounded();
+        let (_shutdown_tx, shutdown_rx) =
+            crate::make_shutdown_channel(crate::ShutdownKind::Testing);
 
         // we'll test a single DownstreamReceiveWorkerConfig
         DownstreamReceiveWorkerConfig {
             worker_id: 1,
-            socket: socket.clone(),
+            port: addr.port(),
+            upstream_receiver: rx.clone(),
             config: config.clone(),
             error_sender,
-            sessions: SessionPool::new(
-                config,
-                Arc::new(
-                    DualStackLocalSocket::new(
-                        crate::test::available_addr(&AddressType::Random)
-                            .await
-                            .port(),
-                    )
-                    .unwrap(),
-                ),
-                crate::make_shutdown_channel(crate::ShutdownKind::Testing).1,
-            ),
+            sessions: SessionPool::new(config, tx, shutdown_rx),
         }
         .spawn();
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
         let socket = create_socket().await;
         socket.send_to(msg.as_bytes(), &addr).await.unwrap();
@@ -643,29 +712,20 @@ mod tests {
         config.clusters.modify(|clusters| {
             clusters.insert_default(
                 [crate::net::endpoint::Endpoint::from(
-                    endpoint.socket.local_ipv4_addr().unwrap(),
+                    endpoint.socket.local_addr().unwrap(),
                 )]
                 .into(),
             )
         });
 
-        let shared_socket = Arc::new(
-            DualStackLocalSocket::new(
-                crate::test::available_addr(&AddressType::Random)
-                    .await
-                    .port(),
-            )
-            .unwrap(),
-        );
-        let sessions = SessionPool::new(
-            config.clone(),
-            shared_socket.clone(),
-            crate::make_shutdown_channel(crate::ShutdownKind::Testing).1,
-        );
+        let (tx, rx) = async_channel::unbounded();
+        let (_shutdown_tx, shutdown_rx) =
+            crate::make_shutdown_channel(crate::ShutdownKind::Testing);
 
-        proxy
-            .run_recv_from(&config, &sessions, shared_socket)
-            .unwrap();
+        let sessions = SessionPool::new(config.clone(), tx, shutdown_rx);
+
+        proxy.run_recv_from(&config, &sessions, rx).unwrap();
+        tokio::time::sleep(Duration::from_millis(500)).await;
 
         let socket = create_socket().await;
         socket.send_to(msg.as_bytes(), &local_addr).await.unwrap();

--- a/src/cli/proxy/sessions.rs
+++ b/src/cli/proxy/sessions.rs
@@ -562,9 +562,8 @@ impl Loggable for Error {
 mod tests {
     use super::*;
     use crate::{
-        make_shutdown_channel,
         test::{available_addr, AddressType, TestHelper},
-        ShutdownKind, ShutdownTx,
+        ShutdownTx,
     };
     use std::sync::Arc;
 

--- a/src/cli/proxy/sessions.rs
+++ b/src/cli/proxy/sessions.rs
@@ -21,7 +21,10 @@ use std::{
     time::Duration,
 };
 
-use tokio::{sync::RwLock, time::Instant};
+use tokio::{
+    sync::{mpsc, RwLock},
+    time::Instant,
+};
 
 use crate::{
     config::Config, filters::Filter, net::maxmind_db::IpNetEntry, net::DualStackLocalSocket,
@@ -31,6 +34,9 @@ use crate::{
 pub(crate) mod metrics;
 
 pub type SessionMap = crate::collections::ttl::TtlMap<SessionKey, Session>;
+type UpstreamSender = mpsc::UnboundedSender<(Vec<u8>, Option<IpNetEntry>, SocketAddr)>;
+type DownstreamSender = async_channel::Sender<(Vec<u8>, Option<IpNetEntry>, SocketAddr)>;
+pub type DownstreamReceiver = async_channel::Receiver<(Vec<u8>, Option<IpNetEntry>, SocketAddr)>;
 
 /// A data structure that is responsible for holding sessions, and pooling
 /// sockets between them. This means that we only provide new unique sockets
@@ -41,10 +47,10 @@ pub type SessionMap = crate::collections::ttl::TtlMap<SessionKey, Session>;
 /// send back to the original client.
 #[derive(Debug)]
 pub struct SessionPool {
-    ports_to_sockets: RwLock<HashMap<u16, Arc<DualStackLocalSocket>>>,
+    ports_to_sockets: RwLock<HashMap<u16, UpstreamSender>>,
     storage: Arc<RwLock<SocketStorage>>,
     session_map: SessionMap,
-    downstream_socket: Arc<DualStackLocalSocket>,
+    downstream_sender: DownstreamSender,
     shutdown_rx: ShutdownRx,
     config: Arc<Config>,
 }
@@ -64,7 +70,7 @@ impl SessionPool {
     /// to release their sockets back to the parent.
     pub fn new(
         config: Arc<Config>,
-        downstream_socket: Arc<DualStackLocalSocket>,
+        downstream_sender: DownstreamSender,
         shutdown_rx: ShutdownRx,
     ) -> Arc<Self> {
         const SESSION_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
@@ -72,7 +78,7 @@ impl SessionPool {
 
         Arc::new(Self {
             config,
-            downstream_socket,
+            downstream_sender,
             shutdown_rx,
             ports_to_sockets: <_>::default(),
             storage: <_>::default(),
@@ -85,86 +91,148 @@ impl SessionPool {
         self: &'pool Arc<Self>,
         key: SessionKey,
         asn_info: Option<IpNetEntry>,
-    ) -> Result<Arc<DualStackLocalSocket>, super::PipelineError> {
+    ) -> Result<UpstreamSender, super::PipelineError> {
         tracing::trace!(source=%key.source, dest=%key.dest, "creating new socket for session");
-        let socket = DualStackLocalSocket::new(0).map(Arc::new)?;
-        let port = socket.local_ipv4_addr()?.port();
-        self.ports_to_sockets
-            .write()
-            .await
-            .insert(port, socket.clone());
+        let raw_socket = crate::net::raw_socket_with_reuse(0)?;
+        let port = raw_socket
+            .local_addr()?
+            .as_socket()
+            .ok_or_else(|| eyre::eyre!("couldn't get socket address from raw socket"))
+            .map_err(super::PipelineError::Session)?
+            .port();
+        let (tx, mut downstream_receiver) = mpsc::unbounded_channel();
+        self.ports_to_sockets.write().await.insert(port, tx.clone());
 
-        let upstream_socket = socket.clone();
         let pool = self.clone();
-        tokio::spawn(async move {
+
+        uring_spawn!(async move {
             let mut buf: Vec<u8> = vec![0; 65535];
             let mut last_received_at = None;
             let mut shutdown_rx = pool.shutdown_rx.clone();
+            cfg_if::cfg_if! {
+                if #[cfg(target_os = "linux")] {
+                    let socket = std::rc::Rc::new(DualStackLocalSocket::from_raw(raw_socket));
+                } else {
+                    let socket = std::sync::Arc::new(DualStackLocalSocket::from_raw(raw_socket));
+                }
+            };
+            let socket2 = socket.clone();
+
+            uring_inner_spawn!(async move {
+                loop {
+                    match downstream_receiver.recv().await {
+                        None => {
+                            crate::metrics::errors_total(
+                                crate::metrics::WRITE,
+                                "downstream channel closed",
+                                None,
+                            )
+                            .inc();
+                        }
+                        Some((data, asn_info, send_addr)) => {
+                            tracing::trace!(%send_addr, contents = %crate::codec::base64::encode(&data), "sending packet upstream");
+                            let (result, _) = socket2.send_to(data, send_addr).await;
+                            let asn_info = asn_info.as_ref();
+                            match result {
+                                Ok(size) => {
+                                    crate::metrics::packets_total(crate::metrics::READ, asn_info)
+                                        .inc();
+                                    crate::metrics::bytes_total(crate::metrics::READ, asn_info)
+                                        .inc_by(size as u64);
+                                }
+                                Err(error) => {
+                                    tracing::trace!(%error, "sending packet upstream failed");
+                                    let source = error.to_string();
+                                    crate::metrics::errors_total(
+                                        crate::metrics::READ,
+                                        &source,
+                                        asn_info,
+                                    )
+                                    .inc();
+                                    crate::metrics::packets_dropped_total(
+                                        crate::metrics::READ,
+                                        &source,
+                                        asn_info,
+                                    )
+                                    .inc();
+                                }
+                            }
+                        }
+                    }
+                }
+            });
 
             loop {
                 tokio::select! {
-                    received = upstream_socket.recv_from(&mut buf) => {
-                        match received {
+                    received = socket.recv_from(buf) => {
+                        let (result, new_buf) = received;
+                        buf = new_buf;
+                        match result {
                             Err(error) => {
                                 tracing::trace!(%error, "error receiving packet");
                                 crate::metrics::errors_total(crate::metrics::WRITE, &error.to_string(), None).inc();
                             },
-                            Ok((size, mut recv_addr)) => {
-                                let received_at = chrono::Utc::now().timestamp_nanos_opt();
-                                crate::net::to_canonical(&mut recv_addr);
-                                tracing::trace!(%recv_addr, %size, "received packet");
-                                let (downstream_addr, asn_info): (SocketAddr, Option<IpNetEntry>) = {
-                                    let storage = pool.storage.read().await;
-                                    let Some(downstream_addr) = storage.destination_to_sources.get(&(recv_addr, port)) else {
-                                        tracing::warn!(address=%recv_addr, "received traffic from a server that has no downstream");
-                                        continue;
-                                    };
-                                    let asn_info = storage.sources_to_asn_info.get(downstream_addr);
-
-                                    (*downstream_addr, asn_info.cloned())
-                                };
-
-                                let asn_info = asn_info.as_ref();
-                                if let (Some(last_received_at), Some(received_at)) = (last_received_at, received_at) {
-                                    crate::metrics::packet_jitter(crate::metrics::WRITE, asn_info).set(received_at - last_received_at);
-                                }
-                                last_received_at = received_at;
-
-                                crate::metrics::packets_total(crate::metrics::WRITE, asn_info).inc();
-                                crate::metrics::bytes_total(crate::metrics::WRITE, asn_info).inc_by(size as u64);
-
-                                let timer = crate::metrics::processing_time(crate::metrics::WRITE).start_timer();
-                                let result = Self::process_recv_packet(
-                                    pool.config.clone(),
-                                    &pool.downstream_socket,
-                                    recv_addr,
-                                    downstream_addr,
-                                    &buf[..size],
-                                ).await;
-                                timer.stop_and_record();
-                                if let Err(error) = result {
-                                    error.log();
-                                    let label = format!("proxy::Session::process_recv_packet: {error}");
-                                    crate::metrics::packets_dropped_total(
-                                        crate::metrics::WRITE,
-                                        &label,
-                                        asn_info
-                                    ).inc();
-                                    crate::metrics::errors_total(crate::metrics::WRITE, &label, asn_info).inc();
-                                }
-                            }
-                        };
+                            Ok((size, recv_addr)) => pool.process_received_upstream_packet(&buf[..size], recv_addr, port, &mut last_received_at).await,
+                        }
                     }
                     _ = shutdown_rx.changed() => {
                         tracing::debug!("Closing upstream socket loop");
                         return;
                     }
-                };
+                }
             }
         });
 
-        self.create_session_from_existing_socket(key, socket, port, asn_info)
+        self.create_session_from_existing_socket(key, tx, port, asn_info)
             .await
+    }
+
+    async fn process_received_upstream_packet(
+        self: &Arc<Self>,
+        packet: &[u8],
+        mut recv_addr: SocketAddr,
+        port: u16,
+        last_received_at: &mut Option<i64>,
+    ) {
+        let received_at = chrono::Utc::now().timestamp_nanos_opt().unwrap();
+        crate::net::to_canonical(&mut recv_addr);
+        let (downstream_addr, asn_info): (SocketAddr, Option<IpNetEntry>) = {
+            let storage = self.storage.read().await;
+            let Some(downstream_addr) = storage.destination_to_sources.get(&(recv_addr, port))
+            else {
+                tracing::debug!(address=%recv_addr, "received traffic from a server that has no downstream");
+                return;
+            };
+            let asn_info = storage.sources_to_asn_info.get(downstream_addr);
+
+            (*downstream_addr, asn_info.cloned())
+        };
+
+        let asn_info = asn_info.as_ref();
+
+        if let Some(last_received_at) = last_received_at {
+            crate::metrics::packet_jitter(crate::metrics::WRITE, asn_info)
+                .set(received_at - *last_received_at);
+        }
+        *last_received_at = Some(received_at);
+
+        let timer = crate::metrics::processing_time(crate::metrics::WRITE).start_timer();
+        let result = Self::process_recv_packet(
+            self.config.clone(),
+            &self.downstream_sender,
+            recv_addr,
+            downstream_addr,
+            asn_info,
+            packet,
+        )
+        .await;
+        timer.stop_and_record();
+        if let Err(error) = result {
+            error.log();
+            let label = format!("proxy::Session::process_recv_packet: {error}");
+            crate::metrics::packets_dropped_total(crate::metrics::WRITE, &label, asn_info).inc();
+            crate::metrics::errors_total(crate::metrics::WRITE, &label, asn_info).inc();
+        }
     }
 
     /// Returns a reference to an existing session mapped to `key`, otherwise
@@ -175,12 +243,12 @@ impl SessionPool {
         self: &'pool Arc<Self>,
         key @ SessionKey { dest, .. }: SessionKey,
         asn_info: Option<IpNetEntry>,
-    ) -> Result<Arc<DualStackLocalSocket>, super::PipelineError> {
+    ) -> Result<UpstreamSender, super::PipelineError> {
         tracing::trace!(source=%key.source, dest=%key.dest, "SessionPool::get");
         // If we already have a session for the key pairing, return that session.
         if let Some(entry) = self.session_map.get(&key) {
             tracing::trace!("returning existing session");
-            return Ok(entry.socket.clone());
+            return Ok(entry.upstream_sender.clone());
         }
 
         // If there's a socket_set available, it means there are sockets
@@ -195,7 +263,7 @@ impl SessionPool {
             } else {
                 // Where we have no allocated sockets for a destination, assign
                 // the first available one.
-                let (port, socket) = self
+                let (port, sender) = self
                     .ports_to_sockets
                     .read()
                     .await
@@ -207,7 +275,7 @@ impl SessionPool {
                     })
                     .map_err(super::PipelineError::Session)?;
 
-                self.create_session_from_existing_socket(key, socket, port, asn_info)
+                self.create_session_from_existing_socket(key, sender, port, asn_info)
                     .await
             };
         };
@@ -244,10 +312,10 @@ impl SessionPool {
     async fn create_session_from_existing_socket<'session>(
         self: &'session Arc<Self>,
         key: SessionKey,
-        upstream_socket: Arc<DualStackLocalSocket>,
+        upstream_sender: UpstreamSender,
         socket_port: u16,
         asn_info: Option<IpNetEntry>,
-    ) -> Result<Arc<DualStackLocalSocket>, super::PipelineError> {
+    ) -> Result<UpstreamSender, super::PipelineError> {
         tracing::trace!(source=%key.source, dest=%key.dest, "reusing socket for session");
         let mut storage = self.storage.write().await;
         storage
@@ -273,7 +341,7 @@ impl SessionPool {
         drop(storage);
         let session = Session::new(
             key,
-            upstream_socket.clone(),
+            upstream_sender.clone(),
             socket_port,
             self.clone(),
             asn_info,
@@ -281,17 +349,18 @@ impl SessionPool {
         tracing::trace!("inserting session into map");
         self.session_map.insert(key, session);
         tracing::trace!("session inserted");
-        Ok(upstream_socket)
+        Ok(upstream_sender)
     }
 
     /// process_recv_packet processes a packet that is received by this session.
     async fn process_recv_packet(
         config: Arc<crate::Config>,
-        downstream_socket: &Arc<DualStackLocalSocket>,
+        downstream_sender: &DownstreamSender,
         source: SocketAddr,
         dest: SocketAddr,
+        asn_info: Option<&IpNetEntry>,
         packet: &[u8],
-    ) -> Result<usize, Error> {
+    ) -> Result<(), Error> {
         tracing::trace!(%source, %dest, contents = %crate::codec::base64::encode(packet), "received packet from upstream");
 
         let mut context =
@@ -299,12 +368,13 @@ impl SessionPool {
 
         config.filters.load().write(&mut context).await?;
 
-        let packet = context.contents.as_ref();
-        tracing::trace!(%source, %dest, contents = %crate::codec::base64::encode(packet), "sending packet downstream");
-        downstream_socket
-            .send_to(packet, &dest)
+        let packet = context.contents;
+        tracing::trace!(%source, %dest, contents = %crate::codec::base64::encode(&packet), "sending packet downstream");
+        downstream_sender
+            .send((packet, asn_info.cloned(), dest))
             .await
-            .map_err(Error::SendTo)
+            .map_err(|_| Error::ChannelClosed)?;
+        Ok(())
     }
 
     /// Returns a map of active sessions.
@@ -317,13 +387,12 @@ impl SessionPool {
         self: &Arc<Self>,
         key: SessionKey,
         asn_info: Option<IpNetEntry>,
-        packet: &[u8],
-    ) -> Result<usize, super::PipelineError> {
-        self.get(key, asn_info)
+        packet: Vec<u8>,
+    ) -> Result<(), super::PipelineError> {
+        self.get(key, asn_info.clone())
             .await?
-            .send_to(packet, key.dest)
-            .await
-            .map_err(From::from)
+            .send((packet, asn_info, key.dest))
+            .map_err(|_| super::PipelineError::ChannelClosed)
     }
 
     /// Returns whether the pool contains any sockets allocated to a destination.
@@ -399,7 +468,7 @@ pub struct Session {
     /// The socket port of the session.
     socket_port: u16,
     /// The socket of the session.
-    socket: Arc<DualStackLocalSocket>,
+    upstream_sender: UpstreamSender,
     /// The GeoIP information of the source.
     asn_info: Option<IpNetEntry>,
     /// The socket pool of the session.
@@ -409,14 +478,14 @@ pub struct Session {
 impl Session {
     pub fn new(
         key: SessionKey,
-        socket: Arc<DualStackLocalSocket>,
+        upstream_sender: UpstreamSender,
         socket_port: u16,
         pool: Arc<SessionPool>,
         asn_info: Option<IpNetEntry>,
     ) -> Result<Self, super::PipelineError> {
         let s = Self {
             key,
-            socket,
+            upstream_sender,
             pool,
             socket_port,
             asn_info,
@@ -474,22 +543,15 @@ impl From<(SocketAddr, SocketAddr)> for SessionKey {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("failed to send packet downstream: {0}")]
-    SendTo(std::io::Error),
+    #[error("downstream channel closed")]
+    ChannelClosed,
     #[error("filter {0}")]
     Filter(#[from] crate::filters::FilterError),
 }
 
 impl Loggable for Error {
     fn log(&self) {
-        match self {
-            Self::SendTo(error) => {
-                tracing::error!(kind=%error.kind(), "{}", self)
-            }
-            Self::Filter(_) => {
-                tracing::error!("{}", self);
-            }
-        }
+        tracing::error!("{}", self);
     }
 }
 
@@ -503,28 +565,21 @@ mod tests {
     };
     use std::sync::Arc;
 
-    async fn new_pool(config: impl Into<Option<Config>>) -> (Arc<SessionPool>, ShutdownTx) {
-        let (tx, rx) = make_shutdown_channel(ShutdownKind::Testing);
+    async fn new_pool(
+        config: impl Into<Option<Config>>,
+    ) -> (Arc<SessionPool>, ShutdownTx, DownstreamReceiver) {
+        let (tx, rx) = crate::make_shutdown_channel(crate::ShutdownKind::Testing);
+        let (sender, receiver) = async_channel::unbounded();
         (
-            SessionPool::new(
-                Arc::new(config.into().unwrap_or_default()),
-                Arc::new(
-                    DualStackLocalSocket::new(
-                        crate::test::available_addr(&AddressType::Random)
-                            .await
-                            .port(),
-                    )
-                    .unwrap(),
-                ),
-                rx,
-            ),
+            SessionPool::new(Arc::new(config.into().unwrap_or_default()), sender, rx),
             tx,
+            receiver,
         )
     }
 
     #[tokio::test]
     async fn insert_and_release_single_socket() {
-        let (pool, _sender) = new_pool(None).await;
+        let (pool, _sender, _receiver) = new_pool(None).await;
         let key = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -540,7 +595,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_and_release_multiple_sockets() {
-        let (pool, _sender) = new_pool(None).await;
+        let (pool, _sender, _receiver) = new_pool(None).await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -565,7 +620,7 @@ mod tests {
 
     #[tokio::test]
     async fn same_address_uses_different_sockets() {
-        let (pool, _sender) = new_pool(None).await;
+        let (pool, _sender, _receiver) = new_pool(None).await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -590,7 +645,7 @@ mod tests {
 
     #[tokio::test]
     async fn different_addresses_uses_same_socket() {
-        let (pool, _sender) = new_pool(None).await;
+        let (pool, _sender, _receiver) = new_pool(None).await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -613,7 +668,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_safe_same_destination() {
-        let (pool, _sender) = new_pool(None).await;
+        let (pool, _sender, _receiver) = new_pool(None).await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -638,7 +693,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_safe_different_destination() {
-        let (pool, _sender) = new_pool(None).await;
+        let (pool, _sender, _receiver) = new_pool(None).await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -671,22 +726,18 @@ mod tests {
         let socket = tokio::net::UdpSocket::bind(source).await.unwrap();
         let mut source = socket.local_addr().unwrap();
         crate::test::map_addr_to_localhost(&mut source);
-        let (pool, _sender) = new_pool(None).await;
+        let (pool, _sender, receiver) = new_pool(None).await;
 
         let key: SessionKey = (source, dest).into();
         let msg = b"helloworld";
 
-        pool.send(key, None, msg).await.unwrap();
+        pool.send(key, None, msg.to_vec()).await.unwrap();
 
-        let mut buf = [0u8; 1024];
-        let (size, _) = tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            socket.recv_from(&mut buf),
-        )
-        .await
-        .unwrap()
-        .unwrap();
+        let (data, _, _) = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
+            .await
+            .unwrap()
+            .unwrap();
 
-        assert_eq!(msg, &buf[..size]);
+        assert_eq!(msg, &*data);
     }
 }

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -17,7 +17,6 @@
 //! Logic for parsing and generating Quilkin Control Message Protocol (QCMP) messages.
 
 use nom::bytes::complete;
-use tracing::Instrument;
 
 use crate::net::DualStackLocalSocket;
 
@@ -33,58 +32,60 @@ const DISCRIMINANT_LEN: usize = 1;
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 pub async fn spawn(port: u16) -> crate::Result<()> {
-    let socket = DualStackLocalSocket::new(port)?;
-    let v4_addr = socket.local_ipv4_addr()?;
-    let v6_addr = socket.local_ipv6_addr()?;
-    tokio::spawn(
-        async move {
-            // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
-            // packet, which is the maximum value of 16 a bit integer.
-            let mut buf = vec![0; 1 << 16];
-            let mut output_buf = Vec::new();
-
-            loop {
-                tracing::debug!("awaiting qcmp packets");
-
-                match socket.recv_from(&mut buf).await {
-                    Ok((size, source)) => {
-                        let received_at = chrono::Utc::now().timestamp_nanos_opt().unwrap();
-                        let command = match Protocol::parse(&buf[..size]) {
-                            Ok(Some(command)) => command,
-                            Ok(None) => {
-                                tracing::debug!("rejected non-qcmp packet");
-                                continue;
-                            }
-                            Err(error) => {
-                                tracing::debug!(%error, "rejected malformed packet");
-                                continue;
-                            }
-                        };
-
-                        let Protocol::Ping {
-                            client_timestamp,
-                            nonce,
-                        } = command
-                        else {
-                            tracing::warn!("rejected unsupported QCMP packet");
+    uring_spawn!(async move {
+        // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
+        // packet, which is the maximum value of 16 a bit integer.
+        let mut input_buf = vec![0; 1 << 16];
+        let mut output_buf = Vec::new();
+        let socket = DualStackLocalSocket::new(port).unwrap();
+        loop {
+            match socket.recv_from(input_buf).await {
+                (Ok((size, source)), new_input_buf) => {
+                    input_buf = new_input_buf;
+                    let received_at = chrono::Utc::now().timestamp_nanos_opt().unwrap();
+                    let command = match Protocol::parse(&input_buf[..size]) {
+                        Ok(Some(command)) => command,
+                        Ok(None) => {
+                            tracing::debug!("rejected non-qcmp packet");
                             continue;
-                        };
-
-                        Protocol::ping_reply(nonce, client_timestamp, received_at)
-                            .encode_into_buffer(&mut output_buf);
-
-                        if let Err(error) = socket.send_to(&output_buf, &source).await {
-                            tracing::warn!(%error, "error responding to ping");
                         }
+                        Err(error) => {
+                            tracing::debug!(%error, "rejected malformed packet");
+                            continue;
+                        }
+                    };
 
-                        output_buf.clear();
-                    }
-                    Err(error) => tracing::warn!(%error, "error receiving packet"),
+                    let Protocol::Ping {
+                        client_timestamp,
+                        nonce,
+                    } = command
+                    else {
+                        tracing::warn!("rejected unsupported QCMP packet");
+                        continue;
+                    };
+
+                    Protocol::ping_reply(nonce, client_timestamp, received_at)
+                        .encode_into_buffer(&mut output_buf);
+
+                    let mut new_output_buf = match socket.send_to(output_buf, source).await {
+                        (Ok(_), buf) => buf,
+                        (Err(error), buf) => {
+                            tracing::warn!(%error, "error responding to ping");
+                            buf
+                        }
+                    };
+
+                    new_output_buf.clear();
+                    output_buf = new_output_buf;
                 }
-            }
+                (Err(error), new_input_buf) => {
+                    tracing::warn!(%error, "error receiving packet");
+                    input_buf = new_input_buf
+                }
+            };
         }
-        .instrument(tracing::debug_span!("qcmp_task", %v4_addr, %v6_addr)),
-    );
+    });
+
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,7 +93,7 @@ impl Config {
             let value: ClusterMap = serde_json::from_value(value)?;
             self.clusters.modify(|clusters| {
                 for cluster in value.iter() {
-                    clusters.merge(cluster.key().clone(), cluster.value().clone());
+                    clusters.insert(cluster.key().clone(), cluster.value().clone());
                 }
 
                 if let Some(locality) = locality {
@@ -170,7 +170,7 @@ impl Config {
                 self.filters.store(Arc::new(chain.try_into()?));
             }
             Resource::Cluster(cluster) => {
-                self.clusters.write().merge(
+                self.clusters.write().insert(
                     cluster.locality.clone().map(From::from),
                     cluster
                         .endpoints

--- a/src/config/providers/k8s.rs
+++ b/src/config/providers/k8s.rs
@@ -121,10 +121,7 @@ pub fn update_endpoints_from_gameservers(
                     };
                     tracing::debug!(endpoint=%serde_json::to_value(&endpoint).unwrap(), "Adding endpoint");
                     config.clusters.write()
-                        .entry(locality.clone())
-                        .or_default()
-                        .value_mut()
-                        .replace(endpoint);
+                        .replace(locality.clone(), endpoint);
                 }
 
                 Event::Restarted(servers) => {
@@ -149,7 +146,7 @@ pub fn update_endpoints_from_gameservers(
                         "Restarting with endpoints"
                     );
 
-                    config.clusters.write().merge(locality.clone(), servers);
+                    config.clusters.write().insert(locality.clone(), servers);
                 }
 
                 Event::Deleted(server) => {

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -83,14 +83,15 @@ pub use self::chain::FilterChain;
 ///
 /// struct Greet;
 ///
+/// /// Prepends data on each packet
 /// #[async_trait::async_trait]
 /// impl Filter for Greet {
 ///     async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
-///         ctx.contents.splice(0..0, b"Hello ".into_iter().copied());
+///         ctx.contents.prepend_from_slice(b"Hello ");
 ///         Ok(())
 ///     }
 ///     async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
-///         ctx.contents.splice(0..0, b"Goodbye ".into_iter().copied());
+///         ctx.contents.prepend_from_slice(b"Goodbye ");
 ///         Ok(())
 ///     }
 /// }

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -20,7 +20,7 @@ mod regex;
 
 crate::include_proto!("quilkin.filters.capture.v1alpha1");
 
-use crate::{filters::prelude::*, net::endpoint::metadata};
+use crate::{filters::prelude::*, net::endpoint::metadata, pool::PoolBuffer};
 
 use self::quilkin::filters::capture::v1alpha1 as proto;
 
@@ -34,7 +34,7 @@ pub use self::{
 pub trait CaptureStrategy {
     /// Capture packet data from the contents, and optionally returns a value if
     /// anything was captured.
-    fn capture(&self, contents: &mut Vec<u8>) -> Option<metadata::Value>;
+    fn capture(&self, contents: &mut PoolBuffer) -> Option<metadata::Value>;
 }
 
 pub struct Capture {
@@ -93,7 +93,7 @@ mod tests {
     use crate::{
         filters::metadata::CAPTURED_BYTES,
         net::endpoint::{metadata::Value, Endpoint},
-        test::assert_write_no_change,
+        test::{alloc_buffer, assert_write_no_change},
     };
 
     use super::*;
@@ -166,7 +166,7 @@ mod tests {
             .read(&mut ReadContext::new(
                 endpoints.into(),
                 (std::net::Ipv4Addr::LOCALHOST, 80).into(),
-                "abc".to_string().into_bytes(),
+                alloc_buffer(b"abc"),
             ))
             .await
             .is_err());
@@ -190,10 +190,10 @@ mod tests {
         let end = Regex {
             pattern: ::regex::bytes::Regex::new(".{3}$").unwrap(),
         };
-        let mut contents = b"helloabc".to_vec();
+        let mut contents = alloc_buffer(b"helloabc");
         let result = end.capture(&mut contents).unwrap();
         assert_eq!(Value::Bytes(b"abc".to_vec().into()), result);
-        assert_eq!(b"helloabc".to_vec(), contents);
+        assert_eq!(b"helloabc", &*contents);
     }
 
     #[test]
@@ -202,16 +202,16 @@ mod tests {
             size: 3,
             remove: false,
         };
-        let mut contents = b"helloabc".to_vec();
+        let mut contents = alloc_buffer(b"helloabc");
         let result = end.capture(&mut contents).unwrap();
         assert_eq!(Value::Bytes(b"abc".to_vec().into()), result);
-        assert_eq!(b"helloabc".to_vec(), contents);
+        assert_eq!(b"helloabc", &*contents);
 
         end.remove = true;
 
         let result = end.capture(&mut contents).unwrap();
         assert_eq!(Value::Bytes(b"abc".to_vec().into()), result);
-        assert_eq!(b"hello".to_vec(), contents);
+        assert_eq!(b"hello", &*contents);
     }
 
     #[test]
@@ -220,17 +220,17 @@ mod tests {
             size: 3,
             remove: false,
         };
-        let mut contents = b"abchello".to_vec();
+        let mut contents = alloc_buffer(b"abchello");
 
         let result = beg.capture(&mut contents);
         assert_eq!(Some(Value::Bytes(b"abc".to_vec().into())), result);
-        assert_eq!(b"abchello".to_vec(), contents);
+        assert_eq!(b"abchello", &*contents);
 
         beg.remove = true;
 
         let result = beg.capture(&mut contents);
         assert_eq!(Some(Value::Bytes(b"abc".to_vec().into())), result);
-        assert_eq!(b"hello".to_vec(), contents);
+        assert_eq!(b"hello", &*contents);
     }
 
     async fn assert_end_strategy<F>(filter: &F, key: metadata::Key, remove: bool)
@@ -243,7 +243,7 @@ mod tests {
         let mut context = ReadContext::new(
             endpoints.into(),
             "127.0.0.1:80".parse().unwrap(),
-            "helloabc".to_string().into_bytes(),
+            alloc_buffer(b"helloabc"),
         );
 
         filter.read(&mut context).await.unwrap();

--- a/src/filters/capture/regex.rs
+++ b/src/filters/capture/regex.rs
@@ -1,4 +1,4 @@
-use crate::net::endpoint::metadata::Value;
+use crate::{net::endpoint::metadata::Value, pool::PoolBuffer};
 
 /// Capture from the start of the packet.
 #[derive(serde::Serialize, serde::Deserialize, Debug, schemars::JsonSchema)]
@@ -10,7 +10,7 @@ pub struct Regex {
 }
 
 impl super::CaptureStrategy for Regex {
-    fn capture(&self, contents: &mut Vec<u8>) -> Option<Value> {
+    fn capture(&self, contents: &mut PoolBuffer) -> Option<Value> {
         let matches = self
             .pattern
             .find_iter(contents)

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -322,7 +322,7 @@ mod tests {
         config,
         filters::Debug,
         net::endpoint::Endpoint,
-        test::{new_test_config, TestFilter},
+        test::{alloc_buffer, new_test_config, TestFilter},
     };
 
     use super::*;
@@ -370,7 +370,7 @@ mod tests {
         let mut context = ReadContext::new(
             endpoints_fixture.clone(),
             "127.0.0.1:70".parse().unwrap(),
-            b"hello".to_vec(),
+            alloc_buffer(b"hello"),
         );
 
         config.filters.read(&mut context).await.unwrap();
@@ -394,7 +394,7 @@ mod tests {
                 .address
                 .clone(),
             "127.0.0.1:70".parse().unwrap(),
-            b"hello".to_vec(),
+            alloc_buffer(b"hello"),
         );
         config.filters.write(&mut context).await.unwrap();
 
@@ -423,7 +423,7 @@ mod tests {
         let mut context = ReadContext::new(
             endpoints_fixture.clone(),
             "127.0.0.1:70".parse().unwrap(),
-            b"hello".to_vec(),
+            alloc_buffer(b"hello"),
         );
 
         chain.read(&mut context).await.unwrap();
@@ -449,7 +449,7 @@ mod tests {
                 .address
                 .clone(),
             "127.0.0.1:70".parse().unwrap(),
-            b"hello".to_vec(),
+            alloc_buffer(b"hello"),
         );
 
         chain.write(&mut context).await.unwrap();

--- a/src/filters/compress/config.rs
+++ b/src/filters/compress/config.rs
@@ -17,7 +17,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::compressor::{Compressor, Snappy};
+use super::compressor::Compressor;
 use super::quilkin::filters::compress::v1alpha1::{
     compress::{Action as ProtoAction, ActionValue, Mode as ProtoMode, ModeValue},
     Compress as ProtoConfig,
@@ -35,10 +35,8 @@ pub enum Mode {
 }
 
 impl Mode {
-    pub(crate) fn as_compressor(&self) -> Box<dyn Compressor + Send + Sync> {
-        match self {
-            Self::Snappy => Box::from(Snappy {}),
-        }
+    pub(crate) fn as_compressor(self) -> Compressor {
+        self.into()
     }
 }
 

--- a/src/filters/concatenate.rs
+++ b/src/filters/concatenate.rs
@@ -48,10 +48,10 @@ impl Filter for Concatenate {
     async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         match self.on_read {
             Strategy::Append => {
-                ctx.contents.extend(self.bytes.iter());
+                ctx.contents.extend_from_slice(&self.bytes);
             }
             Strategy::Prepend => {
-                ctx.contents.splice(..0, self.bytes.iter().cloned());
+                ctx.contents.prepend_from_slice(&self.bytes);
             }
             Strategy::DoNothing => {}
         }
@@ -62,10 +62,10 @@ impl Filter for Concatenate {
     async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         match self.on_write {
             Strategy::Append => {
-                ctx.contents.extend(self.bytes.iter());
+                ctx.contents.extend_from_slice(&self.bytes);
             }
             Strategy::Prepend => {
-                ctx.contents.splice(..0, self.bytes.iter().cloned());
+                ctx.contents.prepend_from_slice(&self.bytes);
             }
             Strategy::DoNothing => {}
         }

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -120,6 +120,7 @@ mod tests {
 
     use crate::filters::firewall::config::PortRange;
     use crate::net::endpoint::Endpoint;
+    use crate::test::alloc_buffer;
     use tracing_test::traced_test;
 
     use super::*;
@@ -140,13 +141,13 @@ mod tests {
         let endpoints = crate::net::cluster::ClusterMap::new_default(
             [Endpoint::new((Ipv4Addr::LOCALHOST, 8080).into())].into(),
         );
-        let mut ctx = ReadContext::new(endpoints.into(), (local_ip, 80).into(), vec![]);
+        let mut ctx = ReadContext::new(endpoints.into(), (local_ip, 80).into(), alloc_buffer([]));
         assert!(firewall.read(&mut ctx).await.is_ok());
 
         let endpoints = crate::net::cluster::ClusterMap::new_default(
             [Endpoint::new((Ipv4Addr::LOCALHOST, 8080).into())].into(),
         );
-        let mut ctx = ReadContext::new(endpoints.into(), (local_ip, 2000).into(), vec![]);
+        let mut ctx = ReadContext::new(endpoints.into(), (local_ip, 2000).into(), alloc_buffer([]));
         assert!(logs_contain("quilkin::filters::firewall")); // the given name to the the logger by tracing
         assert!(logs_contain("Allow"));
 
@@ -166,11 +167,18 @@ mod tests {
 
         let local_addr: crate::net::endpoint::EndpointAddress = (Ipv4Addr::LOCALHOST, 8081).into();
 
-        let mut ctx =
-            WriteContext::new(([192, 168, 75, 20], 80).into(), local_addr.clone(), vec![]);
+        let mut ctx = WriteContext::new(
+            ([192, 168, 75, 20], 80).into(),
+            local_addr.clone(),
+            alloc_buffer([]),
+        );
         assert!(firewall.write(&mut ctx).await.is_ok());
 
-        let mut ctx = WriteContext::new(([192, 168, 77, 20], 80).into(), local_addr, vec![]);
+        let mut ctx = WriteContext::new(
+            ([192, 168, 77, 20], 80).into(),
+            local_addr,
+            alloc_buffer([]),
+        );
         assert!(firewall.write(&mut ctx).await.is_err());
     }
 }

--- a/src/filters/load_balancer.rs
+++ b/src/filters/load_balancer.rs
@@ -61,7 +61,10 @@ mod tests {
     use std::{collections::HashSet, net::Ipv4Addr};
 
     use super::*;
-    use crate::net::endpoint::{Endpoint, EndpointAddress};
+    use crate::{
+        net::endpoint::{Endpoint, EndpointAddress},
+        test::alloc_buffer,
+    };
 
     async fn get_response_addresses(
         filter: &dyn Filter,
@@ -74,7 +77,7 @@ mod tests {
             .map(Endpoint::new)
             .collect::<std::collections::BTreeSet<_>>();
         let endpoints = crate::net::cluster::ClusterMap::new_default(endpoints);
-        let mut context = ReadContext::new(endpoints.into(), source, vec![]);
+        let mut context = ReadContext::new(endpoints.into(), source, alloc_buffer([]));
 
         filter.read(&mut context).await.unwrap();
 

--- a/src/filters/local_rate_limit.rs
+++ b/src/filters/local_rate_limit.rs
@@ -207,7 +207,10 @@ mod tests {
     use tokio::time;
 
     use super::*;
-    use crate::{config::ConfigType, test::assert_write_no_change};
+    use crate::{
+        config::ConfigType,
+        test::{alloc_buffer, assert_write_no_change},
+    };
 
     fn rate_limiter(config: Config) -> LocalRateLimit {
         LocalRateLimit::new(config).unwrap()
@@ -229,12 +232,12 @@ mod tests {
             .into(),
         );
 
-        let mut context = ReadContext::new(endpoints.into(), address.clone(), vec![9]);
+        let mut context = ReadContext::new(endpoints.into(), address.clone(), alloc_buffer([9]));
         let result = r.read(&mut context).await;
 
         if should_succeed {
             result.unwrap();
-            assert_eq!(context.contents, vec![9]);
+            assert_eq!(&*context.contents, [9]);
         } else {
             assert!(result.is_err());
         }

--- a/src/filters/read.rs
+++ b/src/filters/read.rs
@@ -18,9 +18,12 @@ use std::sync::Arc;
 
 #[cfg(doc)]
 use crate::filters::Filter;
-use crate::net::{
-    endpoint::{metadata::DynamicMetadata, Endpoint, EndpointAddress},
-    ClusterMap,
+use crate::{
+    net::{
+        endpoint::{metadata::DynamicMetadata, Endpoint, EndpointAddress},
+        ClusterMap,
+    },
+    pool::PoolBuffer,
 };
 
 /// The input arguments to [`Filter::read`].
@@ -33,14 +36,15 @@ pub struct ReadContext {
     /// The source of the received packet.
     pub source: EndpointAddress,
     /// Contents of the received packet.
-    pub contents: Vec<u8>,
+    pub contents: PoolBuffer,
     /// Arbitrary values that can be passed from one filter to another.
     pub metadata: DynamicMetadata,
 }
 
 impl ReadContext {
     /// Creates a new [`ReadContext`].
-    pub fn new(endpoints: Arc<ClusterMap>, source: EndpointAddress, contents: Vec<u8>) -> Self {
+    #[inline]
+    pub fn new(endpoints: Arc<ClusterMap>, source: EndpointAddress, contents: PoolBuffer) -> Self {
         Self {
             endpoints,
             destinations: Vec::new(),

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -64,7 +64,7 @@ impl FilterRegistry {
 mod tests {
     use std::net::Ipv4Addr;
 
-    use crate::test::load_test_filters;
+    use crate::test::{alloc_buffer, load_test_filters};
 
     use super::*;
     use crate::filters::{Filter, FilterError, FilterRegistry, ReadContext, WriteContext};
@@ -109,12 +109,12 @@ mod tests {
             .read(&mut ReadContext::new(
                 endpoints.into(),
                 addr.clone(),
-                vec![]
+                alloc_buffer([]),
             ))
             .await
             .is_ok());
         assert!(filter
-            .write(&mut WriteContext::new(addr.clone(), addr, vec![],))
+            .write(&mut WriteContext::new(addr.clone(), addr, alloc_buffer([])))
             .await
             .is_ok());
     }

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -162,7 +162,10 @@ impl TryFrom<proto::Timestamp> for Config {
 mod tests {
     use super::*;
 
-    use crate::filters::capture::{self, Capture};
+    use crate::{
+        filters::capture::{self, Capture},
+        test::alloc_buffer,
+    };
 
     #[tokio::test]
     async fn basic() {
@@ -171,7 +174,7 @@ mod tests {
         let mut ctx = ReadContext::new(
             <_>::default(),
             (std::net::Ipv4Addr::UNSPECIFIED, 0).into(),
-            b"hello".to_vec(),
+            alloc_buffer(b"hello"),
         );
         ctx.metadata.insert(
             TIMESTAMP_KEY.into(),
@@ -202,7 +205,7 @@ mod tests {
         let mut ctx = ReadContext::new(
             <_>::default(),
             source.into(),
-            [0, 0, 0, 0, 99, 81, 55, 181].to_vec(),
+            alloc_buffer([0, 0, 0, 0, 99, 81, 55, 181]),
         );
 
         capture.read(&mut ctx).await.unwrap();

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -257,12 +257,14 @@ mod tests {
             },
         );
 
+        let pool = std::sync::Arc::new(crate::pool::BufferPool::new(1, 5));
+
         let endpoints = crate::net::cluster::ClusterMap::default();
         endpoints.insert_default([endpoint1, endpoint2].into());
         ReadContext::new(
             endpoints.into(),
             "127.0.0.1:100".parse().unwrap(),
-            b"hello".to_vec(),
+            pool.alloc_slice(b"hello"),
         )
     }
 
@@ -272,6 +274,6 @@ mod tests {
     {
         filter.read(&mut ctx).await.unwrap();
 
-        assert_eq!(b"hello", &*ctx.contents);
+        assert_eq!(b"hello", ctx.contents.as_ref());
     }
 }

--- a/src/filters/write.rs
+++ b/src/filters/write.rs
@@ -16,7 +16,10 @@
 
 use std::collections::HashMap;
 
-use crate::net::endpoint::{DynamicMetadata, EndpointAddress};
+use crate::{
+    net::endpoint::{DynamicMetadata, EndpointAddress},
+    pool::PoolBuffer,
+};
 
 #[cfg(doc)]
 use crate::filters::Filter;
@@ -29,14 +32,15 @@ pub struct WriteContext {
     /// The destination of the received packet.
     pub dest: EndpointAddress,
     /// Contents of the received packet.
-    pub contents: Vec<u8>,
+    pub contents: PoolBuffer,
     /// Arbitrary values that can be passed from one filter to another
     pub metadata: DynamicMetadata,
 }
 
 impl WriteContext {
     /// Creates a new [`WriteContext`]
-    pub fn new(source: EndpointAddress, dest: EndpointAddress, contents: Vec<u8>) -> Self {
+    #[inline]
+    pub fn new(source: EndpointAddress, dest: EndpointAddress, contents: PoolBuffer) -> Self {
         Self {
             source,
             dest,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,14 @@
 pub(crate) mod collections;
 pub(crate) mod metrics;
 
+// Above other modules for thr `uring_spawn` macro.
+#[macro_use]
+pub mod net;
+
 pub mod cli;
 pub mod codec;
 pub mod config;
 pub mod filters;
-pub mod net;
 
 #[doc(hidden)]
 pub mod test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 
 pub(crate) mod collections;
 pub(crate) mod metrics;
+mod pool;
 
 // Above other modules for thr `uring_spawn` macro.
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ async fn main() {
     // Unwrap is safe here as it will only fail if called more than once.
     stable_eyre::install().unwrap();
 
-    match <quilkin::Cli as clap::Parser>::parse().drive().await {
+    match <quilkin::Cli as clap::Parser>::parse().drive(None).await {
         Ok(()) => std::process::exit(0),
         Err(error) => {
             tracing::error!(%error, error_debug=?error, "fatal error");

--- a/src/net.rs
+++ b/src/net.rs
@@ -25,19 +25,49 @@ use std::{
 };
 
 use socket2::{Protocol, Socket, Type};
-use tokio::{net::ToSocketAddrs, net::UdpSocket};
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        use tokio_uring::net::UdpSocket;
+    } else {
+        use tokio::net::UdpSocket;
+    }
+}
 
 pub use self::{
     cluster::ClusterMap,
     endpoint::{Endpoint, EndpointAddress},
 };
 
-/// returns a UdpSocket with address and port reuse, on Ipv6Addr::UNSPECIFIED
-fn socket_with_reuse(port: u16) -> std::io::Result<UdpSocket> {
-    socket_with_reuse_and_address((Ipv6Addr::UNSPECIFIED, port).into())
+fn socket_with_reuse_and_address(addr: SocketAddr) -> std::io::Result<UdpSocket> {
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "linux")] {
+            raw_socket_with_reuse_and_address(addr)
+                .map(From::from)
+                .map(UdpSocket::from_std)
+        } else {
+            epoll_socket_with_reuse_and_address(addr)
+        }
+    }
 }
 
-fn socket_with_reuse_and_address(addr: SocketAddr) -> std::io::Result<UdpSocket> {
+fn epoll_socket_with_reuse(port: u16) -> std::io::Result<tokio::net::UdpSocket> {
+    raw_socket_with_reuse_and_address((Ipv6Addr::UNSPECIFIED, port).into())
+        .map(From::from)
+        .and_then(tokio::net::UdpSocket::from_std)
+}
+
+fn epoll_socket_with_reuse_and_address(addr: SocketAddr) -> std::io::Result<tokio::net::UdpSocket> {
+    raw_socket_with_reuse_and_address(addr)
+        .map(From::from)
+        .and_then(tokio::net::UdpSocket::from_std)
+}
+
+pub(crate) fn raw_socket_with_reuse(port: u16) -> std::io::Result<Socket> {
+    raw_socket_with_reuse_and_address((Ipv6Addr::UNSPECIFIED, port).into())
+}
+
+fn raw_socket_with_reuse_and_address(addr: SocketAddr) -> std::io::Result<Socket> {
     let domain = match addr {
         SocketAddr::V4(_) => socket2::Domain::IPV4,
         SocketAddr::V6(_) => socket2::Domain::IPV6,
@@ -51,7 +81,7 @@ fn socket_with_reuse_and_address(addr: SocketAddr) -> std::io::Result<UdpSocket>
         sock.set_only_v6(false)?;
     }
     sock.bind(&addr.into())?;
-    UdpSocket::from_std(sock.into())
+    Ok(sock)
 }
 
 #[cfg(not(target_family = "windows"))]
@@ -68,33 +98,109 @@ fn enable_reuse(sock: &Socket) -> io::Result<()> {
 
 /// An ipv6 socket that can accept and send data from either a local ipv4 address or ipv6 address
 /// with port reuse enabled and only_v6 set to false.
-#[derive(Debug)]
 pub struct DualStackLocalSocket {
     socket: UdpSocket,
+    local_addr: SocketAddr,
 }
 
 impl DualStackLocalSocket {
-    pub fn new(port: u16) -> std::io::Result<DualStackLocalSocket> {
-        Ok(Self {
-            socket: socket_with_reuse(port)?,
+    pub fn from_raw(socket: socket2::Socket) -> Self {
+        let socket: std::net::UdpSocket = socket.into();
+        let local_addr = socket.local_addr().unwrap();
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                let socket = UdpSocket::from_std(socket);
+            } else {
+                // This is only for macOS and Windows (non-production platforms),
+                // and should never happen anyway, so unwrap here is fine.
+                let socket = UdpSocket::from_std(socket).unwrap();
+            }
+        }
+        Self { socket, local_addr }
+    }
+
+    pub fn new(port: u16) -> std::io::Result<Self> {
+        raw_socket_with_reuse(port).map(Self::from_raw)
+    }
+
+    pub fn bind_local(port: u16) -> std::io::Result<Self> {
+        let local_addr = (Ipv6Addr::LOCALHOST, port).into();
+        let socket = socket_with_reuse_and_address(local_addr)?;
+        Ok(Self { socket, local_addr })
+    }
+
+    pub fn local_ipv4_addr(&self) -> io::Result<SocketAddr> {
+        Ok(match self.local_addr {
+            SocketAddr::V4(_) => self.local_addr,
+            SocketAddr::V6(_) => (Ipv4Addr::UNSPECIFIED, self.local_addr.port()).into(),
         })
     }
 
-    pub fn bind_local(port: u16) -> std::io::Result<DualStackLocalSocket> {
+    pub fn local_ipv6_addr(&self) -> io::Result<SocketAddr> {
+        Ok(match self.local_addr {
+            SocketAddr::V4(v4addr) => SocketAddr::new(
+                IpAddr::V6(v4addr.ip().to_ipv6_mapped()),
+                self.local_addr.port(),
+            ),
+            SocketAddr::V6(_) => self.local_addr,
+        })
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(target_os = "linux")] {
+            pub async fn recv_from(&self, buf: Vec<u8>) -> (io::Result<(usize, SocketAddr)>, Vec<u8>) {
+                self.socket.recv_from(buf).await
+            }
+
+            pub async fn send_to(&self, buf: Vec<u8>, target: SocketAddr) -> (io::Result<usize>, Vec<u8>) {
+                self.socket.send_to(buf, target).await
+            }
+        } else {
+            pub async fn recv_from(&self, mut buf: Vec<u8>) -> (io::Result<(usize, SocketAddr)>, Vec<u8>) {
+                let result = self.socket.recv_from(&mut buf).await;
+                (result, buf)
+            }
+
+            pub async fn send_to(&self, mut buf: Vec<u8>, target: SocketAddr) -> (io::Result<usize>, Vec<u8>) {
+                let result = self.socket.send_to(&mut buf, target).await;
+                (result, buf)
+            }
+        }
+    }
+}
+
+/// The same as DualStackSocket but uses epoll instead of uring.
+#[derive(Debug)]
+pub struct DualStackEpollSocket {
+    socket: tokio::net::UdpSocket,
+}
+
+impl DualStackEpollSocket {
+    pub fn new(port: u16) -> std::io::Result<Self> {
         Ok(Self {
-            socket: socket_with_reuse_and_address((Ipv6Addr::LOCALHOST, port).into())?,
+            socket: epoll_socket_with_reuse(port)?,
+        })
+    }
+
+    pub fn bind_local(port: u16) -> std::io::Result<Self> {
+        Ok(Self {
+            socket: epoll_socket_with_reuse_and_address((Ipv6Addr::LOCALHOST, port).into())?,
         })
     }
 
     /// Primarily used for testing of ipv4 vs ipv6 addresses.
-    pub(crate) fn new_with_address(addr: SocketAddr) -> std::io::Result<DualStackLocalSocket> {
+    pub(crate) fn new_with_address(addr: SocketAddr) -> std::io::Result<Self> {
         Ok(Self {
-            socket: socket_with_reuse_and_address(addr)?,
+            socket: epoll_socket_with_reuse_and_address(addr)?,
         })
     }
 
     pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.socket.recv_from(buf).await
+    }
+
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.socket.local_addr()
     }
 
     pub fn local_ipv4_addr(&self) -> io::Result<SocketAddr> {
@@ -116,9 +222,41 @@ impl DualStackLocalSocket {
         }
     }
 
-    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> io::Result<usize> {
+    pub async fn send_to<A: tokio::net::ToSocketAddrs>(
+        &self,
+        buf: &[u8],
+        target: A,
+    ) -> io::Result<usize> {
         self.socket.send_to(buf, target).await
     }
+}
+
+/// On linux spawns a io-uring runtime + thread, everywhere else spawns a regular tokio task.
+macro_rules! uring_spawn {
+    ($future:expr) => {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                std::thread::spawn(move || {
+                    tokio_uring::start($future);
+                });
+            } else {
+                tokio::spawn($future);
+            }
+        }
+    };
+}
+
+/// On linux spawns a io-uring task, everywhere else spawns a regular tokio task.
+macro_rules! uring_inner_spawn {
+    ($future:expr) => {
+        cfg_if::cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                tokio_uring::spawn($future);
+            } else {
+                tokio::spawn($future);
+            }
+        }
+    };
 }
 
 #[cfg(test)]
@@ -136,7 +274,7 @@ mod tests {
     #[tokio::test]
     async fn dual_stack_socket_reusable() {
         let expected = available_addr(&AddressType::Random).await;
-        let socket = super::DualStackLocalSocket::new(expected.port()).unwrap();
+        let socket = super::DualStackEpollSocket::new(expected.port()).unwrap();
         let addr = socket.local_ipv4_addr().unwrap();
 
         match expected {
@@ -148,7 +286,7 @@ mod tests {
         assert_eq!(expected.port(), socket.local_ipv6_addr().unwrap().port());
 
         // should be able to do it a second time, since we are reusing the address.
-        let socket = super::DualStackLocalSocket::new(expected.port()).unwrap();
+        let socket = super::DualStackEpollSocket::new(expected.port()).unwrap();
 
         match expected {
             SocketAddr::V4(_) => assert_eq!(expected, socket.local_ipv4_addr().unwrap()),

--- a/src/net.rs
+++ b/src/net.rs
@@ -233,17 +233,30 @@ impl DualStackEpollSocket {
 
 /// On linux spawns a io-uring runtime + thread, everywhere else spawns a regular tokio task.
 macro_rules! uring_spawn {
-    ($future:expr) => {
+    ($future:expr) => {{
+        let (tx, rx) = tokio::sync::oneshot::channel();
         cfg_if::cfg_if! {
             if #[cfg(target_os = "linux")] {
                 std::thread::spawn(move || {
-                    tokio_uring::start($future);
+                    match tokio_uring::Runtime::new(&tokio_uring::builder().entries(2048)) {
+                        Ok(runtime) => {
+                            let _ = tx.send(Ok(()));
+                            runtime.block_on($future);
+                        }
+                        Err(error) => {
+                            let _ = tx.send(Err(error));
+                        }
+                    };
                 });
             } else {
-                tokio::spawn($future);
+                tokio::spawn(async move {
+                    tx.send(Ok(()));
+                    $future.await
+                });
             }
         }
-    };
+        rx
+    }};
 }
 
 /// On linux spawns a io-uring task, everywhere else spawns a regular tokio task.

--- a/src/net.rs
+++ b/src/net.rs
@@ -155,6 +155,10 @@ impl DualStackLocalSocket {
             pub async fn send_to(&self, buf: Vec<u8>, target: SocketAddr) -> (io::Result<usize>, Vec<u8>) {
                 self.socket.send_to(buf, target).await
             }
+
+            pub fn make_refcnt(self) -> std::rc::Rc<Self> {
+                std::rc::Rc::new(self)
+            }
         } else {
             pub async fn recv_from(&self, mut buf: Vec<u8>) -> (io::Result<(usize, SocketAddr)>, Vec<u8>) {
                 let result = self.socket.recv_from(&mut buf).await;
@@ -164,6 +168,10 @@ impl DualStackLocalSocket {
             pub async fn send_to(&self, buf: Vec<u8>, target: SocketAddr) -> (io::Result<usize>, Vec<u8>) {
                 let result = self.socket.send_to(&buf, target).await;
                 (result, buf)
+            }
+
+            pub fn make_refcnt(self) -> std::sync::Arc<Self> {
+                std::sync::Arc::new(self)
             }
         }
     }

--- a/src/net/cluster.rs
+++ b/src/net/cluster.rs
@@ -127,7 +127,6 @@ impl ClusterMap {
         self.0.iter()
     }
 
-    #[cfg(test)]
     pub fn endpoints(&self) -> impl Iterator<Item = Endpoint> + '_ {
         self.0
             .iter()

--- a/src/net/xds.rs
+++ b/src/net/xds.rs
@@ -201,7 +201,7 @@ mod tests {
         let proxy_admin = crate::cli::Admin::Proxy(<_>::default());
         tokio::spawn(async move {
             client_proxy
-                .run(client_config, proxy_admin, shutdown_rx)
+                .run(client_config, proxy_admin, None, shutdown_rx)
                 .await
         });
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/src/net/xds.rs
+++ b/src/net/xds.rs
@@ -317,9 +317,12 @@ mod tests {
                 socket.local_addr().unwrap().into();
 
             config.clusters.modify(|clusters| {
-                let mut cluster = clusters.default_entry();
-                cluster.clear();
-                cluster.insert(Endpoint::new(local_addr.clone()));
+                clusters.insert(
+                    None,
+                    Some(Endpoint::new(local_addr.clone()))
+                        .into_iter()
+                        .collect(),
+                );
             });
 
             let filters = crate::filters::FilterChain::try_from(vec![

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,281 @@
+use bytes::BytesMut;
+use parking_lot::Mutex;
+use std::{
+    fmt,
+    sync::{
+        atomic::{AtomicUsize, Ordering::Relaxed},
+        Arc,
+    },
+};
+
+type Pool = Mutex<Vec<BytesMut>>;
+
+pub struct BufferPool {
+    allocated: AtomicUsize,
+    outstanding: AtomicUsize,
+    pools: Vec<Pool>,
+    buf_capacity: usize,
+}
+
+impl BufferPool {
+    #[inline]
+    pub fn new(buckets: usize, buf_capacity: usize) -> Self {
+        let pools = (0..buckets).map(|_i| Mutex::new(Vec::new())).collect();
+
+        Self {
+            allocated: AtomicUsize::new(0),
+            outstanding: AtomicUsize::new(0),
+            buf_capacity,
+            pools,
+        }
+    }
+
+    #[inline]
+    pub fn alloc(self: Arc<Self>) -> PoolBuffer {
+        let size = self.buf_capacity;
+        self.alloc_sized(size)
+    }
+
+    #[inline]
+    pub fn alloc_sized(self: Arc<Self>, capacity: usize) -> PoolBuffer {
+        let i = self.allocated.fetch_add(1, Relaxed);
+        let index = i % self.pools.len();
+
+        let mut inner = self.pools[index]
+            .lock()
+            .pop()
+            .unwrap_or_else(|| BytesMut::with_capacity(capacity));
+
+        self.outstanding.fetch_add(1, Relaxed);
+
+        if inner.capacity() < capacity {
+            inner.reserve(capacity - inner.capacity());
+        }
+
+        PoolBuffer {
+            inner,
+            owner: self,
+            index,
+            split: None,
+        }
+    }
+
+    #[inline]
+    fn absorb(&self, mut buf: BytesMut, index: usize) {
+        buf.clear();
+        self.pools[index].lock().push(buf);
+        self.outstanding.fetch_sub(1, Relaxed);
+    }
+
+    /// Creates a buffer filled with the specified data, only used for testing
+    #[inline]
+    pub fn alloc_slice(self: Arc<Self>, data: &[u8]) -> PoolBuffer {
+        let mut buffer = self.alloc();
+        buffer.inner.extend_from_slice(data);
+        buffer
+    }
+}
+
+impl Default for BufferPool {
+    fn default() -> Self {
+        Self::new(32, 64 * 1024)
+    }
+}
+
+impl fmt::Debug for BufferPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BufferPool")
+            .field("allocated", &self.allocated.load(Relaxed))
+            .field("outstanding", &self.outstanding.load(Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+pub struct PoolBuffer {
+    inner: BytesMut,
+    owner: Arc<BufferPool>,
+    split: Option<(BytesMut, bool)>,
+    index: usize,
+}
+
+impl PoolBuffer {
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[inline]
+    pub fn extend_from_slice(&mut self, slice: &[u8]) {
+        self.inner.extend_from_slice(slice);
+    }
+
+    #[inline]
+    pub fn prepend_from_slice(&mut self, slice: &[u8]) {
+        if self.inner.len() + slice.len() > self.inner.capacity() {
+            let mut new_buffer = BytesMut::with_capacity(std::cmp::max(
+                self.inner.capacity(),
+                self.inner.len() + slice.len(),
+            ));
+            new_buffer.extend_from_slice(slice);
+            new_buffer.extend_from_slice(&self.inner);
+            self.inner = new_buffer;
+        } else {
+            self.inner.extend_from_slice(slice);
+            let end = self.inner.len() - slice.len();
+            self.inner.copy_within(0..end, slice.len());
+            self.inner[..slice.len()].copy_from_slice(slice);
+        }
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self, range: std::ops::Range<usize>) -> &mut [u8] {
+        if range.end > self.inner.len() {
+            self.inner.resize(range.end, 0);
+        }
+
+        &mut self.inner[range]
+    }
+
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        self.inner.truncate(len);
+    }
+
+    #[inline]
+    pub fn split_off(&mut self, at: usize) -> &mut BytesMut {
+        assert!(self.split.is_none());
+
+        let split = self.inner.split_off(at);
+        self.split = Some((split, true));
+
+        self.split.as_mut().map(|(b, _)| b).unwrap()
+    }
+
+    #[inline]
+    pub fn split_to(&mut self, at: usize) -> &mut BytesMut {
+        assert!(self.split.is_none());
+
+        let split = self.inner.split_to(at);
+        self.split = Some((split, false));
+
+        self.split.as_mut().map(|(b, _)| b).unwrap()
+    }
+
+    #[inline]
+    pub fn freeze(self) -> FrozenPoolBuffer {
+        FrozenPoolBuffer {
+            inner: Arc::new(self),
+        }
+    }
+}
+
+impl fmt::Debug for PoolBuffer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PoolBuffer")
+            .field("len", &self.inner.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl AsRef<[u8]> for PoolBuffer {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl std::ops::Deref for PoolBuffer {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl std::ops::DerefMut for PoolBuffer {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice(0..self.inner.capacity())
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe impl tokio_uring::buf::IoBufMut for PoolBuffer {
+    #[inline]
+    fn stable_mut_ptr(&mut self) -> *mut u8 {
+        self.inner.stable_mut_ptr()
+    }
+
+    #[inline]
+    unsafe fn set_init(&mut self, pos: usize) {
+        self.inner.set_init(pos)
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe impl tokio_uring::buf::IoBuf for PoolBuffer {
+    #[inline]
+    fn stable_ptr(&self) -> *const u8 {
+        self.inner.stable_ptr()
+    }
+
+    #[inline]
+    fn bytes_init(&self) -> usize {
+        self.inner.bytes_init()
+    }
+
+    #[inline]
+    fn bytes_total(&self) -> usize {
+        self.inner.bytes_total()
+    }
+}
+
+impl Drop for PoolBuffer {
+    #[inline]
+    fn drop(&mut self) {
+        if let Some((mut b, which)) = self.split.take() {
+            if which {
+                self.inner.unsplit(b);
+            } else {
+                b.unsplit(std::mem::replace(&mut self.inner, BytesMut::new()));
+                self.inner = b;
+            }
+        }
+
+        if self.inner.capacity() != 0 {
+            let inner = std::mem::replace(&mut self.inner, BytesMut::new());
+            self.owner.absorb(inner, self.index)
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FrozenPoolBuffer {
+    inner: Arc<PoolBuffer>,
+}
+
+impl FrozenPoolBuffer {
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe impl tokio_uring::buf::IoBuf for FrozenPoolBuffer {
+    #[inline]
+    fn stable_ptr(&self) -> *const u8 {
+        self.inner.stable_ptr()
+    }
+
+    #[inline]
+    fn bytes_init(&self) -> usize {
+        self.inner.bytes_init()
+    }
+
+    #[inline]
+    fn bytes_total(&self) -> usize {
+        self.inner.bytes_total()
+    }
+}

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -279,3 +279,12 @@ unsafe impl tokio_uring::buf::IoBuf for FrozenPoolBuffer {
         self.inner.bytes_total()
     }
 }
+
+impl std::ops::Deref for FrozenPoolBuffer {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -27,6 +27,7 @@ use crate::{
     net::endpoint::metadata::Value,
     net::endpoint::{Endpoint, EndpointAddress},
     net::DualStackEpollSocket as DualStackLocalSocket,
+    pool::BufferPool,
     ShutdownKind, ShutdownRx, ShutdownTx,
 };
 
@@ -89,7 +90,7 @@ impl Filter for TestFilter {
             .or_insert_with(|| Value::String("receive".into()));
 
         ctx.contents
-            .append(&mut format!(":odr:{}", ctx.source).into_bytes());
+            .extend_from_slice(format!(":odr:{}", ctx.source).as_bytes());
         Ok(())
     }
 
@@ -101,7 +102,7 @@ impl Filter for TestFilter {
             .or_insert_with(|| Value::String("receive".to_string()));
 
         ctx.contents
-            .append(&mut format!(":our:{}:{}", ctx.source, ctx.dest).into_bytes());
+            .extend_from_slice(format!(":our:{}:{}", ctx.source, ctx.dest).as_bytes());
         Ok(())
     }
 }
@@ -317,6 +318,14 @@ impl TestHelper {
     }
 }
 
+pub static BUFFER_POOL: once_cell::sync::Lazy<Arc<BufferPool>> =
+    once_cell::sync::Lazy::new(|| Arc::new(BufferPool::default()));
+
+#[inline]
+pub fn alloc_buffer(data: impl AsRef<[u8]>) -> crate::pool::PoolBuffer {
+    BUFFER_POOL.clone().alloc_slice(data.as_ref())
+}
+
 /// assert that read makes no changes
 pub async fn assert_filter_read_no_change<F>(filter: &F)
 where
@@ -327,8 +336,8 @@ where
         .parse::<Endpoint>()
         .unwrap()]));
     let source = "127.0.0.1:90".parse().unwrap();
-    let contents = "hello".to_string().into_bytes();
-    let mut context = ReadContext::new(endpoints.clone(), source, contents.clone());
+    let contents = b"hello";
+    let mut context = ReadContext::new(endpoints.clone(), source, alloc_buffer(contents));
 
     filter.read(&mut context).await.unwrap();
     assert!(context.destinations.is_empty());
@@ -342,11 +351,11 @@ where
     F: Filter,
 {
     let endpoint = "127.0.0.1:90".parse::<Endpoint>().unwrap();
-    let contents = "hello".to_string().into_bytes();
+    let contents = b"hello";
     let mut context = WriteContext::new(
         endpoint.address,
         "127.0.0.1:70".parse().unwrap(),
-        contents.clone(),
+        alloc_buffer(contents),
     );
 
     filter.write(&mut context).await.unwrap();

--- a/src/test.rs
+++ b/src/test.rs
@@ -27,7 +27,7 @@ use crate::{
     net::endpoint::metadata::Value,
     net::endpoint::{Endpoint, EndpointAddress},
     net::DualStackEpollSocket as DualStackLocalSocket,
-    ShutdownRx, ShutdownTx,
+    ShutdownKind, ShutdownRx, ShutdownTx,
 };
 
 static LOG_ONCE: Once = Once::new();

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -32,11 +32,6 @@ async fn token_router() {
     let mut t = TestHelper::default();
     let mut echo = t.run_echo_server(&AddressType::Random).await;
     quilkin::test::map_to_localhost(&mut echo).await;
-    let server_port = 12348;
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
 
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.filters.store(
@@ -76,8 +71,7 @@ async fn token_router() {
         )
     });
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let server_port = t.run_server(server_config, None, None).await;
 
     // valid packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -77,6 +77,7 @@ async fn token_router() {
     });
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     // valid packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -54,6 +54,7 @@ on_write: COMPRESS
     };
     // Run server proxy.
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // create a local client
     let client_addr = available_addr(&AddressType::Random).await;
@@ -80,6 +81,7 @@ on_write: DECOMPRESS
     };
     // Run client proxy.
     t.run_server(client_config, client_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // let's send the packet
     let (mut rx, tx) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -53,8 +53,7 @@ on_write: COMPRESS
         ..<_>::default()
     };
     // Run server proxy.
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    t.run_server(server_config, Some(server_proxy), None).await;
 
     // create a local client
     let client_addr = available_addr(&AddressType::Random).await;
@@ -80,8 +79,7 @@ on_write: DECOMPRESS
         ..<_>::default()
     };
     // Run client proxy.
-    t.run_server(client_config, client_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    t.run_server(client_config, Some(client_proxy), None).await;
 
     // let's send the packet
     let (mut rx, tx) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/concatenate.rs
+++ b/tests/concatenate.rs
@@ -34,11 +34,6 @@ bytes: YWJj #abc
 ";
     let echo = t.run_echo_server(&AddressType::Random).await;
 
-    let server_port = 12346;
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
@@ -52,8 +47,7 @@ bytes: YWJj #abc
         .map(std::sync::Arc::new)
         .unwrap(),
     );
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let server_port = t.run_server(server_config, None, None).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/concatenate.rs
+++ b/tests/concatenate.rs
@@ -53,6 +53,7 @@ bytes: YWJj #abc
         .unwrap(),
     );
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
@@ -62,7 +63,7 @@ bytes: YWJj #abc
 
     assert_eq!(
         "helloabc",
-        timeout(Duration::from_secs(5), recv_chan.recv())
+        timeout(Duration::from_millis(250), recv_chan.recv())
             .await
             .expect("should have received a packet")
             .unwrap()

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -86,6 +86,7 @@ on_write: DECOMPRESS
     );
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -54,11 +54,6 @@ on_write: DECOMPRESS
         .await;
 
     quilkin::test::map_to_localhost(&mut echo).await;
-    let server_port = 12346;
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
@@ -85,8 +80,7 @@ on_write: DECOMPRESS
         .unwrap(),
     );
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let server_port = t.run_server(server_config, None, None).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -85,14 +85,19 @@ on_write: DECOMPRESS
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
-    let local_addr = (Ipv4Addr::LOCALHOST, server_port);
-    socket.send_to(b"hello", &local_addr).await.unwrap();
+    let buf = b"hello".repeat(98);
 
-    assert_eq!(
-        "helloxyzabc",
-        timeout(Duration::from_millis(500), recv_chan.recv())
-            .await
-            .expect("should have received a packet")
-            .unwrap()
-    );
+    let local_addr = (Ipv4Addr::LOCALHOST, server_port);
+    socket.send_to(&buf, &local_addr).await.unwrap();
+
+    let received = timeout(Duration::from_millis(500), recv_chan.recv())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+
+    let hellos = received
+        .strip_suffix("xyzabc")
+        .expect("expected appended data");
+
+    assert_eq!(&buf, hellos.as_bytes(),);
 }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -36,11 +36,6 @@ async fn test_filter() {
     let echo = t.run_echo_server(&AddressType::Random).await;
 
     // create server configuration
-    let server_port = 12346;
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.filters.store(
         quilkin::filters::FilterChain::try_from(vec![Filter {
@@ -56,15 +51,9 @@ async fn test_filter() {
         .clusters
         .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let server_port = t.run_server(server_config, None, None).await;
 
     // create a local client
-    let client_port = 12347;
-    let client_proxy = quilkin::cli::Proxy {
-        port: client_port,
-        ..<_>::default()
-    };
     let client_config = std::sync::Arc::new(quilkin::Config::default());
     client_config.clusters.modify(|clusters| {
         clusters.insert_default(
@@ -85,8 +74,7 @@ async fn test_filter() {
     );
 
     // Run client proxy.
-    t.run_server(client_config, client_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let client_port = t.run_server(client_config, None, None).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
@@ -129,12 +117,7 @@ async fn debug_filter() {
 
     tracing::trace!(%echo, "running echo server");
     // create server configuration
-    let server_port = 12247;
     let server_config = std::sync::Arc::new(quilkin::Config::default());
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
     server_config
         .clusters
         .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
@@ -148,15 +131,9 @@ async fn debug_filter() {
         .unwrap(),
     );
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let server_port = t.run_server(server_config, None, None).await;
 
     // create a local client
-    let client_port = 12248;
-    let client_proxy = quilkin::cli::Proxy {
-        port: client_port,
-        ..<_>::default()
-    };
     let client_config = std::sync::Arc::new(quilkin::Config::default());
     client_config.clusters.modify(|clusters| {
         clusters.insert_default(
@@ -175,8 +152,7 @@ async fn debug_filter() {
         .map(std::sync::Arc::new)
         .unwrap(),
     );
-    t.run_server(client_config, client_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let client_port = t.run_server(client_config, None, None).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -57,6 +57,7 @@ async fn test_filter() {
         .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // create a local client
     let client_port = 12347;
@@ -85,6 +86,7 @@ async fn test_filter() {
 
     // Run client proxy.
     t.run_server(client_config, client_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
@@ -147,6 +149,7 @@ async fn debug_filter() {
     );
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // create a local client
     let client_port = 12248;
@@ -173,6 +176,7 @@ async fn debug_filter() {
         .unwrap(),
     );
     t.run_server(client_config, client_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -203,8 +203,8 @@ async fn test(
     };
 
     let client_addr = match address_type {
-        AddressType::Ipv4 => socket.local_ipv4_addr().unwrap(),
-        AddressType::Ipv6 => socket.local_ipv6_addr().unwrap(),
+        AddressType::Ipv4 => socket.local_addr().unwrap(),
+        AddressType::Ipv6 => socket.local_addr().unwrap(),
         AddressType::Random => unreachable!(),
     };
 
@@ -233,6 +233,7 @@ async fn test(
         .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let local_addr: SocketAddr = match address_type {
         AddressType::Ipv4 => (std::net::Ipv4Addr::LOCALHOST, server_port).into(),

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -232,8 +232,7 @@ async fn test(
         .clusters
         .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    t.run_server(server_config, Some(server_proxy), None).await;
 
     let local_addr: SocketAddr = match address_type {
         AddressType::Ipv4 => (std::net::Ipv4Addr::LOCALHOST, server_port).into(),

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -40,6 +40,7 @@ async fn health_server() {
         server_proxy,
         Some(Some((std::net::Ipv6Addr::UNSPECIFIED, 9093).into())),
     );
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let client = Client::new();
     let resp = client

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -26,20 +26,16 @@ async fn health_server() {
     let mut t = TestHelper::default();
 
     // create server configuration
-    let server_port = 12349;
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.clusters.modify(|clusters| {
         clusters.insert_default(["127.0.0.1:0".parse::<Endpoint>().unwrap()].into())
     });
     t.run_server(
         server_config,
-        server_proxy,
+        None,
         Some(Some((std::net::Ipv6Addr::UNSPECIFIED, 9093).into())),
-    );
+    )
+    .await;
     tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let client = Client::new();

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -46,7 +46,6 @@ policy: ROUND_ROBIN
         );
     }
 
-    let server_port = 12346;
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.clusters.modify(|clusters| {
         clusters.insert_default(echo_addresses.iter().cloned().map(Endpoint::new).collect())
@@ -61,12 +60,7 @@ policy: ROUND_ROBIN
         .unwrap(),
     );
 
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let server_port = t.run_server(server_config, None, None).await;
     let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
 
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -66,6 +66,7 @@ policy: ROUND_ROBIN
         ..<_>::default()
     };
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
     let server_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), server_port);
 
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -55,8 +55,7 @@ period: 1
         .unwrap(),
     );
     tracing::trace!("spawning server");
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    t.run_server(server_config, Some(server_proxy), None).await;
 
     let msg = "hello";
     let (mut rx, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -56,6 +56,7 @@ period: 1
     );
     tracing::trace!("spawning server");
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let msg = "hello";
     let (mut rx, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -57,11 +57,6 @@ on_read:
             bytes: YWJj # abc
 ";
 
-    let server_port = 12348;
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config
         .clusters
@@ -83,8 +78,7 @@ on_read:
         .unwrap(),
     );
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let server_port = t.run_server(server_config, None, None).await;
 
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -84,6 +84,7 @@ on_read:
     );
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -59,6 +59,7 @@ async fn metrics_server() {
         .clusters
         .modify(|clusters| clusters.insert_default([Endpoint::new(server_addr.into())].into()));
     t.run_server(client_config, client_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
@@ -85,6 +86,8 @@ async fn metrics_server() {
         .unwrap();
 
     let response = String::from_utf8(resp.to_vec()).unwrap();
-    let regex = regex::Regex::new(r#"quilkin_packets_total\{.*event="read".*\} 2"#).unwrap();
-    assert!(regex.is_match(&response));
+    let read_regex = regex::Regex::new(r#"quilkin_packets_total\{.*event="read".*\} 2"#).unwrap();
+    let write_regex = regex::Regex::new(r#"quilkin_packets_total\{.*event="write".*\} 2"#).unwrap();
+    assert!(read_regex.is_match(&response));
+    assert!(write_regex.is_match(&response));
 }

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -47,8 +47,7 @@ async fn echo() {
         )
     });
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    t.run_server(server_config, Some(server_proxy), None).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -48,6 +48,7 @@ async fn echo() {
     });
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     // let's send the packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/qcmp.rs
+++ b/tests/qcmp.rs
@@ -35,7 +35,7 @@ async fn proxy_ping() {
         ..<_>::default()
     };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
-    t.run_server(server_config, server_proxy, None);
+    t.run_server(server_config, Some(server_proxy), None).await;
     ping(server_port).await;
 }
 

--- a/tests/qcmp.rs
+++ b/tests/qcmp.rs
@@ -61,6 +61,7 @@ async fn agent_ping() {
 }
 
 async fn ping(port: u16) {
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
     let socket = tokio::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0))
         .await
         .unwrap();

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -44,11 +44,6 @@ quilkin.dev:
         - YWJj # abc
         ";
 
-    let server_port = 12348;
-    let server_proxy = quilkin::cli::Proxy {
-        port: server_port,
-        ..<_>::default()
-    };
     let server_config = std::sync::Arc::new(quilkin::Config::default());
     server_config.clusters.modify(|clusters| {
         clusters.insert_default(
@@ -77,8 +72,7 @@ quilkin.dev:
         .unwrap(),
     );
 
-    t.run_server(server_config, server_proxy, None);
-    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    let server_port = t.run_server(server_config, None, None).await;
 
     // valid packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -78,14 +78,17 @@ quilkin.dev:
     );
 
     t.run_server(server_config, server_proxy, None);
+    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
 
     // valid packet
     let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
 
     let local_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, server_port));
     let msg = b"helloabc";
+    tracing::trace!(%local_addr, "sending echo packet");
     socket.send_to(msg, &local_addr).await.unwrap();
 
+    tracing::trace!("awaiting echo packet");
     assert_eq!(
         "hello",
         timeout(Duration::from_millis(500), recv_chan.recv())


### PR DESCRIPTION
There's a lot of sleeps added in the tests, because this requires spawning threads, the tests need to wait for the threads to spawn. We should probably have a better interface for tests to remove them.