### PR TITLE
Fix health_server test

### DIFF
--- a/tests/health.rs
+++ b/tests/health.rs
@@ -32,7 +32,10 @@ async fn health_server() {
     });
     t.run_server(
         server_config,
-        None,
+        Some(quilkin::Proxy {
+            qcmp_port: 9094,
+            ..Default::default()
+        }),
         Some(Some((std::net::Ipv6Addr::UNSPECIFIED, 9093).into())),
     )
     .await;


### PR DESCRIPTION
When running all tests in parallel with cargo nextest this would fail since the port is bound in multiple tests