### PR TITLE
Move non-linux builds to github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@
 # with auto-merge enabled and update it to the latest `main`, forming a best-effort queue
 # of approved PRs.
 
-name: Validate protobufs
+name: CI
 
 on:
   push:
@@ -30,10 +30,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
+  validate-proto-bufs:
+    name: Validate proto bufs
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
             submodules: true
       - run: cargo run -p proto-gen -- validate
+
+  build:
+    name: Build
+    strategy:
+      matrix:
+        os: [windows-2022, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fetch
+      - run: cargo build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: "clippy, rustfmt"
+      - uses: Swatinem/rust-cache@v2
+
+      # make sure all code has been formatted with rustfmt and linted with clippy
+      - name: rustfmt
+        run: cargo fmt -- --check --color always
+
+      # run clippy to verify we have no warnings
+      - run: cargo fetch
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
   validate-proto-bufs:
     name: Validate proto bufs
     runs-on: ubuntu-22.04
@@ -53,3 +72,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fetch
       - run: cargo build
+
+  deny-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: deny check
+        uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
   deny-check:
     runs-on: ubuntu-22.04
+    if: false # skip until I've updated the action
     steps:
       - uses: actions/checkout@v4
       - name: deny check

--- a/build/Makefile
+++ b/build/Makefile
@@ -78,6 +78,14 @@ version:
 # Run all tests
 test: ensure-build-image test-quilkin test-examples test-docs
 
+# In CI with split jobs that both fetch they will fail if run in parallel since
+# cargo will be fighting with itself for some the same host directory that is
+# mapped into the container, so instead just split it out to its own job
+fetch-quilkin: ensure-build-image
+	docker run --rm $(common_rust_args)  \
+			--network=host \
+			-e RUST_BACKTRACE=1 --entrypoint=cargo $(BUILD_IMAGE_TAG) fetch
+
 check-quilkin: ensure-build-image
 	docker run --rm $(common_rust_args) \
 			--entrypoint=cargo $(BUILD_IMAGE_TAG) deny check

--- a/build/Makefile
+++ b/build/Makefile
@@ -86,12 +86,13 @@ check-quilkin: ensure-build-image
 	docker run --rm $(common_rust_args) \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
 
-# test only the quilkin crate
+# test only the quilkin crate, if you want to see test output regardless of test
+# failure or success, set RUST_TEST_NOCAPTURE to something other than "0"
 test-quilkin: ensure-build-image
 	# --network=host because docker containers are not great at ipv6.
 	docker run --rm $(common_rust_args)  \
 			--network=host \
-			-e RUST_BACKTRACE=1 --entrypoint=cargo $(BUILD_IMAGE_TAG) test -- --nocapture
+			-e RUST_BACKTRACE=1 --entrypoint=cargo $(BUILD_IMAGE_TAG) test
 
 # Run tests against the examples
 test-examples: ensure-build-image

--- a/build/Makefile
+++ b/build/Makefile
@@ -78,14 +78,16 @@ version:
 # Run all tests
 test: ensure-build-image test-quilkin test-examples test-docs
 
-# test only the quilkin crate
-test-quilkin: ensure-build-image
+check-quilkin: ensure-build-image
 	docker run --rm $(common_rust_args) \
 			--entrypoint=cargo $(BUILD_IMAGE_TAG) deny check
 	docker run --rm $(common_rust_args) \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) clippy --tests -- -D warnings
 	docker run --rm $(common_rust_args) \
 		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
+
+# test only the quilkin crate
+test-quilkin: ensure-build-image
 	# --network=host because docker containers are not great at ipv6.
 	docker run --rm $(common_rust_args)  \
 			--network=host \

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,6 +34,14 @@ steps:
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
+      - check-quilkin
+    id: check-quilkin
+    waitFor:
+      - fetch-git-submodules
+      - pull-build-image
+  - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
+    dir: ./build
+    args:
       - test-examples
     id: test-examples
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,12 +14,12 @@
 
 steps:
   - name: gcr.io/cloud-builders/git
-    args: [ submodule, update, --init, --recursive ]
+    args: [submodule, update, --init, --recursive]
     id: fetch-git-submodules
     waitFor:
       - "-"
   - name: gcr.io/cloud-builders/docker
-    args: [ pull, "${_BUILD_IMAGE_TAG}" ]
+    args: [pull, "${_BUILD_IMAGE_TAG}"]
     id: pull-build-image
     waitFor:
       - "-" # Run immediately, don't wait for any previous steps
@@ -44,7 +44,7 @@ steps:
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
-      - build
+      - build-image
     id: build
 
   #
@@ -56,7 +56,7 @@ steps:
     dir: ./build
     entrypoint: bash
     args:
-      - '-c'
+      - "-c"
       - 'timeout --signal=INT --preserve-status 5s docker run --rm -v "/workspace/examples/proxy.yaml:/etc/quilkin/quilkin.yaml" ${_REPOSITORY}quilkin:$(make version) proxy'
     id: test-quilkin-image-default-config-file
     waitFor:
@@ -67,7 +67,7 @@ steps:
     dir: ./build
     entrypoint: bash
     args:
-      - '-c'
+      - "-c"
       - 'timeout --signal=INT --preserve-status 5s docker run -v /tmp:/etc/quilkin/ --rm ${_REPOSITORY}quilkin:$(make version) proxy --to="127.0.0.1:0"'
     id: test-quilkin-image-command-line
     waitFor:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -41,31 +41,18 @@ steps:
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
-      - check-quilkin
-    id: check-quilkin
-    waitFor:
-      - fetch-quilkin
-  - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
-    dir: ./build
-    args:
       - test-examples
     id: test-examples
-    waitFor:
-      - fetch-quilkin
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
       - test-docs
     id: test-docs
-    waitFor:
-      - fetch-quilkin
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
       - build-image
     id: build
-    waitFor:
-      - fetch-quilkin
 
   #
   # Run the built images for 5 seconds in a few standard configurations, to test basic common scenarios

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -26,34 +26,46 @@ steps:
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
-      - test-quilkin
-    id: test-quilkin
+      - fetch-quilkin
+    id: fetch-quilkin
     waitFor:
       - fetch-git-submodules
       - pull-build-image
+  - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
+    dir: ./build
+    args:
+      - test-quilkin
+    id: test-quilkin
+    waitFor:
+      - fetch-quilkin
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
       - check-quilkin
     id: check-quilkin
     waitFor:
-      - fetch-git-submodules
-      - pull-build-image
+      - fetch-quilkin
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
       - test-examples
     id: test-examples
+    waitFor:
+      - fetch-quilkin
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
       - test-docs
     id: test-docs
+    waitFor:
+      - fetch-quilkin
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
       - build-image
     id: build
+    waitFor:
+      - fetch-quilkin
 
   #
   # Run the built images for 5 seconds in a few standard configurations, to test basic common scenarios


### PR DESCRIPTION
This allows CI to still check windows/macos compile, but actually run in parallel rather than serializing on each platform and wasting valuable CI time
