### PR TITLE
Add lz4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,6 +1442,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ea9b256699eda7b0387ffbc776dd625e28bde3918446381781245b7a50349d8"
+
+[[package]]
 name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +1897,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "lasso",
+ "lz4_flex",
  "maxminddb",
  "nom",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,11 @@ name = "read_write"
 harness = false
 test = false
 
+[[bench]]
+name = "compression"
+harness = false
+test = false
+
 [dependencies]
 # Local
 quilkin-macros = { version = "0.8.0-dev", path = "./macros" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ hyper = { version = "0.14.27", features = ["http2"] }
 hyper-rustls = { version = "0.24.1", features = ["http2", "webpki-roots"] }
 ipnetwork = "0.20.0"
 k8s-openapi.workspace = true
+lz4_flex = { version = "0.11", default-features = false }
 maxminddb = "0.23.0"
 notify = "6.1.1"
 num_cpus = "1.16.0"

--- a/benches/compression.rs
+++ b/benches/compression.rs
@@ -1,0 +1,92 @@
+mod shared;
+
+use divan::Bencher;
+use quilkin::{filters::compress::*, pool::*};
+use shared::*;
+use std::sync::Arc;
+
+fn main() {
+    divan::main();
+}
+
+fn init<const N: usize>() -> ([u8; N], Arc<BufferPool>) {
+    use rand::{RngCore, SeedableRng};
+    let mut packet = [0u8; N];
+
+    // Fill in the packet with random bytes rather than easily compressible data
+    // as game traffic will more resemble the former than the latter
+    let mut rng = rand::rngs::SmallRng::seed_from_u64(N as _);
+    rng.fill_bytes(&mut packet);
+
+    (packet, Arc::new(BufferPool::new(32, 2 * 1024)))
+}
+
+#[divan::bench_group(sample_count = 1000)]
+mod decompress {
+    use super::*;
+
+    #[divan::bench(consts = PACKET_SIZES)]
+    fn snappy<const N: usize>(b: Bencher) {
+        let (packet, pool) = init::<N>();
+
+        let compressor = Compressor::from(Mode::Snappy);
+
+        b.with_inputs(|| {
+            let mut packet = pool.clone().alloc_slice(&packet);
+            compressor.encode(pool.clone(), &mut packet).unwrap();
+            packet
+        })
+        .input_counter(|buf| divan::counter::BytesCount::new(buf.len()))
+        .bench_local_refs(|buf| {
+            compressor.decode(pool.clone(), buf).unwrap();
+        })
+    }
+
+    #[divan::bench(consts = PACKET_SIZES)]
+    fn lz4<const N: usize>(b: Bencher) {
+        let (packet, pool) = init::<N>();
+
+        let compressor = Compressor::from(Mode::Lz4);
+
+        b.with_inputs(|| {
+            let mut packet = pool.clone().alloc_slice(&packet);
+            compressor.encode(pool.clone(), &mut packet).unwrap();
+            packet
+        })
+        .input_counter(|buf| divan::counter::BytesCount::new(buf.len()))
+        .bench_local_refs(|buf| {
+            compressor.decode(pool.clone(), buf).unwrap();
+        })
+    }
+}
+
+#[divan::bench_group(sample_count = 1000)]
+mod compress {
+    use super::*;
+
+    #[divan::bench(consts = PACKET_SIZES)]
+    fn snappy<const N: usize>(b: Bencher) {
+        let (packet, pool) = init::<N>();
+
+        let compressor = Compressor::from(Mode::Snappy);
+
+        b.with_inputs(|| pool.clone().alloc_slice(&packet))
+            .input_counter(|buf| divan::counter::BytesCount::new(buf.len()))
+            .bench_local_refs(|buf| {
+                compressor.encode(pool.clone(), buf).unwrap();
+            })
+    }
+
+    #[divan::bench(consts = PACKET_SIZES)]
+    fn lz4<const N: usize>(b: Bencher) {
+        let (packet, pool) = init::<N>();
+
+        let compressor = Compressor::from(Mode::Lz4);
+
+        b.with_inputs(|| pool.clone().alloc_slice(&packet))
+            .input_counter(|buf| divan::counter::BytesCount::new(buf.len()))
+            .bench_local_refs(|buf| {
+                compressor.encode(pool.clone(), buf).unwrap();
+            })
+    }
+}

--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4, UdpSocket},
     sync::{atomic, mpsc, Arc},
@@ -293,7 +295,6 @@ impl<const N: usize> Writer<N> {
     }
 }
 
-#[allow(dead_code)]
 pub struct QuilkinLoop {
     shutdown: Option<quilkin::ShutdownTx>,
     thread: Option<std::thread::JoinHandle<()>>,

--- a/docs/src/services/proxy/filters/compress.md
+++ b/docs/src/services/proxy/filters/compress.md
@@ -4,11 +4,13 @@ The `Compress` filter's job is to provide a variety of compression implementatio
 and subsequent decompression of UDP data when sent between systems, such as a game client and game server.
 
 ## Filter name
+
 ```text
 quilkin.filters.compress.v1alpha1.Compress
 ```
 
 ## Configuration Examples
+
 ```rust
 # let yaml = "
 version: v1alpha1
@@ -47,11 +49,34 @@ decompressed when traffic is returned from the dedicated game server before bein
 > Snappy is a compression/decompression library. It does not aim for maximum compression, or compatibility with any
 > other compression library; instead, it aims for very high speeds and reasonable compression.
 
-Currently, this filter only provides the [Snappy](https://github.com/google/snappy/) compression format via the
-[rust-snappy](https://github.com/BurntSushi/rust-snappy) crate, but more will be
-provided in the future.
+This compression method is provided by [rust-snappy](https://github.com/BurntSushi/rust-snappy).
 
-### Metrics
+```yaml
+- name: quilkin.filters.compress.v1alpha1.Compress
+    config:
+        on_read: COMPRESS
+        on_write: DECOMPRESS
+        mode: SNAPPY
+```
+
+### LZ4
+
+> LZ4 is lossless compression algorithm, providing compression speed > 500 MB/s per core, scalable with multi-cores CPU.
+> It features an extremely fast decoder, with speed in multiple GB/s per core, typically reaching RAM speed limits on
+> multi-core systems.
+
+This compression method is provided by [lz4_flex](https://github.com/PSeitz/lz4_flex).
+
+```yaml
+- name: quilkin.filters.compress.v1alpha1.Compress
+    config:
+        on_read: COMPRESS
+        on_write: DECOMPRESS
+        mode: LZ4
+```
+
+## Metrics
+
 * `quilkin_filter_int_counter{label="compressed_bytes_total"}`
   Total number of compressed bytes either received or sent.
 * `quilkin_filter_int_counter{label="decompressed_bytes_total"}`

--- a/docs/src/services/proxy/filters/compress.md
+++ b/docs/src/services/proxy/filters/compress.md
@@ -51,6 +51,8 @@ decompressed when traffic is returned from the dedicated game server before bein
 
 This compression method is provided by [rust-snappy](https://github.com/BurntSushi/rust-snappy).
 
+Due to the small size of packets, this only encodes and decodes the non-streaming version of the format described [here](https://github.com/google/snappy/blob/main/format_description.txt).
+
 ```yaml
 - name: quilkin.filters.compress.v1alpha1.Compress
     config:
@@ -66,6 +68,10 @@ This compression method is provided by [rust-snappy](https://github.com/BurntSus
 > multi-core systems.
 
 This compression method is provided by [lz4_flex](https://github.com/PSeitz/lz4_flex).
+
+Due to the small size of packets, this only encodes and decodes the block version of the format described. If your game client/server itself is performing LZ4 de/compression it needs to encode or
+decode a varint of the uncompressed packet size (maximum 2^16) since that is not part of the LZ4 block
+format. The varint is of the same exact form as that used by [snappy](https://github.com/google/snappy/blob/27f34a580be4a3becf5f8c0cba13433f53c21337/format_description.txt#L20-L25).
 
 ```yaml
 - name: quilkin.filters.compress.v1alpha1.Compress

--- a/proto/quilkin/filters/compress/v1alpha1/compress.proto
+++ b/proto/quilkin/filters/compress/v1alpha1/compress.proto
@@ -21,11 +21,10 @@ package quilkin.filters.compress.v1alpha1;
 message Compress {
   enum Mode {
     Snappy = 0;
+    Lz4 = 1;
   }
 
-  message ModeValue {
-    Mode value = 1;
-  }
+  message ModeValue { Mode value = 1; }
 
   enum Action {
     DoNothing = 0;
@@ -33,12 +32,9 @@ message Compress {
     Decompress = 2;
   }
 
-  message ActionValue {
-    Action value = 1;
-  }
+  message ActionValue { Action value = 1; }
 
   ModeValue mode = 1;
   ActionValue on_read = 2;
   ActionValue on_write = 3;
 }
-

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -148,7 +148,9 @@ impl StaticFilter for Compress {
 #[cfg(test)]
 mod tests {
     use crate::{
-        filters::compress::compressor::Compressor, net::endpoint::Endpoint, test::alloc_buffer,
+        filters::compress::compressor::Compressor,
+        net::endpoint::Endpoint,
+        test::{alloc_buffer, BUFFER_POOL},
     };
 
     use super::*;
@@ -165,9 +167,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn config_factory() {
+    async fn config_factory_snappy() {
         let config = serde_json::json!({
             "mode": "SNAPPY".to_string(),
+            "on_read": "DECOMPRESS".to_string(),
+            "on_write": "COMPRESS".to_string(),
+
+        });
+        let filter = Compress::from_config(Some(serde_json::from_value(config).unwrap()));
+        assert_downstream(&filter).await;
+    }
+
+    #[tokio::test]
+    async fn config_factory_lz4() {
+        let config = serde_json::json!({
+            "mode": "LZ4".to_string(),
             "on_read": "DECOMPRESS".to_string(),
             "on_write": "COMPRESS".to_string(),
 
@@ -300,15 +314,13 @@ mod tests {
         assert_eq!(b"hello".to_vec(), &*write_context.contents)
     }
 
-    #[test]
-    fn snappy() {
+    fn roundtrip_compression(compressor: Compressor) {
         let expected = contents_fixture();
         let mut contents = alloc_buffer(&expected);
-        let snappy = Compressor::from(Mode::Snappy);
 
-        let compression_pool = Arc::new(BufferPool::new(1, 64 * 1024));
-        let ok = compressor.encode(compression_pool.clone(), &mut contents);
-        assert!(ok.is_ok());
+        compressor
+            .encode(BUFFER_POOL.clone(), &mut contents)
+            .expect("failed to compress");
         assert!(
             !contents.is_empty(),
             "compressed array should be greater than 0"
@@ -324,12 +336,23 @@ mod tests {
             contents.len()
         ); // 45000 bytes uncompressed, 276 bytes compressed
 
-        let ok = compressor.decode(compression_pool.clone(), &mut contents);
-        assert!(ok.is_ok());
+        compressor
+            .decode(BUFFER_POOL.clone(), &mut contents)
+            .expect("failed to decompress");
         assert_eq!(
             expected, &*contents,
             "should be equal, as decompressed state should go back to normal"
         );
+    }
+
+    #[test]
+    fn snappy() {
+        roundtrip_compression(Mode::Snappy.into());
+    }
+
+    #[test]
+    fn lz4() {
+        roundtrip_compression(Mode::Lz4.into());
     }
 
     /// At small data packets, compression will add data, so let's give a bigger data packet!

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -23,7 +23,7 @@ crate::include_proto!("quilkin.filters.compress.v1alpha1");
 use crate::{filters::prelude::*, pool::BufferPool};
 
 use self::quilkin::filters::compress::v1alpha1 as proto;
-use compressor::Compressor;
+pub use compressor::Compressor;
 use metrics::Metrics;
 use std::sync::Arc;
 

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -304,7 +304,7 @@ mod tests {
     fn snappy() {
         let expected = contents_fixture();
         let mut contents = alloc_buffer(&expected);
-        let compressor: Compressor = Mode::Snappy.into();
+        let snappy = Compressor::from(Mode::Snappy);
 
         let compression_pool = Arc::new(BufferPool::new(1, 64 * 1024));
         let ok = compressor.encode(compression_pool.clone(), &mut contents);

--- a/src/filters/compress/compressor.rs
+++ b/src/filters/compress/compressor.rs
@@ -18,6 +18,7 @@ use crate::pool::{BufferPool, PoolBuffer};
 use parking_lot::Mutex;
 use std::{io, sync::Arc};
 
+use lz4_flex::block;
 use snap::raw;
 
 /// A trait that provides a compression and decompression strategy for this filter.
@@ -25,6 +26,7 @@ use snap::raw;
 /// decompression operation can occur.
 pub(crate) enum Compressor {
     Snappy(SnappyImpl),
+    Lz4,
 }
 
 impl Compressor {
@@ -41,6 +43,24 @@ impl Compressor {
 
                 let compressed = res?;
                 encoded.truncate(compressed);
+                encoded
+            }
+            Self::Lz4 => {
+                let size = block::get_maximum_output_size(contents.len()) + 3;
+                let mut encoded = vec![0; size];
+
+                let slen = size::write(&mut encoded, contents.len() as u16);
+
+                let compressed =
+                    block::compress_into(contents, &mut encoded[slen..]).map_err(|_e| {
+                        // This should be impossible
+                        io::Error::new(
+                            io::ErrorKind::OutOfMemory,
+                            "not enough space allocated for compressed output",
+                        )
+                    })?;
+
+                encoded.truncate(compressed + slen);
                 encoded
             }
         };
@@ -61,6 +81,22 @@ impl Compressor {
                 decoded.truncate(decompressed);
                 decoded
             }
+            Self::Lz4 => {
+                let (size, slen) = size::read(contents);
+                let mut decoded = vec![0; size as usize];
+
+                let decompressed = block::decompress_into(&contents[slen..], &mut decoded)
+                    .map_err(|_e| {
+                        // This should be impossible
+                        io::Error::new(
+                            io::ErrorKind::OutOfMemory,
+                            "not enough space allocated for decompressed output",
+                        )
+                    })?;
+
+                decoded.truncate(decompressed);
+                decoded
+            }
         };
 
         *contents = decoded;
@@ -74,6 +110,7 @@ impl From<super::Mode> for Compressor {
             super::Mode::Snappy => Self::Snappy(SnappyImpl {
                 encoders: Mutex::new(Vec::new()),
             }),
+            super::Mode::Lz4 => Self::Lz4,
         }
     }
 }
@@ -91,5 +128,45 @@ impl SnappyImpl {
     #[inline]
     fn absorb(&self, enc: raw::Encoder) {
         self.encoders.lock().push(enc);
+    }
+}
+
+/// Sadly lz4_flex only has prepends the size when compressing to its own
+/// allocated vector, so we can't use it, so we just implement our own based
+/// on <https://developers.google.com/protocol-buffers/docs/encoding#varints>,
+/// and bonus points, we have up to 3 bytes from the payload since lz4_flex always
+/// encodes a full 4 byte u32, regardless of the actual length (which in our case
+/// will always be <64k
+mod size {
+    #[inline]
+    pub(super) fn write(data: &mut [u8], mut n: u16) -> usize {
+        let mut i = 0;
+        while n >= 0b1000_0000 {
+            data[i] = (n as u8) | 0b1000_0000;
+            n >>= 7;
+            i += 1;
+        }
+        data[i] = n as u8;
+        i + 1
+    }
+
+    #[inline]
+    pub(super) fn read(data: &[u8]) -> (u16, usize) {
+        let mut n: u16 = 0;
+        let mut shift: u32 = 0;
+        for (i, &b) in data.iter().enumerate() {
+            if b < 0b1000_0000 {
+                return match (b as u16).checked_shl(shift) {
+                    None => (0, 0),
+                    Some(b) => (n | b, i + 1),
+                };
+            }
+            match ((b as u16) & 0b0111_1111).checked_shl(shift) {
+                None => return (0, 0),
+                Some(b) => n |= b,
+            }
+            shift += 7;
+        }
+        (0, 0)
     }
 }

--- a/src/filters/compress/compressor.rs
+++ b/src/filters/compress/compressor.rs
@@ -24,7 +24,7 @@ use snap::raw;
 /// A trait that provides a compression and decompression strategy for this filter.
 /// Conversion takes place on a mutable Vec, to ensure the most performant compression or
 /// decompression operation can occur.
-pub(crate) enum Compressor {
+pub enum Compressor {
     Snappy(SnappyImpl),
     Lz4,
 }

--- a/src/filters/compress/config.rs
+++ b/src/filters/compress/config.rs
@@ -32,6 +32,8 @@ pub enum Mode {
     #[serde(rename = "SNAPPY")]
     #[default]
     Snappy,
+    #[serde(rename = "LZ4")]
+    Lz4,
 }
 
 impl Mode {
@@ -44,6 +46,7 @@ impl From<Mode> for ProtoMode {
     fn from(mode: Mode) -> Self {
         match mode {
             Mode::Snappy => Self::Snappy,
+            Mode::Lz4 => Self::Lz4,
         }
     }
 }
@@ -52,6 +55,7 @@ impl From<ProtoMode> for Mode {
     fn from(mode: ProtoMode) -> Self {
         match mode {
             ProtoMode::Snappy => Self::Snappy,
+            ProtoMode::Lz4 => Self::Lz4,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 
 pub(crate) mod collections;
 pub(crate) mod metrics;
-mod pool;
+pub mod pool;
 
 // Above other modules for thr `uring_spawn` macro.
 #[macro_use]

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -107,7 +107,7 @@ impl PoolBuffer {
     }
 
     #[inline]
-    pub fn is_empty(&self) -> usize {
+    pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
@@ -283,7 +283,7 @@ impl FrozenPoolBuffer {
     }
 
     #[inline]
-    pub fn is_empty(&self) -> usize {
+    pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -107,6 +107,11 @@ impl PoolBuffer {
     }
 
     #[inline]
+    pub fn is_empty(&self) -> usize {
+        self.inner.is_empty()
+    }
+
+    #[inline]
     pub fn extend_from_slice(&mut self, slice: &[u8]) {
         self.inner.extend_from_slice(slice);
     }
@@ -275,6 +280,11 @@ impl FrozenPoolBuffer {
     #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> usize {
+        self.inner.is_empty()
     }
 }
 

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -99,7 +99,7 @@ on_write: DECOMPRESS
         .strip_suffix("xyzabc")
         .expect("expected appended data");
 
-    assert_eq!(&buf, hellos.as_bytes(),);
+    assert_eq!(&buf, hellos.as_bytes());
 }
 
 #[tokio::test]


### PR DESCRIPTION
This adds support for LZ4 compression. Initial benchmarks with (seeded) randomized data shows that snappy is easily beating it on both compression and decompression, but thought I might as well PR it.

Resolves: #862 