### PR TITLE
Fix PoolBuffer::split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +433,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f057a694a54f12365049b0958a1685bb52d567f5593b355fbf685838e873d400"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +657,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "eyre"
@@ -1096,6 +1122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd1e1a01cfb924fd8c5c43b6827965db394f5a3a16c599ce03452266e1cf984c"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1833,12 +1869,14 @@ name = "quilkin"
 version = "0.8.0-dev"
 dependencies = [
  "arc-swap",
+ "async-channel",
  "async-stream",
  "async-trait",
  "base64 0.21.5",
  "base64-serde",
  "bytes",
  "cached",
+ "cfg-if",
  "chrono",
  "clap",
  "dashmap",
@@ -1884,6 +1922,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-uring",
  "tonic",
  "tonic-build",
  "tracing",
@@ -2165,6 +2204,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2619,6 +2664,21 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-uring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5e02bb137e030b3a547c65a3bd2f1836d66a97369fdcc69034002b10e155ef"
+dependencies = [
+ "bytes",
+ "io-uring",
+ "libc",
+ "scoped-tls",
+ "slab",
+ "socket2 0.4.10",
+ "tokio",
 ]
 
 [[package]]

--- a/src/filters/capture/affix.rs
+++ b/src/filters/capture/affix.rs
@@ -21,7 +21,9 @@ impl super::CaptureStrategy for Prefix {
     fn capture(&self, contents: &mut PoolBuffer) -> Option<Value> {
         is_valid_size(contents, self.size).then(|| {
             if self.remove {
-                Value::Bytes(Bytes::copy_from_slice(contents.split_to(self.size as _)))
+                Value::Bytes(Bytes::copy_from_slice(
+                    contents.split_prefix(self.size as _),
+                ))
             } else {
                 Value::Bytes(Bytes::copy_from_slice(&contents[..self.size as _]))
             }
@@ -42,11 +44,12 @@ pub struct Suffix {
 impl super::CaptureStrategy for Suffix {
     fn capture(&self, contents: &mut PoolBuffer) -> Option<Value> {
         is_valid_size(contents, self.size).then(|| {
-            let index = contents.len() - self.size as usize;
-
             if self.remove {
-                Value::Bytes(Bytes::copy_from_slice(contents.split_off(index)))
+                Value::Bytes(Bytes::copy_from_slice(
+                    contents.split_suffix(self.size as _),
+                ))
             } else {
+                let index = contents.len() - self.size as usize;
                 Value::Bytes(Bytes::copy_from_slice(&contents[index..]))
             }
         })

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -101,3 +101,60 @@ on_write: DECOMPRESS
 
     assert_eq!(&buf, hellos.as_bytes(),);
 }
+
+#[tokio::test]
+async fn multiple_mutations() {
+    let filters = r#"
+- name: quilkin.filters.capture.v1alpha1.Capture
+  config:
+    metadataKey: embark.dev/load_balancer/version
+    suffix:
+      size: 1
+      remove: true
+- name: quilkin.filters.capture.v1alpha1.Capture
+  config:
+    metadataKey: embark.dev/load_balancer/token
+    suffix:
+      size: 16
+      remove: true
+"#;
+
+    let filters: Vec<Filter> = serde_yaml::from_str(filters).unwrap();
+
+    let mut t = TestHelper::default();
+    let mut echo = t
+        .run_echo_server_with_tap(&AddressType::Random, move |_, bytes, _| {
+            assert_eq!(b"hello", bytes);
+        })
+        .await;
+
+    quilkin::test::map_to_localhost(&mut echo).await;
+    let server_config = std::sync::Arc::new(quilkin::Config::default());
+    server_config
+        .clusters
+        .modify(|clusters| clusters.insert_default([Endpoint::new(echo.clone())].into()));
+    server_config.filters.store(
+        quilkin::filters::FilterChain::try_from(filters)
+            .map(std::sync::Arc::new)
+            .unwrap(),
+    );
+
+    let server_port = t.run_server(server_config, None, None).await;
+
+    // let's send the packet
+    let (mut recv_chan, socket) = t.open_socket_and_recv_multiple_packets().await;
+
+    let local_addr = (Ipv4Addr::LOCALHOST, server_port);
+
+    socket
+        .send_to(b"helloxxxxxxxxxxxxxxxx6", &local_addr)
+        .await
+        .unwrap();
+
+    let received = timeout(Duration::from_millis(500), recv_chan.recv())
+        .await
+        .expect("should have received a packet")
+        .unwrap();
+
+    assert_eq!(b"hello", received.as_bytes());
+}


### PR DESCRIPTION
Splitting is only done in the capture filter if `remove` is specified, the previous code didn't take into account there could be multiple capture filters, this fixes that oversight and adds an integration and unit test.