### PR TITLE
Fix phoenix http

### DIFF
--- a/examples/quilkin-filter-example/src/generated.rs
+++ b/examples/quilkin-filter-example/src/generated.rs
@@ -1,2 +1,18 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #![allow(clippy::doc_markdown, clippy::use_self)]
 pub mod greet;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,16 +14,27 @@
  * limitations under the License.
  */
 
-#[tokio::main]
-async fn main() {
-    // Unwrap is safe here as it will only fail if called more than once.
-    stable_eyre::install().unwrap();
+fn main() {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name_fn(|| {
+            static ATOMIC_ID: std::sync::atomic::AtomicUsize =
+                std::sync::atomic::AtomicUsize::new(0);
+            let id = ATOMIC_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            format!("tokio-main-{id}")
+        })
+        .build()
+        .unwrap()
+        .block_on(async {
+            // Unwrap is safe here as it will only fail if called more than once.
+            stable_eyre::install().unwrap();
 
-    match <quilkin::Cli as clap::Parser>::parse().drive(None).await {
-        Ok(()) => std::process::exit(0),
-        Err(error) => {
-            tracing::error!(%error, error_debug=?error, "fatal error");
-            std::process::exit(-1)
-        }
-    }
+            match <quilkin::Cli as clap::Parser>::parse().drive(None).await {
+                Ok(()) => std::process::exit(0),
+                Err(error) => {
+                    tracing::error!(%error, error_debug=?error, "fatal error");
+                    std::process::exit(-1)
+                }
+            }
+        })
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -23,7 +23,7 @@ macro_rules! uring_spawn {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "linux")] {
                 let dispatcher = tracing::dispatcher::get_default(|d| d.clone());
-                std::thread::spawn(move || {
+                std::thread::Builder::new().name("io-uring".into()).spawn(move || {
                     let _guard = tracing::dispatcher::set_default(&dispatcher);
 
                     match tokio_uring::Runtime::new(&tokio_uring::builder().entries(2048)) {
@@ -35,7 +35,7 @@ macro_rules! uring_spawn {
                             let _ = tx.send(Err(error.into()));
                         }
                     };
-                });
+                }).expect("failed to spawn io-uring thread");
             } else {
                 use tracing::instrument::WithSubscriber as _;
                 tokio::spawn(async move {

--- a/src/net/phoenix.rs
+++ b/src/net/phoenix.rs
@@ -41,14 +41,9 @@ pub fn spawn<M: Clone + Measurement + Sync + Send + 'static>(
     };
     let mut config_watcher = datacenters.watch();
 
-    std::thread::spawn(move || {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        let res = runtime.block_on({
-            let mut phoenix_watcher = phoenix.update_watcher();
-            let config = config.clone();
+    std::thread::Builder::new()
+        .name("phoenix-http".into())
+        .spawn(move || {
 
             async move {
                 let json = crate::config::Slot::new(serde_json::Map::default());

--- a/src/net/phoenix.rs
+++ b/src/net/phoenix.rs
@@ -31,6 +31,7 @@ pub fn spawn<M: Clone + Measurement + Sync + Send + 'static>(
     mut shutdown_rx: crate::ShutdownRx,
     phoenix: Phoenix<M>,
 ) -> crate::Result<()> {
+    use eyre::WrapErr as _;
     use hyper::service::{make_service_fn, service_fn};
     use hyper::{Body, Response, Server as HyperServer, StatusCode};
 
@@ -44,115 +45,131 @@ pub fn spawn<M: Clone + Measurement + Sync + Send + 'static>(
     std::thread::Builder::new()
         .name("phoenix-http".into())
         .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .worker_threads(2)
+                .thread_name_fn(|| {
+                    static ATOMIC_ID: std::sync::atomic::AtomicUsize =
+                        std::sync::atomic::AtomicUsize::new(0);
+                    let id = ATOMIC_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    format!("phoenix-http-{id}")
+                })
+                .build()
+                .unwrap();
+            let res = runtime.block_on({
+                let mut phoenix_watcher = phoenix.update_watcher();
+                let config = config.clone();
 
-            async move {
-                let json = crate::config::Slot::new(serde_json::Map::default());
+                async move {
+                    let json = crate::config::Slot::new(serde_json::Map::default());
 
-                tokio::spawn({
-                    let phoenix = phoenix.clone();
-                    async move { phoenix.background_update_task().await }
-                });
+                    tokio::spawn({
+                        let phoenix = phoenix.clone();
+                        async move { phoenix.background_update_task().await }
+                    });
 
-                let json2 = json.clone();
-                let make_svc = make_service_fn(move |_conn| {
-                    let json = json2.clone();
-                    #[allow(clippy::declare_interior_mutable_const)]
-                    const JSON: hyper::header::HeaderValue =
-                        hyper::header::HeaderValue::from_static("application/json");
+                    let json2 = json.clone();
+                    let make_svc = make_service_fn(move |_conn| {
+                        let json = json2.clone();
+                        #[allow(clippy::declare_interior_mutable_const)]
+                        const JSON: hyper::header::HeaderValue =
+                            hyper::header::HeaderValue::from_static("application/json");
 
-                    async move {
-                        Ok::<_, std::convert::Infallible>(service_fn(move |_| {
-                            let json = json.clone();
-                            async move {
-                                tracing::trace!("serving phoenix request");
-                                Ok::<_, std::convert::Infallible>(
-                                    Response::builder()
-                                        .status(StatusCode::OK)
-                                        .header(hyper::header::CONTENT_TYPE, JSON)
-                                        .body(Body::from(serde_json::to_string(&json).unwrap()))
-                                        .unwrap(),
-                                )
-                            }
-                        }))
+                        async move {
+                            Ok::<_, std::convert::Infallible>(service_fn(move |_| {
+                                let json = json.clone();
+                                async move {
+                                    tracing::trace!("serving phoenix request");
+                                    Ok::<_, std::convert::Infallible>(
+                                        Response::builder()
+                                            .status(StatusCode::OK)
+                                            .header(hyper::header::CONTENT_TYPE, JSON)
+                                            .body(Body::from(serde_json::to_string(&json).unwrap()))
+                                            .unwrap(),
+                                    )
+                                }
+                            }))
+                        }
+                    });
+
+                    tracing::info!(addr=%listener.local_addr(), "starting phoenix HTTP service");
+                    let (stx, srx) = tokio::sync::oneshot::channel::<()>();
+
+                    let http_task = tokio::spawn(
+                        HyperServer::from_tcp(listener.into())?
+                            .serve(make_svc)
+                            .with_graceful_shutdown(async move {
+                                let _ = srx.await;
+                            }),
+                    );
+
+                    let res = loop {
+                        use eyre::WrapErr as _;
+
+                        tokio::select! {
+                            _ = shutdown_rx.changed() => break Ok::<_, eyre::Error>(()),
+                            result = config_watcher.changed() => if let Err(err) = result {
+                                break Err(err).context("config watcher sender dropped");
+                            },
+                            result = phoenix_watcher.changed() => if let Err(err) = result {
+                                break Err(err).context("phoenix watcher sender dropped");
+                            },
+                        }
+
+                        tracing::trace!("change detected, updating phoenix");
+                        phoenix.add_nodes_from_config(&config);
+                        let nodes = phoenix.ordered_nodes_by_latency();
+                        let mut new_json = serde_json::Map::default();
+
+                        for (identifier, latency) in nodes {
+                            new_json.insert(identifier.to_string(), latency.into());
+                        }
+
+                        json.store(new_json.into());
+                    };
+
+                    if stx.send(()).is_err() {
+                        tracing::error!("phoenix HTTP service task has already exited");
                     }
-                });
 
-                tracing::info!(addr=%listener.local_addr(), "starting phoenix HTTP service");
-                let (stx, srx) = tokio::sync::oneshot::channel::<()>();
+                    // This should happen quickly, abort if it takes too long
+                    let max_wait =
+                        std::time::Instant::now() + std::time::Duration::from_millis(100);
+                    let mut interval = tokio::time::interval(std::time::Duration::from_millis(1));
 
-                let http_task = tokio::spawn(
-                    HyperServer::from_tcp(listener.into())?
-                        .serve(make_svc)
-                        .with_graceful_shutdown(async move {
-                            let _ = srx.await;
-                        }),
-                );
+                    loop {
+                        if http_task.is_finished() || std::time::Instant::now() > max_wait {
+                            break;
+                        }
 
-                let res = loop {
-                    use eyre::WrapErr as _;
-
-                    tokio::select! {
-                        _ = shutdown_rx.changed() => break Ok::<_, eyre::Error>(()),
-                        result = config_watcher.changed() => if let Err(err) = result {
-                            break Err(err).context("config watcher sender dropped");
-                        },
-                        result = phoenix_watcher.changed() => if let Err(err) = result {
-                            break Err(err).context("phoenix watcher sender dropped");
-                        },
+                        interval.tick().await;
                     }
 
-                    tracing::trace!("change detected, updating phoenix");
-                    phoenix.add_nodes_from_config(&config);
-                    let nodes = phoenix.ordered_nodes_by_latency();
-                    let mut new_json = serde_json::Map::default();
-
-                    for (identifier, latency) in nodes {
-                        new_json.insert(identifier.to_string(), latency.into());
+                    if !http_task.is_finished() {
+                        http_task.abort();
                     }
 
-                    json.store(new_json.into());
-                };
+                    if let Err(err) = http_task.await {
+                        if let Ok(panic) = err.try_into_panic() {
+                            let message = panic
+                                .downcast_ref::<String>()
+                                .map(String::as_str)
+                                .or_else(|| panic.downcast_ref::<&str>().copied())
+                                .unwrap_or("<unknown non-string panic>");
 
-                if stx.send(()).is_err() {
-                    tracing::error!("phoenix HTTP service task has already exited");
+                            tracing::error!(panic = message, "phoenix HTTP task panicked");
+                        }
+                    }
+
+                    res
                 }
+            });
 
-                // This should happen quickly, abort if it takes too long
-                let max_wait = std::time::Instant::now() + std::time::Duration::from_millis(100);
-                let mut interval = tokio::time::interval(std::time::Duration::from_millis(1));
-
-                loop {
-                    if http_task.is_finished() || std::time::Instant::now() > max_wait {
-                        break;
-                    }
-
-                    interval.tick().await;
-                }
-
-                if !http_task.is_finished() {
-                    http_task.abort();
-                }
-
-                if let Err(err) = http_task.await {
-                    if let Ok(panic) = err.try_into_panic() {
-                        let message = panic
-                            .downcast_ref::<String>()
-                            .map(String::as_str)
-                            .or_else(|| panic.downcast_ref::<&str>().copied())
-                            .unwrap_or("<unknown non-string panic>");
-
-                        tracing::error!(panic = message, "phoenix HTTP task panicked");
-                    }
-                }
-
-                res
+            if let Err(err) = res {
+                tracing::error!(err = %err, "phoenix thread failed with an error");
             }
-        });
-
-        if let Err(err) = res {
-            tracing::error!(err = %err, "phoenix thread failed with an error");
-        }
-    });
+        })
+        .context("failed to spawn phoenix-http thread")?;
 
     Ok(())
 }


### PR DESCRIPTION
This fixes the issue where the phoenix HTTP server would stop responding after some amount of time. The issue was that since a single thread was being used for the service, it would deadlock itself accessing the `Inner::nodes` map, as the `background_update_task` could be context switched during an await while a write lock was held, causing the "main" loop to deadlock adding/retrieving nodes (or vice versa). I'm _fairly_ confident this is the fix as now locks will _eventually_ be released as tokio will be driving all tasks, not only a single one.

Resolves: #918 

This also adds thread names to all of the threads and tokio workers spawned by quilkin for easier debug inspection. This also made me realize that because we use `tokio::main` we spawn a ton of extra workers in the proxy case, but I'll leave fixing that for a different PR.