### PR TITLE
Remove Watch requirements on Clone/PartialEq

### DIFF
--- a/src/cli/admin.rs
+++ b/src/cli/admin.rs
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn check_proxy_readiness() {
         let config = crate::Config::default();
-        assert_eq!(config.clusters.read().endpoints().count(), 0);
+        assert_eq!(config.clusters.read().endpoints().len(), 0);
 
         let admin = Admin::Proxy(<_>::default());
         assert!(!admin.is_ready(&config));

--- a/src/codec/base64.rs
+++ b/src/codec/base64.rs
@@ -16,10 +16,12 @@
 
 use base64::Engine;
 
+#[inline]
 pub(crate) fn encode<A: AsRef<[u8]>>(bytes: A) -> String {
     base64::engine::general_purpose::STANDARD.encode(bytes.as_ref())
 }
 
-pub(crate) fn decode<A: AsRef<str>>(input: A) -> Result<Vec<u8>, base64::DecodeError> {
+#[inline]
+pub(crate) fn decode<A: AsRef<[u8]>>(input: A) -> Result<Vec<u8>, base64::DecodeError> {
     base64::engine::general_purpose::STANDARD.decode(input.as_ref())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,8 +27,9 @@ use crate::{
     filters::prelude::*,
     net::cluster::ClusterMap,
     net::xds::{
-        config::listener::v3::Listener, service::discovery::v3::DiscoveryResponse, Resource,
-        ResourceType,
+        config::listener::v3::Listener,
+        service::discovery::v3::{DeltaDiscoveryResponse, DiscoveryResponse},
+        Resource, ResourceType,
     },
 };
 
@@ -162,6 +163,13 @@ impl Config {
             type_url: resource_type.type_url().into(),
             ..<_>::default()
         })
+    }
+
+    pub fn delta_discovery_request(
+        &self,
+        resource_type: ResourceType,
+    ) -> Result<DeltaDiscoveryResponse, eyre::Error> {
+        unimplemented!();
     }
 
     #[tracing::instrument(skip_all, fields(response = response.type_url()))]

--- a/src/config/providers/k8s/agones.rs
+++ b/src/config/providers/k8s/agones.rs
@@ -68,21 +68,21 @@ impl GameServer {
         })
     }
 
-    pub fn tokens(&self) -> std::collections::BTreeSet<Vec<u8>> {
-        match self.metadata.annotations.as_ref() {
-            Some(annotations) => annotations
-                .get(QUILKIN_TOKEN_LABEL)
-                .map(|value| {
+    #[inline]
+    fn tokens(&self) -> std::collections::BTreeSet<Vec<u8>> {
+        self.metadata
+            .annotations
+            .as_ref()
+            .and_then(|anno| {
+                anno.get(QUILKIN_TOKEN_LABEL).map(|value| {
                     value
                         .split(',')
-                        .map(String::from)
                         .map(crate::codec::base64::decode)
                         .filter_map(Result::ok)
                         .collect()
                 })
-                .unwrap_or_default(),
-            None => <_>::default(),
-        }
+            })
+            .unwrap_or_default()
     }
 }
 

--- a/src/config/watch.rs
+++ b/src/config/watch.rs
@@ -18,57 +18,81 @@ pub mod agones;
 mod fs;
 
 pub use self::{agones::watch as agones, fs::watch as fs};
+use std::sync::Arc;
 
 use tokio::sync::watch;
 
 #[derive(Clone, Debug)]
 pub struct Watch<T> {
-    value: std::sync::Arc<T>,
-    watchers: std::sync::Arc<watch::Sender<T>>,
+    value: Arc<T>,
+    watchers: Arc<watch::Sender<Arc<T>>>,
 }
 
-impl<T: Clone> Watch<T> {
+impl<T> Watch<T> {
     pub fn new(value: T) -> Self {
+        let value = Arc::new(value);
         Self {
-            watchers: std::sync::Arc::new(watch::channel(value.clone()).0),
-            value: std::sync::Arc::new(value),
+            watchers: Arc::new(watch::channel(value.clone()).0),
+            value,
         }
     }
 
-    pub fn watch(&self) -> watch::Receiver<T> {
+    #[inline]
+    pub fn watch(&self) -> watch::Receiver<Arc<T>> {
         self.watchers.subscribe()
     }
 
-    pub fn clone_value(&self) -> std::sync::Arc<T> {
+    #[inline]
+    pub fn clone_value(&self) -> Arc<T> {
         self.value.clone()
     }
 }
 
-impl<T: Clone + PartialEq + std::fmt::Debug> Watch<T> {
+#[derive(Clone, Copy)]
+pub enum Marker {
+    Version(u64),
+}
+
+pub trait Watchable {
+    fn mark(&self) -> Marker;
+    fn has_changed(&self, marker: Marker) -> bool;
+}
+
+impl<T: Watchable + std::fmt::Debug> Watch<T> {
     pub fn read(&self) -> ReadGuard<T> {
-        ReadGuard { inner: self }
+        ReadGuard {
+            inner: self,
+            marker: self.value.mark(),
+        }
     }
 
     pub fn write(&self) -> WatchGuard<T> {
-        WatchGuard { inner: self }
+        WatchGuard {
+            inner: self,
+            marker: self.value.mark(),
+        }
     }
 
     pub fn modify(&self, func: impl FnOnce(&WatchGuard<T>)) {
-        (func)(&WatchGuard { inner: self })
+        (func)(&WatchGuard {
+            inner: self,
+            marker: self.value.mark(),
+        })
     }
 
-    pub fn has_changed(&self) -> bool {
-        *self.value != *self.watchers.borrow()
+    #[inline]
+    fn has_changed(&self, marker: Marker) -> bool {
+        self.value.has_changed(marker)
     }
 
-    pub fn check_for_changes(&self) {
-        if self.has_changed() {
+    fn check_for_changes(&self, marker: Marker) {
+        if self.has_changed(marker) {
             tracing::debug!(
                 watchers = self.watchers.receiver_count(),
                 "changed detected"
             );
             self.watchers
-                .send_modify(|value| *value = (*self.value).clone());
+                .send_modify(|value| *value = self.value.clone());
         } else {
             tracing::debug!("no change detected");
         }
@@ -109,17 +133,18 @@ impl<T: schemars::JsonSchema> schemars::JsonSchema for Watch<T> {
     }
 }
 
-pub struct ReadGuard<'inner, T: Clone + PartialEq + std::fmt::Debug> {
+pub struct ReadGuard<'inner, T: Watchable + std::fmt::Debug> {
     inner: &'inner Watch<T>,
+    marker: Marker,
 }
 
-impl<'inner, T: Clone + PartialEq + std::fmt::Debug> Drop for ReadGuard<'inner, T> {
+impl<'inner, T: Watchable + std::fmt::Debug> Drop for ReadGuard<'inner, T> {
     fn drop(&mut self) {
-        debug_assert!(!self.inner.has_changed());
+        debug_assert!(!self.inner.has_changed(self.marker));
     }
 }
 
-impl<'inner, T: Clone + PartialEq + std::fmt::Debug> std::ops::Deref for ReadGuard<'inner, T> {
+impl<'inner, T: Watchable + std::fmt::Debug> std::ops::Deref for ReadGuard<'inner, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -127,17 +152,18 @@ impl<'inner, T: Clone + PartialEq + std::fmt::Debug> std::ops::Deref for ReadGua
     }
 }
 
-pub struct WatchGuard<'inner, T: Clone + PartialEq + std::fmt::Debug> {
+pub struct WatchGuard<'inner, T: Watchable + std::fmt::Debug> {
     inner: &'inner Watch<T>,
+    marker: Marker,
 }
 
-impl<'inner, T: Clone + PartialEq + std::fmt::Debug> Drop for WatchGuard<'inner, T> {
+impl<'inner, T: Watchable + std::fmt::Debug> Drop for WatchGuard<'inner, T> {
     fn drop(&mut self) {
-        self.inner.check_for_changes();
+        self.inner.check_for_changes(self.marker);
     }
 }
 
-impl<'inner, T: Clone + PartialEq + std::fmt::Debug> std::ops::Deref for WatchGuard<'inner, T> {
+impl<'inner, T: Watchable + std::fmt::Debug> std::ops::Deref for WatchGuard<'inner, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -145,10 +171,12 @@ impl<'inner, T: Clone + PartialEq + std::fmt::Debug> std::ops::Deref for WatchGu
     }
 }
 
+#[cfg(test)]
 impl<T: PartialEq> PartialEq for Watch<T> {
     fn eq(&self, rhs: &Self) -> bool {
         self.value.eq(&rhs.value)
     }
 }
 
+#[cfg(test)]
 impl<T: Eq> Eq for Watch<T> {}

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -432,15 +432,20 @@ mod tests {
         );
 
         let mut context = WriteContext::new(
-            endpoints_fixture.endpoints().pop().unwrap().address.clone(),
+            endpoints_fixture
+                .endpoints()
+                .first()
+                .unwrap()
+                .address
+                .clone(),
             "127.0.0.1:70".parse().unwrap(),
             alloc_buffer(b"hello"),
         );
 
         chain.write(&mut context).await.unwrap();
         assert_eq!(
-            b"hello:our:127.0.0.1:80:127.0.0.1:70:our:127.0.0.1:80:127.0.0.1:70",
-            &*context.contents,
+            "hello:our:127.0.0.1:80:127.0.0.1:70:our:127.0.0.1:80:127.0.0.1:70",
+            std::str::from_utf8(&context.contents).unwrap(),
         );
         assert_eq!(
             "receive:receive",

--- a/src/net/cluster.rs
+++ b/src/net/cluster.rs
@@ -321,7 +321,7 @@ impl schemars::JsonSchema for ClusterMap {
 }
 
 pub struct ClusterMapDeser {
-    pub endpoints: Vec<EndpointWithLocality>,
+    pub(crate) endpoints: Vec<EndpointWithLocality>,
 }
 
 impl<'de> Deserialize<'de> for ClusterMapDeser {
@@ -334,7 +334,7 @@ impl<'de> Deserialize<'de> for ClusterMapDeser {
         endpoints.sort_by(|a, b| a.locality.cmp(&b.locality));
 
         for window in endpoints.windows(2) {
-            if &window[0] == &window[1] {
+            if window[0] == window[1] {
                 return Err(serde::de::Error::custom(
                     "duplicate localities found in cluster map",
                 ));

--- a/src/net/xds.rs
+++ b/src/net/xds.rs
@@ -89,25 +89,6 @@ mod xds {
         pub mod discovery {
             pub mod v3 {
                 tonic::include_proto!("envoy.service.discovery.v3");
-
-                impl TryFrom<DiscoveryResponse> for DiscoveryRequest {
-                    type Error = eyre::Error;
-
-                    fn try_from(response: DiscoveryResponse) -> Result<Self, Self::Error> {
-                        Ok(Self {
-                            version_info: response.version_info,
-                            resource_names: response
-                                .resources
-                                .into_iter()
-                                .map(crate::net::xds::Resource::try_from)
-                                .map(|result| result.map(|resource| resource.name().to_owned()))
-                                .collect::<Result<Vec<_>, _>>()?,
-                            type_url: response.type_url,
-                            response_nonce: response.nonce,
-                            ..<_>::default()
-                        })
-                    }
-                }
             }
         }
         pub mod cluster {
@@ -355,6 +336,7 @@ mod tests {
                     .read()
                     .get_default()
                     .unwrap()
+                    .endpoints
                     .iter()
                     .next()
                     .unwrap()

--- a/src/test.rs
+++ b/src/test.rs
@@ -327,6 +327,7 @@ pub fn alloc_buffer(data: impl AsRef<[u8]>) -> crate::pool::PoolBuffer {
 }
 
 /// assert that read makes no changes
+#[cfg(test)]
 pub async fn assert_filter_read_no_change<F>(filter: &F)
 where
     F: Filter,


### PR DESCRIPTION
This just changes `Watch<T>` to no longer require Clone + PartialEq, but rather a `Watchable` trait that can get a marker that can then be compared to the value after the write/read operation to see if it has changed, as right now with the non-incremental xds there is no need to be more granular than that, removing the extremely expensive PartialEq (though it is kept for testing purposes). In addition, this completely removes the clones done on the ClusterMap in favor of just  cloning the Arc<>. All tests pass, but I don't know if there is actually an integration test that really exercises this.