### PR TITLE
Upgrade Agones CRD

### DIFF
--- a/agones/src/lib.rs
+++ b/agones/src/lib.rs
@@ -465,7 +465,7 @@ pub fn game_server() -> GameServer {
         },
         spec: GameServerSpec {
             ports: vec![GameServerPort {
-                container_port: 7654,
+                container_port: Some(7654),
                 host_port: None,
                 name: "udp-port".into(),
                 port_policy: Default::default(),

--- a/agones/src/sidecar.rs
+++ b/agones/src/sidecar.rs
@@ -88,7 +88,7 @@ clusters:
         let mut gs = game_server();
 
         // reset ports to point at the Quilkin sidecar
-        gs.spec.ports[0].container_port = 7777;
+        gs.spec.ports[0].container_port = Some(7777);
         gs.spec.ports[0].container = Some("quilkin".into());
 
         // set the gameserver container to the simple-game-server container.

--- a/src/config/providers/k8s/agones.rs
+++ b/src/config/providers/k8s/agones.rs
@@ -357,7 +357,8 @@ pub struct GameServerPort {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container: Option<String>,
     /// The port that is being opened on the specified container's process
-    pub container_port: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_port: Option<u16>,
     /// The port exposed on the host for clients to connect to
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub host_port: Option<u16>,


### PR DESCRIPTION
Upgrading the latest agones, the CRD is out of sync with our version in the Quilkin repo, this PR will solve it.

- First we're just using a version of kube that exposes more information about what is breaking so we can fix it.

Resolves #938 