### PR TITLE
Use ClusterMap for Filter::read

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -190,7 +190,7 @@ impl Config {
     pub fn apply_metrics(&self) {
         let clusters = self.clusters.read();
         crate::net::cluster::active_clusters().set(clusters.len() as i64);
-        crate::net::cluster::active_endpoints().set(clusters.endpoints().count() as i64);
+        crate::net::cluster::active_endpoints().set(clusters.num_of_endpoints() as i64);
     }
 }
 

--- a/src/config/watch.rs
+++ b/src/config/watch.rs
@@ -38,6 +38,10 @@ impl<T: Clone> Watch<T> {
     pub fn watch(&self) -> watch::Receiver<T> {
         self.watchers.subscribe()
     }
+
+    pub fn clone_value(&self) -> std::sync::Arc<T> {
+        self.value.clone()
+    }
 }
 
 impl<T: Clone + PartialEq + std::fmt::Debug> Watch<T> {

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -159,10 +159,12 @@ mod tests {
             }),
         };
         let filter = Capture::from_config(config.into());
-        let endpoints = vec![Endpoint::new("127.0.0.1:81".parse().unwrap())];
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
+        );
         assert!(filter
             .read(&mut ReadContext::new(
-                endpoints,
+                endpoints.into(),
                 (std::net::Ipv4Addr::LOCALHOST, 80).into(),
                 "abc".to_string().into_bytes(),
             ))
@@ -235,9 +237,11 @@ mod tests {
     where
         F: Filter + ?Sized,
     {
-        let endpoints = vec![Endpoint::new("127.0.0.1:81".parse().unwrap())];
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
+        );
         let mut context = ReadContext::new(
-            endpoints,
+            endpoints.into(),
             "127.0.0.1:80".parse().unwrap(),
             "helloabc".to_string().into_bytes(),
         );

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -278,6 +278,17 @@ impl Filter for FilterChain {
             }
         }
 
+        // Special case to handle to allow for pass-through, if no filter
+        // has rejected, and the destinations is empty, we passthrough to all.
+        // Which mimics the old behaviour while avoid clones in most cases.
+        if ctx.destinations.is_empty() {
+            ctx.destinations = ctx
+                .endpoints
+                .iter()
+                .flat_map(|e| e.value().iter().cloned().collect::<Vec<_>>())
+                .collect();
+        }
+
         Ok(())
     }
 
@@ -340,11 +351,15 @@ mod tests {
         assert!(result.is_err());
     }
 
-    fn endpoints() -> Vec<Endpoint> {
-        vec![
-            Endpoint::new("127.0.0.1:80".parse().unwrap()),
-            Endpoint::new("127.0.0.1:90".parse().unwrap()),
-        ]
+    fn endpoints() -> std::sync::Arc<crate::net::cluster::ClusterMap> {
+        crate::net::cluster::ClusterMap::new_default(
+            [
+                Endpoint::new("127.0.0.1:80".parse().unwrap()),
+                Endpoint::new("127.0.0.1:90".parse().unwrap()),
+            ]
+            .into(),
+        )
+        .into()
     }
 
     #[tokio::test]
@@ -361,7 +376,10 @@ mod tests {
         config.filters.read(&mut context).await.unwrap();
         let expected = endpoints_fixture.clone();
 
-        assert_eq!(expected, &*context.endpoints);
+        assert_eq!(
+            &*expected.endpoints().collect::<Vec<_>>(),
+            &*context.destinations
+        );
         assert_eq!(b"hello:odr:127.0.0.1:70", &*context.contents);
         assert_eq!(
             "receive",
@@ -369,7 +387,12 @@ mod tests {
         );
 
         let mut context = WriteContext::new(
-            endpoints_fixture[0].address.clone(),
+            endpoints_fixture
+                .endpoints()
+                .next()
+                .unwrap()
+                .address
+                .clone(),
             "127.0.0.1:70".parse().unwrap(),
             b"hello".to_vec(),
         );
@@ -405,7 +428,10 @@ mod tests {
 
         chain.read(&mut context).await.unwrap();
         let expected = endpoints_fixture.clone();
-        assert_eq!(expected, context.endpoints.to_vec());
+        assert_eq!(
+            expected.endpoints().collect::<Vec<_>>(),
+            context.destinations
+        );
         assert_eq!(
             b"hello:odr:127.0.0.1:70:odr:127.0.0.1:70",
             &*context.contents
@@ -416,7 +442,12 @@ mod tests {
         );
 
         let mut context = WriteContext::new(
-            endpoints_fixture[0].address.clone(),
+            endpoints_fixture
+                .endpoints()
+                .next()
+                .unwrap()
+                .address
+                .clone(),
             "127.0.0.1:70".parse().unwrap(),
             b"hello".to_vec(),
         );

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -176,8 +176,11 @@ mod tests {
         let expected = contents_fixture();
 
         // read compress
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
+        );
         let mut read_context = ReadContext::new(
-            vec![Endpoint::new("127.0.0.1:80".parse().unwrap())],
+            endpoints.into(),
             "127.0.0.1:8080".parse().unwrap(),
             expected.clone(),
         );
@@ -238,9 +241,12 @@ mod tests {
             Metrics::new(),
         );
 
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
+        );
         assert!(compression
             .read(&mut ReadContext::new(
-                vec![Endpoint::new("127.0.0.1:80".parse().unwrap())],
+                endpoints.into(),
                 "127.0.0.1:8080".parse().unwrap(),
                 b"hello".to_vec(),
             ))
@@ -259,8 +265,11 @@ mod tests {
             Metrics::new(),
         );
 
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
+        );
         let mut read_context = ReadContext::new(
-            vec![Endpoint::new("127.0.0.1:80".parse().unwrap())],
+            endpoints.into(),
             "127.0.0.1:8080".parse().unwrap(),
             b"hello".to_vec(),
         );
@@ -345,8 +354,11 @@ mod tests {
         );
 
         // read decompress
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
+        );
         let mut read_context = ReadContext::new(
-            vec![Endpoint::new("127.0.0.1:80".parse().unwrap())],
+            endpoints.into(),
             "127.0.0.1:8080".parse().unwrap(),
             write_context.contents.clone(),
         );

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -137,18 +137,16 @@ mod tests {
         };
 
         let local_ip = [192, 168, 75, 20];
-        let mut ctx = ReadContext::new(
-            vec![Endpoint::new((Ipv4Addr::LOCALHOST, 8080).into())],
-            (local_ip, 80).into(),
-            vec![],
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new((Ipv4Addr::LOCALHOST, 8080).into())].into(),
         );
+        let mut ctx = ReadContext::new(endpoints.into(), (local_ip, 80).into(), vec![]);
         assert!(firewall.read(&mut ctx).await.is_ok());
 
-        let mut ctx = ReadContext::new(
-            vec![Endpoint::new((Ipv4Addr::LOCALHOST, 8080).into())],
-            (local_ip, 2000).into(),
-            vec![],
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new((Ipv4Addr::LOCALHOST, 8080).into())].into(),
         );
+        let mut ctx = ReadContext::new(endpoints.into(), (local_ip, 2000).into(), vec![]);
         assert!(logs_contain("quilkin::filters::firewall")); // the given name to the the logger by tracing
         assert!(logs_contain("Allow"));
 

--- a/src/filters/load_balancer.rs
+++ b/src/filters/load_balancer.rs
@@ -68,16 +68,18 @@ mod tests {
         input_addresses: &[EndpointAddress],
         source: EndpointAddress,
     ) -> Vec<EndpointAddress> {
-        let mut context = ReadContext::new(
-            Vec::from_iter(input_addresses.iter().cloned().map(Endpoint::new)),
-            source,
-            vec![],
-        );
+        let endpoints = input_addresses
+            .iter()
+            .cloned()
+            .map(Endpoint::new)
+            .collect::<std::collections::BTreeSet<_>>();
+        let endpoints = crate::net::cluster::ClusterMap::new_default(endpoints);
+        let mut context = ReadContext::new(endpoints.into(), source, vec![]);
 
         filter.read(&mut context).await.unwrap();
 
         context
-            .endpoints
+            .destinations
             .iter()
             .map(|ep| ep.address.clone())
             .collect::<Vec<_>>()

--- a/src/filters/local_rate_limit.rs
+++ b/src/filters/local_rate_limit.rs
@@ -222,11 +222,14 @@ mod tests {
 
     /// Send a packet to the filter and assert whether or not it was processed.
     async fn read(r: &LocalRateLimit, address: &EndpointAddress, should_succeed: bool) {
-        let endpoints = vec![crate::net::endpoint::Endpoint::new(
-            (Ipv4Addr::LOCALHOST, 8089).into(),
-        )];
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [crate::net::endpoint::Endpoint::new(
+                (Ipv4Addr::LOCALHOST, 8089).into(),
+            )]
+            .into(),
+        );
 
-        let mut context = ReadContext::new(endpoints, address.clone(), vec![9]);
+        let mut context = ReadContext::new(endpoints.into(), address.clone(), vec![9]);
         let result = r.read(&mut context).await;
 
         if should_succeed {

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -205,8 +205,11 @@ mod tests {
         assert_eq!(0, filter.metrics.packets_matched_total.get());
 
         // config so we can test match and fallthrough.
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
+        );
         let mut ctx = ReadContext::new(
-            vec![Default::default()],
+            endpoints.into(),
             ([127, 0, 0, 1], 7000).into(),
             contents.clone(),
         );
@@ -216,11 +219,10 @@ mod tests {
         assert_eq!(1, filter.metrics.packets_matched_total.get());
         assert_eq!(0, filter.metrics.packets_fallthrough_total.get());
 
-        let mut ctx = ReadContext::new(
-            vec![Default::default()],
-            ([127, 0, 0, 1], 7000).into(),
-            contents,
+        let endpoints = crate::net::cluster::ClusterMap::new_default(
+            [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
         );
+        let mut ctx = ReadContext::new(endpoints.into(), ([127, 0, 0, 1], 7000).into(), contents);
         ctx.metadata.insert(key, "xyz".into());
 
         let result = filter.read(&mut ctx).await;

--- a/src/filters/read.rs
+++ b/src/filters/read.rs
@@ -14,15 +14,22 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 #[cfg(doc)]
 use crate::filters::Filter;
-use crate::net::endpoint::{metadata::DynamicMetadata, Endpoint, EndpointAddress};
+use crate::net::{
+    endpoint::{metadata::DynamicMetadata, Endpoint, EndpointAddress},
+    ClusterMap,
+};
 
 /// The input arguments to [`Filter::read`].
 #[non_exhaustive]
 pub struct ReadContext {
     /// The upstream endpoints that the packet will be forwarded to.
-    pub endpoints: Vec<Endpoint>,
+    pub endpoints: Arc<ClusterMap>,
+    /// The upstream endpoints that the packet will be forwarded to.
+    pub destinations: Vec<Endpoint>,
     /// The source of the received packet.
     pub source: EndpointAddress,
     /// Contents of the received packet.
@@ -33,9 +40,10 @@ pub struct ReadContext {
 
 impl ReadContext {
     /// Creates a new [`ReadContext`].
-    pub fn new(endpoints: Vec<Endpoint>, source: EndpointAddress, contents: Vec<u8>) -> Self {
+    pub fn new(endpoints: Arc<ClusterMap>, source: EndpointAddress, contents: Vec<u8>) -> Self {
         Self {
             endpoints,
+            destinations: Vec::new(),
             source,
             contents,
             metadata: DynamicMetadata::new(),

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -104,9 +104,10 @@ mod tests {
         let addr: EndpointAddress = (Ipv4Addr::LOCALHOST, 8080).into();
         let endpoint = Endpoint::new(addr.clone());
 
+        let endpoints = crate::net::cluster::ClusterMap::new_default([endpoint.clone()].into());
         assert!(filter
             .read(&mut ReadContext::new(
-                vec![endpoint.clone()],
+                endpoints.into(),
                 addr.clone(),
                 vec![]
             ))

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -169,7 +169,7 @@ mod tests {
         const TIMESTAMP_KEY: &str = "BASIC";
         let filter = Timestamp::from_config(Config::new(TIMESTAMP_KEY).into());
         let mut ctx = ReadContext::new(
-            vec![],
+            <_>::default(),
             (std::net::Ipv4Addr::UNSPECIFIED, 0).into(),
             b"hello".to_vec(),
         );
@@ -200,7 +200,7 @@ mod tests {
         let timestamp = Timestamp::from_config(Config::new(TIMESTAMP_KEY).into());
         let source = (std::net::Ipv4Addr::UNSPECIFIED, 0);
         let mut ctx = ReadContext::new(
-            vec![],
+            <_>::default(),
             source.into(),
             [0, 0, 0, 0, 99, 81, 55, 181].to_vec(),
         );

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -54,7 +54,7 @@ impl Filter for TokenRouter {
     async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         match ctx.metadata.get(&self.config.metadata_key) {
             Some(metadata::Value::Bytes(token)) => {
-                ctx.endpoints.retain(|endpoint| {
+                ctx.destinations = ctx.endpoints.filter_endpoints(|endpoint| {
                     if endpoint.metadata.known.tokens.contains(&**token) {
                         tracing::trace!(%endpoint.address, token = &*crate::codec::base64::encode(token), "Endpoint matched");
                         true
@@ -63,7 +63,7 @@ impl Filter for TokenRouter {
                     }
                 });
 
-                if ctx.endpoints.is_empty() {
+                if ctx.destinations.is_empty() {
                     Err(FilterError::new(Error::NoEndpointMatch(
                         self.config.metadata_key,
                         crate::codec::base64::encode(token),
@@ -257,8 +257,10 @@ mod tests {
             },
         );
 
+        let endpoints = crate::net::cluster::ClusterMap::default();
+        endpoints.insert_default([endpoint1, endpoint2].into());
         ReadContext::new(
-            vec![endpoint1, endpoint2],
+            endpoints.into(),
             "127.0.0.1:100".parse().unwrap(),
             b"hello".to_vec(),
         )

--- a/src/test.rs
+++ b/src/test.rs
@@ -307,13 +307,17 @@ pub async fn assert_filter_read_no_change<F>(filter: &F)
 where
     F: Filter,
 {
-    let endpoints = vec!["127.0.0.1:80".parse::<Endpoint>().unwrap()];
+    let endpoints = std::sync::Arc::new(crate::net::cluster::ClusterMap::default());
+    endpoints.insert_default(std::collections::BTreeSet::from(["127.0.0.1:80"
+        .parse::<Endpoint>()
+        .unwrap()]));
     let source = "127.0.0.1:90".parse().unwrap();
     let contents = "hello".to_string().into_bytes();
     let mut context = ReadContext::new(endpoints.clone(), source, contents.clone());
 
     filter.read(&mut context).await.unwrap();
-    assert_eq!(endpoints, &*context.endpoints);
+    assert!(context.destinations.is_empty());
+    assert_eq!(endpoints, context.endpoints);
     assert_eq!(contents, &*context.contents);
 }
 


### PR DESCRIPTION
This removes the cloning of endpoints that happens for every packet, which has a large impact when you're talking about 12–20K endpoints.