### PR TITLE
Send back an empty delta response for initial `ignore-me`

### DIFF
--- a/src/config/xds.rs
+++ b/src/config/xds.rs
@@ -43,6 +43,10 @@ pub fn handle_delta_discovery_responses(
                 }
             };
 
+            if response.type_url == "ignore-me" {
+                continue;
+            }
+
             let control_plane_identifier = response.control_plane.as_ref().map(|cp| cp.identifier.as_str()).unwrap_or_default();
 
             metrics::delta_discovery_responses(control_plane_identifier, &response.type_url).inc();

--- a/src/net/xds/server.rs
+++ b/src/net/xds/server.rs
@@ -399,13 +399,25 @@ impl ControlPlane {
             };
 
         let response = {
-            let resource_type: ResourceType = message.type_url.parse()?;
-            tracing::trace!(id = %node_id, %resource_type, "initial delta request");
-            responder(
-                Some(message),
-                &mut trackers[resource_type],
-                &mut pending_acks,
-            )?
+            if message.type_url == "ignore-me" {
+                DeltaDiscoveryResponse {
+                    resources: Vec::new(),
+                    nonce: String::new(),
+                    control_plane: None,
+                    type_url: message.type_url,
+                    removed_resources: Vec::new(),
+                    // Only used for debugging, not really useful
+                    system_version_info: String::new(),
+                }
+            } else {
+                let resource_type: ResourceType = message.type_url.parse()?;
+                tracing::trace!(id = %node_id, %resource_type, "initial delta request");
+                responder(
+                    Some(message),
+                    &mut trackers[resource_type],
+                    &mut pending_acks,
+                )?
+            }
         };
 
         let nid = node_id.clone();


### PR DESCRIPTION
The initial request, which _should_ be the only `ignore-me` request was being treated as a regular request. Note there is apparently no test that covers this case otherwise the bug wouldn't have been merged