### PR TITLE
Fix: warning: failed to get HEAD path

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,11 @@ fn git_path(path: &str) -> IoResult<String> {
     if !output.status.success() {
         return Err(Error::new(
             ErrorKind::Other,
-            format!("`git` failed with status {}", output.status),
+            format!(
+                "`git` failed with status {}: {}",
+                output.status,
+                std::str::from_utf8(&output.stderr).unwrap_or("no output")
+            ),
         ));
     }
 

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -25,7 +25,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 # Install packages
 RUN set -eux && \
     apt-get update && \
-    apt-get install -y lsb-release jq curl wget zip build-essential software-properties-common \
+    apt-get install -y lsb-release jq curl wget zip git build-essential software-properties-common \
         libssl-dev pkg-config python3-pip bash-completion g++-x86-64-linux-gnu g++-mingw-w64-x86-64 && \
     pip3 install live-server && \
     echo "source /etc/bash_completion" >> /root/.bashrc
@@ -50,6 +50,9 @@ RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | b
 WORKDIR /tmp
 RUN wget --quiet -O htmltest.tar.gz "https://github.com/wjdp/htmltest/releases/download/v0.16.0/htmltest_0.16.0_linux_$(dpkg --print-architecture).tar.gz" && \
      tar -xf htmltest.tar.gz && mv ./htmltest /usr/local/bin/ && rm htmltest.tar.gz
+
+# Add /workspace as a git safe directory
+RUN git config --global --add safe.directory /workspace
 
 # Install Rust. Inspiration from: https://github.com/rust-lang/docker-rust/blob/master/1.64.0/bullseye/Dockerfile
 RUN set -eux; \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

I noticed on building the release binaries, we were getting the warning:

```
warning: failed to get HEAD path: `git` failed with status exit status: 128
```

Which made me realise that `git` wasn't installed on the build image, and therefore the builds didn't include the git commit.

This implements a fix for this, some better debugging error messaging and also some file ownership issues.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

