### PR TITLE
Add datacenter discovery

### DIFF
--- a/proto/quilkin/config/v1alpha1/config.proto
+++ b/proto/quilkin/config/v1alpha1/config.proto
@@ -39,3 +39,9 @@ message Endpoint {
     uint32 port = 2;
     google.protobuf.Struct metadata = 3;
 }
+
+message Datacenter {
+    string host = 1;
+    uint32 qcmp_port = 2;
+    string icao_code = 3;
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -259,6 +259,115 @@ mod tests {
     };
 
     #[tokio::test]
+    async fn datacenter_discovery() {
+        let relay_xds_port = crate::test::available_addr(&AddressType::Random)
+            .await
+            .port();
+        let relay_mds_port = crate::test::available_addr(&AddressType::Random)
+            .await
+            .port();
+        let relay_config = Arc::new(Config::default());
+        let relay = Relay {
+            xds_port: relay_xds_port,
+            mds_port: relay_mds_port,
+            ..<_>::default()
+        };
+
+        let agent_file = tempfile::NamedTempFile::new().unwrap();
+        let config = Config::default();
+
+        std::fs::write(agent_file.path(), serde_yaml::to_string(&config).unwrap()).unwrap();
+
+        let agent_qcmp_port = crate::test::available_addr(&AddressType::Random)
+            .await
+            .port();
+
+        let icao_code: crate::config::IcaoCode = "EIDW".parse().unwrap();
+
+        let agent_config = Arc::new(Config::default());
+        let agent = Agent {
+            relay: vec![format!("http://localhost:{relay_mds_port}")
+                .parse()
+                .unwrap()],
+            region: None,
+            sub_zone: None,
+            zone: None,
+            idle_request_interval_secs: admin::IDLE_REQUEST_INTERVAL_SECS,
+            qcmp_port: agent_qcmp_port,
+            icao_code: icao_code.clone(),
+            provider: Some(Providers::File {
+                path: agent_file.path().to_path_buf(),
+            }),
+        };
+
+        let proxy_config = Arc::new(Config::default());
+        let proxy = Proxy {
+            management_server: vec![format!("http://localhost:{relay_xds_port}")
+                .parse()
+                .unwrap()],
+            ..<_>::default()
+        };
+
+        let (_tx, shutdown_rx) = tokio::sync::watch::channel(());
+        tokio::spawn({
+            let config = relay_config.clone();
+            let shutdown_rx = shutdown_rx.clone();
+            async move {
+                relay
+                    .relay(config, Admin::Relay(<_>::default()), shutdown_rx)
+                    .await
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        tokio::spawn({
+            let config = agent_config.clone();
+            let shutdown_rx = shutdown_rx.clone();
+            async move {
+                agent
+                    .run(config, Admin::Agent(<_>::default()), shutdown_rx)
+                    .await
+            }
+        });
+        tokio::spawn({
+            let config = proxy_config.clone();
+            let shutdown_rx = shutdown_rx.clone();
+            async move {
+                proxy
+                    .run(config, Admin::Proxy(<_>::default()), shutdown_rx)
+                    .await
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+        let datacenter = crate::config::Datacenter {
+            qcmp_port: agent_qcmp_port,
+            icao_code,
+        };
+
+        assert!(agent_config.datacenters.read().is_empty());
+        assert!(!relay_config.datacenters.read().is_empty());
+        assert!(!proxy_config.datacenters.read().is_empty());
+        assert_eq!(
+            relay_config
+                .datacenters
+                .read()
+                .get(&std::net::Ipv6Addr::LOCALHOST.into())
+                .unwrap()
+                .value(),
+            &datacenter
+        );
+        assert_eq!(
+            proxy_config
+                .datacenters
+                .read()
+                .get(&std::net::Ipv6Addr::LOCALHOST.into())
+                .unwrap()
+                .value(),
+            &datacenter
+        );
+    }
+
+    #[tokio::test]
     async fn relay_routing() {
         let mut t = TestHelper::default();
         let (mut rx, server_socket) = t.open_socket_and_recv_multiple_packets().await;
@@ -346,6 +455,7 @@ mod tests {
                 provider: Some(Providers::File {
                     path: endpoints_file.path().to_path_buf(),
                 }),
+                ..<_>::default()
             }),
             log_format: LogFormats::default(),
         };

--- a/src/cli/admin.rs
+++ b/src/cli/admin.rs
@@ -50,6 +50,11 @@ impl Admin {
         }
     }
 
+    #[must_use]
+    pub fn is_agent(&self) -> bool {
+        matches!(self, Self::Agent(_))
+    }
+
     #[track_caller]
     pub fn unwrap_proxy(&self) -> &proxy::RuntimeConfig {
         match self {

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -55,6 +55,9 @@ pub struct Agent {
     /// request from a relay server before restarting the connection.
     #[clap(long, env = "QUILKIN_IDLE_REQUEST_INTERVAL_SECS", default_value_t = super::admin::IDLE_REQUEST_INTERVAL_SECS)]
     pub idle_request_interval_secs: u64,
+    /// The ICAO code for the agent.
+    #[clap(short, long, env, default_value_t = crate::config::IcaoCode::default())]
+    pub icao_code: crate::config::IcaoCode,
 }
 
 impl Default for Agent {
@@ -67,6 +70,7 @@ impl Default for Agent {
             sub_zone: <_>::default(),
             provider: <_>::default(),
             idle_request_interval_secs: super::admin::IDLE_REQUEST_INTERVAL_SECS,
+            icao_code: <_>::default(),
         }
     }
 }
@@ -84,6 +88,9 @@ impl Agent {
                 zone: self.zone.clone().unwrap_or_default(),
                 sub_zone: self.sub_zone.clone().unwrap_or_default(),
             });
+
+        config.qcmp_port.store(self.qcmp_port.into());
+        config.icao_code.store(self.icao_code.clone().into());
 
         let runtime_config = mode.unwrap_agent();
 

--- a/src/cli/manage.rs
+++ b/src/cli/manage.rs
@@ -92,7 +92,7 @@ impl Manage {
             None
         };
 
-        let server_task = tokio::spawn(crate::net::xds::server::spawn(self.port, config))
+        let server_task = tokio::spawn(crate::net::xds::server::spawn(self.port, mode, config))
             .map_err(From::from)
             .and_then(std::future::ready);
 

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -153,6 +153,10 @@ impl Proxy {
             stream
                 .discovery_request(ResourceType::Listener, &[])
                 .await?;
+            tokio::time::sleep(std::time::Duration::from_nanos(1)).await;
+            stream
+                .discovery_request(ResourceType::Datacenter, &[])
+                .await?;
             Some((client, stream))
         } else {
             None

--- a/src/cli/relay.rs
+++ b/src/cli/relay.rs
@@ -63,10 +63,11 @@ impl Relay {
         mode: crate::cli::Admin,
         mut shutdown_rx: tokio::sync::watch::Receiver<()>,
     ) -> crate::Result<()> {
-        let xds_server = crate::net::xds::server::spawn(self.xds_port, config.clone());
+        let xds_server =
+            crate::net::xds::server::spawn(self.xds_port, mode.clone(), config.clone());
         let mds_server = tokio::spawn(crate::net::xds::server::control_plane_discovery_server(
             self.mds_port,
-            self.idle_request_interval_secs,
+            mode.clone(),
             config.clone(),
         ));
         let runtime_config = mode.unwrap_relay();


### PR DESCRIPTION
This commit adds the concept of "datacenter" to our xDS protocol. Unlike other resources, there's slightly different behaviour between proxies to relays and relays to agents. When a relay queries for a datacenter from the agent, the agent returns its own QCMP port and ICAO location. The host then adds the address of remote agent to identify the datacenter. When the proxy then queries the relay for datacenters, it gets all of the relay's agent's addresses, ports, and ICAO codes.

This will be used with a future commit to measure the distance between proxies and agents.