### PR TITLE
WIP: Fix for flaky agent <-> relay connections

### DIFF
--- a/agones/src/relay.rs
+++ b/agones/src/relay.rs
@@ -262,6 +262,8 @@ mod tests {
         // agent deployment
         let args = [
             "agent",
+            "--idle-request-interval-secs",
+            "5",
             "--relay",
             "http://quilkin-relay-agones:7900",
             "agones",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -405,7 +405,7 @@ mod tests {
 
             assert_eq!(
                 "hello",
-                timeout(Duration::from_millis(100), rx.recv())
+                timeout(Duration::from_secs(5), rx.recv())
                     .await
                     .expect("should have received a packet")
                     .unwrap()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -159,7 +159,7 @@ impl Cli {
         tracing::info!(
             version = crate_version!(),
             commit = crate::net::endpoint::metadata::build::GIT_COMMIT_HASH,
-            "Starting Quilkin"
+            "starting Quilkin"
         );
 
         // Non-long running commands (e.g. ones with no administration server)

--- a/src/cli/admin.rs
+++ b/src/cli/admin.rs
@@ -90,7 +90,7 @@ impl Admin {
     ) -> std::thread::JoinHandle<Result<(), hyper::Error>> {
         let address = address.unwrap_or_else(|| (std::net::Ipv6Addr::UNSPECIFIED, PORT).into());
         let health = Health::new();
-        tracing::info!(address = %address, "Starting admin endpoint");
+        tracing::info!(address = %address, "starting admin endpoint");
 
         let mode = self.clone();
         std::thread::spawn(move || {

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -128,7 +128,7 @@ impl RuntimeConfig {
     pub fn is_ready(&self) -> bool {
         let provider_healthy = self.provider_is_healthy.load(Ordering::SeqCst);
         let relay_healthy = self.relay_is_healthy.load(Ordering::SeqCst);
-        tracing::trace!(?provider_healthy, ?relay_healthy, "Agent readiness check");
+        tracing::trace!(?provider_healthy, ?relay_healthy, "agent readiness check");
 
         provider_healthy && relay_healthy
     }

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -126,7 +126,10 @@ pub struct RuntimeConfig {
 
 impl RuntimeConfig {
     pub fn is_ready(&self) -> bool {
-        self.provider_is_healthy.load(Ordering::SeqCst)
-            && self.relay_is_healthy.load(Ordering::SeqCst)
+        let provider_healthy = self.provider_is_healthy.load(Ordering::SeqCst);
+        let relay_healthy = self.relay_is_healthy.load(Ordering::SeqCst);
+        tracing::trace!(?provider_healthy, ?relay_healthy, "Agent readiness check");
+
+        provider_healthy && relay_healthy
     }
 }

--- a/src/config/providers/k8s.rs
+++ b/src/config/providers/k8s.rs
@@ -143,7 +143,7 @@ pub fn update_endpoints_from_gameservers(
 
                     tracing::trace!(
                         endpoints=%serde_json::to_value(servers.clone()).unwrap(),
-                        "Restarting with endpoints"
+                        "restarting with endpoints"
                     );
 
                     config.clusters.write().insert(locality.clone(), servers);

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -46,7 +46,7 @@ impl<T> Slot<T> {
     /// Adds a watcher to to the slot. The watcher will fire whenever slot's
     /// value changes.
     pub fn watch(&self, watcher: impl Fn(&T) + Send + Sync + 'static) {
-        tracing::trace!("Adding new watcher");
+        tracing::trace!("adding new watcher");
         self.watcher.store(Some(Arc::new(Box::new(watcher))));
     }
 

--- a/src/net/xds/client.rs
+++ b/src/net/xds/client.rs
@@ -410,6 +410,7 @@ impl MdsStream {
                     tracing::trace!("sending request");
                     let _ = requests.send(initial_response);
                     tracing::trace!("streaming requests");
+                    // TOXO: got an idea - can we timeout up here, and fall into retry loop?
                     let stream = client
                         .stream_requests(
                             // Errors only happen if the stream is behind, which

--- a/src/net/xds/client.rs
+++ b/src/net/xds/client.rs
@@ -425,6 +425,7 @@ impl MdsStream {
                         mode.idle_request_interval_secs(),
                     );
                     let mut stream = control_plane.stream_aggregated_resources(stream).await?;
+                    tracing::trace!("relay marked as healthy");
                     mode.unwrap_agent()
                         .relay_is_healthy
                         .store(true, Ordering::SeqCst);

--- a/src/net/xds/client.rs
+++ b/src/net/xds/client.rs
@@ -143,7 +143,7 @@ impl<C: ServiceClient> Client<C> {
         let max_delay = Duration::from_secs(BACKOFF_MAX_DELAY_SECONDS);
 
         let retry_config = RetryFutureConfig::new(u32::MAX).custom_backoff(|attempt, error: &_| {
-            tracing::info!(attempt, "Retrying to connect");
+            tracing::info!(attempt, "retrying to connect");
             // reset after success
             if attempt <= 1 {
                 backoff = ExponentialBackoff::new(Duration::from_millis(
@@ -162,16 +162,16 @@ impl<C: ServiceClient> Client<C> {
 
             match error {
                 RpcSessionError::InvalidEndpoint(ref error) => {
-                    tracing::error!(?error, "Error creating endpoint");
+                    tracing::error!(?error, "error creating endpoint");
                     // Do not retry if this is an invalid URL error that we cannot recover from.
                     RetryPolicy::Break
                 }
                 RpcSessionError::InitialConnect(ref error) => {
-                    tracing::warn!(?error, "Unable to connect to the XDS server");
+                    tracing::warn!(?error, "unable to connect to the xDS server");
                     RetryPolicy::Delay(delay)
                 }
                 RpcSessionError::Receive(ref status) => {
-                    tracing::warn!(status = ?status, "Failed to receive response from XDS server");
+                    tracing::warn!(status = ?status, "failed to receive response from xDS server");
                     RetryPolicy::Delay(delay)
                 }
             }
@@ -217,7 +217,7 @@ impl<C: ServiceClient> Client<C> {
         let client = connect_to_server
             .instrument(tracing::trace_span!("client_connect"))
             .await?;
-        tracing::info!("Connected to management server");
+        tracing::info!("connected to management server");
         Ok(client)
     }
 }
@@ -325,7 +325,7 @@ impl AdsStream {
                                 continue;
                             }
                             Ok(Some(Err(error))) => {
-                                tracing::warn!(%error, "xds stream error");
+                                tracing::warn!(%error, "xDS stream error");
                                 break;
                             }
                             Ok(None) => {

--- a/src/net/xds/client.rs
+++ b/src/net/xds/client.rs
@@ -407,7 +407,9 @@ impl MdsStream {
                         }),
                         ..<_>::default()
                     };
+                    tracing::trace!("sending request");
                     let _ = requests.send(initial_response);
+                    tracing::trace!("streaming requests");
                     let stream = client
                         .stream_requests(
                             // Errors only happen if the stream is behind, which
@@ -419,11 +421,12 @@ impl MdsStream {
                         .in_current_span()
                         .await?
                         .into_inner();
-
+                    tracing::trace!("control plane: creating from config");
                     let control_plane = super::server::ControlPlane::from_arc(
                         config.clone(),
                         mode.idle_request_interval_secs(),
                     );
+                    tracing::trace!("control plane: streaming aggregated resources");
                     let mut stream = control_plane.stream_aggregated_resources(stream).await?;
                     tracing::trace!("relay marked as healthy");
                     mode.unwrap_agent()

--- a/src/net/xds/server.rs
+++ b/src/net/xds/server.rs
@@ -190,11 +190,13 @@ impl ControlPlane {
             tracing::error!("No message found");
             tonic::Status::invalid_argument("No message found")
         })??;
+        tracing::trace!("message received: checking");
 
         if message.node.is_none() {
             tracing::error!("Node identifier was not found");
             return Err(tonic::Status::invalid_argument("Node identifier required"));
         }
+        tracing::trace!("message received: success");
 
         let node = message.node.clone().unwrap();
         let resource_type: ResourceType = message.type_url.parse()?;
@@ -212,6 +214,7 @@ impl ControlPlane {
             yield response;
 
             loop {
+                tracing::trace!("LOOPING!");
                 tokio::select! {
                     _ = rx.changed() => {
                         tracing::trace!("sending new discovery response");

--- a/src/net/xds/server.rs
+++ b/src/net/xds/server.rs
@@ -186,6 +186,7 @@ impl ControlPlane {
             + 'static,
     {
         tracing::trace!("starting stream");
+        // TOXO should timeout be here?
         let message = streaming.next().await.ok_or_else(|| {
             tracing::error!("No message found");
             tonic::Status::invalid_argument("No message found")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking

/kind bug

> /kind cleanup
> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Initial connection to a relay can get hung, this is an attempt at forcing a reconnection attempt on timeout.

Please take a look and let me know what you think of the approach.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Work on #877

**Special notes for your reviewer**:

Left in my debugging logging, since this is draft. Will clear out when we're happy with the approach.

Running the test `relay::tests::agones_token_router` no longer fails. I ran it 100 times and it passed, whereas it would often fail <= the 20th iteration.

Once weird thing I definitely see with this though, if a retry of the initial connection does happen, I see this a lot in the Agent logs. The integration test still passes, but I fear that's only because I set the `--idle-request-interval-secs` to `5s`.

```json
{
  "insertId": "r1zix3op9jh9f7ur",
  "jsonPayload": {
    "timestamp": "2023-11-29T00:46:13.971649Z",
    "span": {
      "name": "handle_discovery_response"
    },
    "filename": "src/net/xds/client.rs",
    "target": "quilkin::net::xds::client",
    "spans": [
      {
        "name": "handle_discovery_response"
      }
    ],
    "level": "WARN",
    "fields": {
      "message": "lost connection to relay server, retrying"
    }
  },
  "resource": {
    "type": "k8s_container",
    "labels": {
      "project_id": "quilkin-mark-dev",
      "location": "us-west1-c",
      "pod_name": "quilkin-agones-agent-75b75d7494-28fjf",
      "container_name": "quilkin",
      "cluster_name": "agones",
      "namespace_name": "1701218738"
    }
  },
  "timestamp": "2023-11-29T00:46:13.971916187Z",
  "severity": "WARNING",
  "labels": {
    "k8s-pod/pod-template-hash": "75b75d7494",
    "compute.googleapis.com/resource_name": "gke-agones-default-ad8cd7e5-nq83",
    "k8s-pod/role": "agent"
  },
  "logName": "projects/quilkin-mark-dev/logs/stdout",
  "receiveTimestamp": "2023-11-29T00:46:15.465040550Z"
}
```

While this fix does provide greater reliability on the Agent side (so we may want to merge it anyway) -- I am wondering if it's masking an issue on the relay side?

Would love your thoughts!
