### PR TITLE
Fix timestamp/duration unit confusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -915,9 +915,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1046,7 +1046,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.6",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,12 +1585,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,16 +1620,6 @@ dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2104,7 +2088,6 @@ dependencies = [
  "libflate",
  "lz4_flex",
  "maxminddb",
- "nom",
  "notify",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,6 @@ trust-dns-resolver = { version = "0.23.0", features = [
     "dns-over-https-rustls",
 ] }
 async-trait = "0.1.73"
-nom = "7.1.3"
 strum = "0.25.0"
 strum_macros = "0.25.2"
 cfg-if = "1.0.0"

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -249,6 +249,8 @@ pub fn spawn(socket: socket2::Socket, mut shutdown_rx: crate::ShutdownRx) {
                     Protocol::ping_reply(nonce, client_timestamp, received_at)
                         .encode(&mut output_buf);
 
+                    tracing::debug!("sending ping reply {:?}", &output_buf.buf[..output_buf.len]);
+
                     output_buf = match socket.send_to(output_buf, source).await {
                         (Ok(_), buf) => buf,
                         (Err(error), buf) => {
@@ -684,13 +686,15 @@ mod tests {
         let delay = std::time::Duration::from_millis(50);
         let node = QcmpMeasurement::with_artificial_delay(delay).unwrap();
 
-        let dm = node.measure_distance(addr).await.unwrap();
-        let total = dm.total();
+        for _ in 0..3 {
+            let dm = node.measure_distance(addr).await.unwrap();
+            let total = dm.total();
 
-        assert!(
-            total > delay && total < delay * 2,
-            "Node1's distance is {total:?}, expected > {delay:?} and less than {:?}",
-            delay * 2
-        );
+            assert!(
+                total > delay && total < delay * 2,
+                "Node1's distance is {total:?}, expected > {delay:?} and less than {:?}",
+                delay * 2
+            );
+        }
     }
 }

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -199,7 +199,7 @@ impl Measurement for QcmpMeasurement {
 
         let now = UtcTimestamp::now();
         let Some(reply) = Protocol::parse(&recv[..size])? else {
-            return Err(eyre::eyre!("received non qcmp packet"));
+            return Err(eyre::eyre!("received non qcmp packet {:?}", &recv[..size]));
         };
 
         reply

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -66,6 +66,15 @@ unsafe impl tokio_uring::buf::IoBuf for QcmpPacket {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
+impl std::ops::Deref for QcmpPacket {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.buf[..self.len]
+    }
+}
+
 type Result<T, E = Error> = std::result::Result<T, E>;
 
 struct PacketBuilder<'buf> {

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -16,44 +16,165 @@
 
 //! Logic for parsing and generating Quilkin Control Message Protocol (QCMP) messages.
 
+use crate::{
+    net::{
+        phoenix::{DistanceMeasure, Measurement},
+        DualStackEpollSocket, DualStackLocalSocket,
+    },
+    time::{DurationNanos, UtcTimestamp},
+};
 use std::sync::Arc;
-
-use nom::bytes::complete;
-
-use crate::net::{phoenix::Measurement, DualStackEpollSocket, DualStackLocalSocket};
+#[cfg(test)]
+use std::time::Duration;
 
 // Magic number to distinguish control packets from regular traffic.
 const MAGIC_NUMBER: &[u8] = b"QLKN";
-const TIMESTAMP_LEN: usize = (i64::BITS / 8) as usize;
 const VERSION: u8 = 0;
-const VERSION_LEN: usize = 1;
-const NONCE_LEN: usize = 1;
-const LENGTH_LEN: usize = 2;
-const DISCRIMINANT_LEN: usize = 1;
+/// The minimum length of a QCMP packet
+pub const MIN_QCMP_PACKET_LEN: usize = 4 /* MAGIC_NUMBER */ + 1 /* VERSION */ + 1 /* DISCRIMINANT */ + 1 /* NONCE */ + 2 /* LENGTH */ + std::mem::size_of::<u64>();
+/// The maximum length of a QCMP packet, including 2 additional i64 timestamps
+pub const MAX_QCMP_PACKET_LEN: usize = MIN_QCMP_PACKET_LEN + std::mem::size_of::<u64>() * 2;
+const PING: u8 = 0;
+const PONG: u8 = 1;
+
+pub struct QcmpPacket {
+    buf: [u8; MAX_QCMP_PACKET_LEN],
+    len: usize,
+}
+
+impl Default for QcmpPacket {
+    fn default() -> Self {
+        Self {
+            buf: [0u8; MAX_QCMP_PACKET_LEN],
+            len: 0,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe impl tokio_uring::buf::IoBuf for QcmpPacket {
+    fn stable_ptr(&self) -> *const u8 {
+        self.buf.as_ptr()
+    }
+
+    fn bytes_init(&self) -> usize {
+        self.len
+    }
+
+    fn bytes_total(&self) -> usize {
+        self.buf.len()
+    }
+}
 
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+struct PacketBuilder<'buf> {
+    packet: &'buf mut QcmpPacket,
+    offset: usize,
+}
+
+impl<'buf> PacketBuilder<'buf> {
+    #[inline]
+    fn wrap(packet: &'buf mut QcmpPacket) -> Self {
+        packet.len = 0;
+        Self { packet, offset: 0 }
+    }
+
+    #[inline]
+    fn push(&mut self, val: u8) {
+        self.packet.buf[self.offset] = val;
+        self.offset += 1;
+    }
+
+    #[inline]
+    fn push_slice(&mut self, slice: &[u8]) {
+        self.packet.buf[self.offset..self.offset + slice.len()].copy_from_slice(slice);
+        self.offset += slice.len();
+    }
+
+    #[inline]
+    fn finalize(self) -> &'buf [u8] {
+        self.packet.buf[self.offset..].fill(0);
+        self.packet.len = self.offset;
+        &self.packet.buf[..self.offset]
+    }
+}
+
+struct PacketParser<'buf> {
+    packet: &'buf [u8],
+    offset: usize,
+}
+
+impl<'buf> PacketParser<'buf> {
+    fn wrap(packet: &'buf [u8]) -> Result<Self> {
+        if packet.len() < MIN_QCMP_PACKET_LEN {
+            return Err(Error::LengthMismatch(
+                MIN_QCMP_PACKET_LEN as _,
+                packet.len(),
+            ));
+        }
+
+        Ok(Self { packet, offset: 0 })
+    }
+
+    #[inline]
+    fn read(&mut self) -> u8 {
+        let index = self.offset;
+        self.offset += 1;
+        // SAFETY: We manually check the packet size before any reads
+        unsafe { *self.packet.get_unchecked(index) }
+    }
+
+    #[inline]
+    fn read_slice<const N: usize>(&mut self) -> [u8; N] {
+        let mut s = [0u8; N];
+        // SAFETY: We manually check the packet size before any reads
+        s.copy_from_slice(unsafe { self.packet.get_unchecked(self.offset..self.offset + N) });
+        self.offset += N;
+        s
+    }
+}
 
 /// A measurement implementation using QCMP pings for measuring the distance
 /// between nodes.
 #[derive(Debug, Clone)]
 pub struct QcmpMeasurement {
     socket: Arc<DualStackEpollSocket>,
+    #[cfg(test)]
+    delay: Option<Duration>,
 }
 
 impl QcmpMeasurement {
     pub fn new() -> crate::Result<Self> {
         Ok(Self {
             socket: Arc::new(DualStackEpollSocket::new(0)?),
+            #[cfg(test)]
+            delay: None,
+        })
+    }
+
+    #[cfg(test)]
+    pub fn with_artificial_delay(delay: Duration) -> crate::Result<Self> {
+        Ok(Self {
+            socket: Arc::new(DualStackEpollSocket::new(0)?),
+            delay: Some(delay),
         })
     }
 }
 
 #[async_trait::async_trait]
 impl Measurement for QcmpMeasurement {
-    async fn measure_distance(&self, address: std::net::SocketAddr) -> eyre::Result<(i64, i64)> {
-        self.socket
-            .send_to(&Protocol::ping().encode(), address)
-            .await?;
+    async fn measure_distance(
+        &self,
+        address: std::net::SocketAddr,
+    ) -> eyre::Result<DistanceMeasure> {
+        {
+            let mut ping = QcmpPacket::default();
+            self.socket
+                .send_to(Protocol::ping().encode(&mut ping), address)
+                .await?;
+        }
+
         let mut recv = [0u8; 512];
 
         let (size, _) = tokio::time::timeout(
@@ -61,13 +182,19 @@ impl Measurement for QcmpMeasurement {
             self.socket.recv_from(&mut recv),
         )
         .await??;
-        let now = crate::unix_timestamp();
+
+        #[cfg(test)]
+        if let Some(ad) = self.delay {
+            tokio::time::sleep(ad).await;
+        }
+
+        let now = UtcTimestamp::now();
         let Some(reply) = Protocol::parse(&recv[..size])? else {
             return Err(eyre::eyre!("received non qcmp packet"));
         };
 
         reply
-            .incoming_and_outgoing_latency(now)
+            .distance(now)
             .ok_or_else(|| eyre::eyre!("received non ping reply"))
     }
 }
@@ -76,11 +203,9 @@ pub fn spawn(socket: socket2::Socket, mut shutdown_rx: crate::ShutdownRx) {
     let port = crate::net::socket_port(&socket);
 
     uring_spawn!(tracing::debug_span!("qcmp"), async move {
-        // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
-        // packet, which is the maximum value of 16 a bit integer.
         let mut input_buf = vec![0; 1 << 16];
         let socket = DualStackLocalSocket::new(port).unwrap();
-        let mut output_buf = Vec::new();
+        let mut output_buf = QcmpPacket::default();
 
         loop {
             let result = tokio::select! {
@@ -90,7 +215,7 @@ pub fn spawn(socket: socket2::Socket, mut shutdown_rx: crate::ShutdownRx) {
             match result {
                 (Ok((size, source)), new_input_buf) => {
                     input_buf = new_input_buf;
-                    let received_at = crate::unix_timestamp();
+                    let received_at = UtcTimestamp::now();
                     let command = match Protocol::parse(&input_buf[..size]) {
                         Ok(Some(command)) => command,
                         Ok(None) => {
@@ -113,18 +238,15 @@ pub fn spawn(socket: socket2::Socket, mut shutdown_rx: crate::ShutdownRx) {
                     };
 
                     Protocol::ping_reply(nonce, client_timestamp, received_at)
-                        .encode_into_buffer(&mut output_buf);
+                        .encode(&mut output_buf);
 
-                    let mut new_output_buf = match socket.send_to(output_buf, source).await {
+                    output_buf = match socket.send_to(output_buf, source).await {
                         (Ok(_), buf) => buf,
                         (Err(error), buf) => {
                             tracing::warn!(%error, "error responding to ping");
                             buf
                         }
                     };
-
-                    new_output_buf.clear();
-                    output_buf = new_output_buf;
                 }
                 (Err(error), new_input_buf) => {
                     tracing::warn!(%error, "error receiving packet");
@@ -142,7 +264,7 @@ pub enum Protocol {
     /// latency.
     Ping {
         /// The timestamp from when the client sent the packet.
-        client_timestamp: i64,
+        client_timestamp: UtcTimestamp,
         /// The client's nonce.
         nonce: u8,
     },
@@ -152,13 +274,13 @@ pub enum Protocol {
     /// two machines.
     PingReply {
         /// The timestamp from when the client sent the ping packet.
-        client_timestamp: i64,
+        client_timestamp: UtcTimestamp,
         /// The client's nonce.
         nonce: u8,
         /// The timestamp from when the server received the ping packet.
-        server_start_timestamp: i64,
+        server_start_timestamp: UtcTimestamp,
         /// The timestamp from when the server sent the reply.
-        server_transmit_timestamp: i64,
+        server_transmit_timestamp: UtcTimestamp,
     },
 }
 
@@ -168,49 +290,54 @@ impl Protocol {
     pub fn ping() -> Self {
         Self::ping_with_nonce(rand::random())
     }
+
     /// Creates a [`Self::Ping`] with a user-specified nonce, should be sent
     /// as soon as possible from creation to maintain accuracy.
     pub fn ping_with_nonce(nonce: u8) -> Self {
         Self::Ping {
             nonce,
-            client_timestamp: crate::unix_timestamp(),
+            client_timestamp: UtcTimestamp::now(),
         }
     }
 
     /// Creates a [`Self::PingReply`] from the client and server start timestamp.
     /// It's recommended to transmit as as soon as possible from creation to
     /// keep the start and transmit times as accurate as possible.
-    pub fn ping_reply(nonce: u8, client_timestamp: i64, server_start_timestamp: i64) -> Self {
+    pub fn ping_reply(
+        nonce: u8,
+        client_timestamp: UtcTimestamp,
+        server_start_timestamp: UtcTimestamp,
+    ) -> Self {
         Self::PingReply {
             nonce,
             client_timestamp,
             server_start_timestamp,
-            server_transmit_timestamp: crate::unix_timestamp(),
+            server_transmit_timestamp: UtcTimestamp::now(),
         }
     }
 
     /// Encodes the protocol command into a buffer of bytes for network transmission.
-    pub fn encode(&self) -> Vec<u8> {
-        let mut buffer = Vec::new();
-        self.encode_into_buffer(&mut buffer);
-        buffer
-    }
+    pub fn encode<'buf>(&self, buffer: &'buf mut QcmpPacket) -> &'buf [u8] {
+        let mut pb = PacketBuilder::wrap(buffer);
+        pb.push_slice(MAGIC_NUMBER);
+        pb.push(VERSION);
+        pb.push(self.discriminant());
+        pb.push_slice(&self.discriminant_length().to_be_bytes());
 
-    /// Encodes the protocol command into a buffer of bytes for network transmission.
-    pub fn encode_into_buffer(&self, buffer: &mut Vec<u8>) {
-        buffer.extend(MAGIC_NUMBER);
-        buffer.push(VERSION);
-        buffer.push(self.discriminant());
-        buffer.extend_from_slice(&self.discriminant_length().to_be_bytes());
+        #[cfg(debug_assertions)]
+        {
+            let length = pb.offset;
+            self.encode_payload(&mut pb);
 
-        let length = buffer.len();
+            assert_eq!(pb.offset, length + usize::from(self.discriminant_length()));
+        }
 
-        self.encode_payload(buffer);
+        #[cfg(not(debug_assertions))]
+        {
+            self.encode_payload(&mut pb);
+        }
 
-        debug_assert_eq!(
-            buffer.len(),
-            length + usize::from(self.discriminant_length())
-        );
+        pb.finalize()
     }
 
     /// Returns the packet's nonce.
@@ -221,25 +348,28 @@ impl Protocol {
         }
     }
 
-    fn encode_payload(&self, buffer: &mut Vec<u8>) {
+    fn encode_payload(&self, pb: &mut PacketBuilder<'_>) {
+        pb.push(self.nonce());
+
+        let mut ets = |ts: &UtcTimestamp| {
+            pb.push_slice(&ts.unix_nanos().to_be_bytes());
+        };
+
         match self {
             Protocol::Ping {
-                nonce,
-                client_timestamp,
+                client_timestamp, ..
             } => {
-                buffer.push(*nonce);
-                buffer.extend_from_slice(&client_timestamp.to_be_bytes())
+                ets(client_timestamp);
             }
             Protocol::PingReply {
-                nonce,
                 client_timestamp,
                 server_start_timestamp,
                 server_transmit_timestamp,
+                ..
             } => {
-                buffer.push(*nonce);
-                buffer.extend_from_slice(&client_timestamp.to_be_bytes());
-                buffer.extend_from_slice(&server_start_timestamp.to_be_bytes());
-                buffer.extend_from_slice(&server_transmit_timestamp.to_be_bytes());
+                ets(client_timestamp);
+                ets(server_start_timestamp);
+                ets(server_transmit_timestamp);
             }
         }
     }
@@ -249,7 +379,10 @@ impl Protocol {
     /// proxy, using the same algorithm as [Network Time Protocol (NTP)][ntp].
     ///
     /// [ntp]: https://en.wikipedia.org/wiki/Network_Time_Protocol#Clock_synchronization_algorithm
-    pub fn round_trip_delay(&self, client_response_timestamp: i64) -> Option<i64> {
+    pub fn round_trip_delay(
+        &self,
+        client_response_timestamp: UtcTimestamp,
+    ) -> Option<DurationNanos> {
         let Protocol::PingReply {
             client_timestamp,
             server_start_timestamp,
@@ -260,18 +393,15 @@ impl Protocol {
             return None;
         };
 
-        Some(
-            (client_response_timestamp - client_timestamp)
-                - (server_transmit_timestamp - server_start_timestamp),
-        )
+        Some(DurationNanos::from_nanos(
+            (client_response_timestamp.unix_nanos() - client_timestamp.unix_nanos())
+                - (server_transmit_timestamp.unix_nanos() - server_start_timestamp.unix_nanos()),
+        ))
     }
 
     /// If the command is [`Protocol::PingReply`], with `client_response_timestamp`
     /// returns the time between the client -> server, and the server -> client.
-    pub fn incoming_and_outgoing_latency(
-        &self,
-        client_response_timestamp: i64,
-    ) -> Option<(i64, i64)> {
+    pub fn distance(&self, client_response_timestamp: UtcTimestamp) -> Option<DistanceMeasure> {
         let Protocol::PingReply {
             client_timestamp,
             server_start_timestamp,
@@ -282,17 +412,17 @@ impl Protocol {
             return None;
         };
 
-        Some((
-            server_start_timestamp - client_timestamp,
-            client_response_timestamp - server_transmit_timestamp,
-        ))
+        Some(DistanceMeasure {
+            incoming: *server_start_timestamp - *client_timestamp,
+            outgoing: client_response_timestamp - *server_transmit_timestamp,
+        })
     }
 
     /// Returns the discriminant code, identifying the payload.
     const fn discriminant(&self) -> u8 {
         match self {
-            Self::Ping { .. } => 0,
-            Self::PingReply { .. } => 1,
+            Self::Ping { .. } => PING,
+            Self::PingReply { .. } => PONG,
         }
     }
 
@@ -303,89 +433,86 @@ impl Protocol {
 
     /// The expected length of payload based on its discriminant.
     const fn payload_length(discriminant: u8) -> Result<u16> {
-        Ok(match discriminant {
-            0 => NONCE_LEN as u16 + TIMESTAMP_LEN as u16,
-            1 => NONCE_LEN as u16 + (TIMESTAMP_LEN as u16 * 3),
+        let num = match discriminant {
+            PING => 1,
+            PONG => 3,
             code => return Err(Error::InvalidCommand(code)),
-        })
+        };
+
+        Ok(1 + std::mem::size_of::<i64>() as u16 * num)
     }
 
     /// Parses the provided input, and attempts to parse it as a `Protocol`
-    /// packet. Returning `None` if the magic number is not present, and thus
-    /// is not a QCMP packet, and returning `Err` when it was detected as a
-    /// QCMP packet, but there was an error in parsing the payload.
+    /// packet.
+    ///
+    /// Returns `None` if the magic number is not present, and thus is not a
+    /// QCMP packet, and returning `Err` when it was detected as a QCMP packet,
+    /// but there was an error in parsing the payload.
     pub fn parse(input: &[u8]) -> Result<Option<Self>> {
-        let Ok((input, _)) = complete::tag::<_, _, nom::error::Error<_>>(MAGIC_NUMBER)(input)
-        else {
+        let mut pp = PacketParser::wrap(input)?;
+
+        let magic = pp.read_slice::<4>();
+        if magic != MAGIC_NUMBER {
             return Ok(None);
-        };
+        }
 
-        let (input, version) = Self::parse_version(input)?;
-
-        if version != 0 {
+        let version = pp.read();
+        if version != VERSION {
             return Err(Error::UnknownVersion(version));
         }
 
-        let (input, discriminant) = Self::parse_discriminant(input)?;
-        let (input, length) = Self::parse_length(input)?;
+        let discriminant = pp.read();
+        // Now that we know the packet kind we can ensure the rest of the expected
+        // packet length is available to avoid panics
+        let size = match discriminant {
+            PING => MIN_QCMP_PACKET_LEN,
+            PONG => MAX_QCMP_PACKET_LEN,
+            unknown => return Err(Error::InvalidCommand(unknown)),
+        };
+
+        if pp.packet.len() < size {
+            return Err(Error::LengthMismatch(size as _, pp.packet.len()));
+        }
+
+        let length = u16::from_be_bytes(pp.read_slice::<2>());
         let payload_length = Self::payload_length(discriminant)?;
 
-        if usize::from(length) != input.len() {
-            return Err(Error::LengthMismatch(length, input.len()));
-        } else if length != payload_length {
+        if length != payload_length {
             return Err(Error::LengthMismatch(length, payload_length.into()));
         }
 
-        match discriminant {
-            0 => Self::parse_ping_payload(input).map(Some),
-            1 => Self::parse_ping_reply_payload(input).map(Some),
-            _ => unreachable!(),
+        let remainder = pp.packet.len() - pp.offset;
+
+        if usize::from(length) != remainder {
+            return Err(Error::LengthMismatch(length, remainder));
         }
-    }
 
-    fn parse_length(input: &[u8]) -> nom::IResult<&[u8], u16> {
-        complete::take(LENGTH_LEN)(input)
-            .map(|(input, length)| (input, u16::from_be_bytes([length[0], length[1]])))
-    }
+        let nonce = pp.read();
 
-    fn parse_version(input: &[u8]) -> nom::IResult<&[u8], u8> {
-        complete::take(VERSION_LEN)(input).map(|(input, version)| (input, version[0]))
-    }
+        fn parse_timestamp(pp: &mut PacketParser<'_>) -> UtcTimestamp {
+            UtcTimestamp::from_nanos(i64::from_be_bytes(pp.read_slice::<8>()))
+        }
 
-    fn parse_nonce(input: &[u8]) -> nom::IResult<&[u8], u8> {
-        complete::take(NONCE_LEN)(input).map(|(input, nonce)| (input, nonce[0]))
-    }
+        let payload = match discriminant {
+            PING => Self::Ping {
+                nonce,
+                client_timestamp: parse_timestamp(&mut pp),
+            },
+            PONG => {
+                let client_timestamp = parse_timestamp(&mut pp);
+                let server_start_timestamp = parse_timestamp(&mut pp);
+                let server_transmit_timestamp = parse_timestamp(&mut pp);
+                Self::PingReply {
+                    nonce,
+                    client_timestamp,
+                    server_start_timestamp,
+                    server_transmit_timestamp,
+                }
+            }
+            _ => unreachable!("we should have already verified the discriminant"),
+        };
 
-    fn parse_discriminant(input: &[u8]) -> nom::IResult<&[u8], u8> {
-        complete::take(DISCRIMINANT_LEN)(input)
-            .map(|(input, discriminant)| (input, discriminant[0]))
-    }
-
-    fn parse_timestamp(input: &[u8]) -> nom::IResult<&[u8], i64> {
-        complete::take(TIMESTAMP_LEN)(input)
-            .map(|(input, ts)| (input, i64::from_be_bytes(ts.try_into().unwrap())))
-    }
-
-    fn parse_ping_payload(input: &[u8]) -> Result<Self> {
-        let (input, nonce) = Self::parse_nonce(input)?;
-        let (_, client_timestamp) = Self::parse_timestamp(input)?;
-        Ok(Self::Ping {
-            nonce,
-            client_timestamp,
-        })
-    }
-
-    fn parse_ping_reply_payload(input: &[u8]) -> Result<Self> {
-        let (input, nonce) = Self::parse_nonce(input)?;
-        let (input, client_timestamp) = Self::parse_timestamp(input)?;
-        let (input, server_start_timestamp) = Self::parse_timestamp(input)?;
-        let (_, server_transmit_timestamp) = Self::parse_timestamp(input)?;
-        Ok(Self::PingReply {
-            nonce,
-            client_timestamp,
-            server_start_timestamp,
-            server_transmit_timestamp,
-        })
+        Ok(Some(payload))
     }
 }
 
@@ -400,14 +527,6 @@ pub enum Error {
     LengthMismatch(u16, usize),
     #[error("unknown command code: {0}")]
     InvalidCommand(u8),
-    #[error("failed to parse packet payload: {0}")]
-    Parse(String),
-}
-
-impl From<nom::Err<nom::error::Error<&'_ [u8]>>> for Error {
-    fn from(error: nom::Err<nom::error::Error<&'_ [u8]>>) -> Self {
-        Self::Parse(error.to_string())
-    }
 }
 
 #[cfg(test)]
@@ -425,7 +544,7 @@ mod tests {
             // Version
             0,
             // Code
-            0,
+            PING,
             // Length
             0, 9,
             // Nonce
@@ -438,7 +557,8 @@ mod tests {
 
         assert!(matches!(ping, Protocol::Ping { nonce: 0xBF, .. }));
 
-        assert_eq!(ping.encode(), INPUT);
+        let mut packet = QcmpPacket::default();
+        assert_eq!(ping.encode(&mut packet), INPUT);
     }
 
     #[test]
@@ -450,7 +570,7 @@ mod tests {
             // Version
             0,
             // Code
-            1,
+            PONG,
             // Length
             0, 25,
             // Nonce
@@ -467,7 +587,8 @@ mod tests {
             ping_reply,
             Protocol::PingReply { nonce: 0xBF, .. }
         ));
-        assert_eq!(ping_reply.encode(), INPUT);
+        let mut packet = QcmpPacket::default();
+        assert_eq!(ping_reply.encode(&mut packet), INPUT);
     }
 
     #[test]
@@ -479,7 +600,7 @@ mod tests {
             // Version
             0,
             // Code (intentionally Ping)
-            0,
+            PING,
             // Length
             0, 25,
             // Nonce
@@ -524,31 +645,43 @@ mod tests {
     #[test]
     fn reject_no_magic_header() {
         #[rustfmt::skip]
-        const INPUT: &[u8] = &[0xff, 0xff, 0, 0, 0, 0, 0x63, 0xb6, 0xe9, 0x57];
+        const INPUT: &[u8] = &[
+            // Magic
+            b'Q', 0xff, b'K', b'N',
+            // Version
+            0,
+            // Code
+            PING,
+            // Length
+            0, 9,
+            // Nonce
+            0xBF,
+            // Payload
+            0, 0, 0, 0, 0x63, 0xb6, 0xe9, 0x57,
+        ];
 
         assert!(Protocol::parse(INPUT).unwrap().is_none());
     }
 
     #[tokio::test]
     async fn qcmp_measurement() {
-        const FIFTY_MILLIS_IN_NANOS: i64 = 50_000_000;
-
         let socket = raw_socket_with_reuse(0).unwrap();
         let addr = socket.local_addr().unwrap().as_socket().unwrap();
 
         let (_tx, rx) = crate::make_shutdown_channel(Default::default());
         super::spawn(socket, rx);
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
-        let node = QcmpMeasurement::new().unwrap();
+        let delay = std::time::Duration::from_millis(50);
+        let node = QcmpMeasurement::with_artificial_delay(delay).unwrap();
 
-        let (incoming, outgoing) = node.measure_distance(addr).await.unwrap();
+        let dm = node.measure_distance(addr).await.unwrap();
+        let total = dm.total();
 
         assert!(
-            FIFTY_MILLIS_IN_NANOS > incoming + outgoing,
-            "Node1's distance is {}ns, greater than {}ns",
-            incoming + outgoing,
-            FIFTY_MILLIS_IN_NANOS
+            total > delay && total < delay * 2,
+            "Node1's distance is {total:?}, expected > {delay:?} and less than {:?}",
+            delay * 2
         );
     }
 }

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -679,7 +679,7 @@ mod tests {
 
         let (_tx, rx) = crate::make_shutdown_channel(Default::default());
         super::spawn(socket, rx);
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
         let delay = std::time::Duration::from_millis(50);
         let node = QcmpMeasurement::with_artificial_delay(delay).unwrap();

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -212,7 +212,12 @@ impl Proxy {
         .await?;
 
         crate::codec::qcmp::spawn(self.qcmp, shutdown_rx.clone());
-        crate::net::phoenix::spawn(self.phoenix, config.clone(), shutdown_rx.clone())?;
+        crate::net::phoenix::spawn(
+            self.phoenix,
+            config.clone(),
+            shutdown_rx.clone(),
+            crate::codec::qcmp::QcmpMeasurement::new()?,
+        )?;
 
         for notification in worker_notifications {
             notification.notified().await;

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -165,7 +165,7 @@ mod tests {
         );
         ctx.metadata.insert(
             TIMESTAMP_KEY.into(),
-            Value::Number(crate::unix_timestamp() as u64),
+            Value::Number(crate::time::UtcTimestamp::now().unix() as u64),
         );
 
         filter.read(&mut ctx).await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 pub(crate) mod collections;
 pub(crate) mod metrics;
 pub mod pool;
+pub mod time;
 
 // Above other modules for thr `uring_spawn` macro.
 #[macro_use]
@@ -76,12 +77,6 @@ pub fn make_shutdown_channel(init: ShutdownKind) -> (ShutdownTx, ShutdownRx) {
 pub(crate) trait Loggable {
     /// Output a log.
     fn log(&self);
-}
-
-/// Gets the current [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time)
-#[inline]
-pub fn unix_timestamp() -> i64 {
-    time::OffsetDateTime::now_utc().unix_timestamp()
 }
 
 #[cfg(doctest)]

--- a/src/net/phoenix.rs
+++ b/src/net/phoenix.rs
@@ -802,7 +802,7 @@ mod tests {
             .unwrap(),
         )
         .unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
         let client = hyper::Client::new();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -298,8 +298,7 @@ impl TestHelper {
 
         let server = server.unwrap_or_else(|| {
             let qcmp = crate::net::raw_socket_with_reuse(0).unwrap();
-            let phoenix =
-                crate::net::TcpListener::bind(Some(crate::net::socket_port(&qcmp))).unwrap();
+            let phoenix = crate::net::TcpListener::bind(None).unwrap();
 
             crate::components::proxy::Proxy {
                 num_workers: std::num::NonZeroUsize::new(1).unwrap(),

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,74 @@
+/// A UTC timestamp
+#[derive(Copy, Clone)]
+pub struct UtcTimestamp {
+    inner: time::OffsetDateTime,
+}
+
+impl UtcTimestamp {
+    #[inline]
+    pub fn now() -> Self {
+        Self {
+            inner: time::OffsetDateTime::now_utc(),
+        }
+    }
+
+    /// Gets the current [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time)
+    #[inline]
+    pub fn unix(self) -> i64 {
+        self.inner.unix_timestamp()
+    }
+
+    /// Gets the current [Unix timestamp](https://en.wikipedia.org/wiki/Unix_time) in nanoseconds.
+    ///
+    /// Note we truncate to a 64-bit integer, which will be fine unless someone happens
+    /// to be running quilkin in a couple of hundred years
+    #[inline]
+    pub fn unix_nanos(self) -> i64 {
+        self.inner.unix_timestamp_nanos() as _
+    }
+
+    #[inline]
+    pub fn from_nanos(nanos: i64) -> Self {
+        Self {
+            inner: time::OffsetDateTime::from_unix_timestamp_nanos(nanos as _)
+                .expect("hello future person, apologies"),
+        }
+    }
+}
+
+use std::fmt;
+
+impl fmt::Debug for UtcTimestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
+}
+
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(test, derive(Debug))]
+pub struct DurationNanos(i64);
+
+impl DurationNanos {
+    #[inline]
+    pub fn from_nanos(n: i64) -> Self {
+        Self(n)
+    }
+
+    #[inline]
+    pub fn nanos(self) -> i64 {
+        self.0
+    }
+
+    #[inline]
+    pub fn duration(self) -> std::time::Duration {
+        std::time::Duration::from_nanos(self.0 as _)
+    }
+}
+
+impl std::ops::Sub for UtcTimestamp {
+    type Output = DurationNanos;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        DurationNanos(self.unix_nanos() - rhs.unix_nanos())
+    }
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -221,6 +221,7 @@ abort_task!(AgentPail);
 pub struct ProxyPail {
     pub port: u16,
     pub qcmp_port: u16,
+    pub phoenix_port: u16,
     pub task: JoinHandle,
     pub shutdown: ShutdownTx,
     pub config: Arc<Config>,
@@ -421,8 +422,8 @@ impl Pail {
                 let qcmp =
                     quilkin::net::raw_socket_with_reuse(0).expect("failed to bind qcmp socket");
                 let qcmp_port = quilkin::net::socket_port(&qcmp);
-                let phoenix =
-                    TcpListener::bind(Some(qcmp_port)).expect("failed to bind phoenix socket");
+                let phoenix = TcpListener::bind(None).expect("failed to bind phoenix socket");
+                let phoenix_port = phoenix.port();
 
                 let port = quilkin::net::socket_port(&socket);
 
@@ -506,6 +507,7 @@ impl Pail {
                 Self::Proxy(ProxyPail {
                     port,
                     qcmp_port,
+                    phoenix_port,
                     shutdown,
                     task,
                     config,


### PR DESCRIPTION
I made a big mistake in #896 by changing the units of various timestamps from nanoseconds -> seconds, which caused QCMP distances to be completely wrong as the unit change caused all calculations to be 0. This fixes the bug by actually having a modicum of type safety so that all conversions between timestamps and duration/nanoseconds are clear as opposed to "losing" the units. It also changes the `qcmp::ping` test to force a delay and ensure that the calculated time is both less than twice the delay but _also_ greater than the delay, which was why this bug was not detected by the test.

Resolves: #920 