### PR TITLE
Remove idle request interval for agent

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,16 +147,7 @@ impl Cli {
             Commands::GenerateConfigSchema(generator) => {
                 return generator.generate_config_schema();
             }
-            Commands::Agent(agent) => {
-                let ready = components::agent::Ready {
-                    idle_request_interval: agent
-                        .idle_request_interval_secs
-                        .map(std::time::Duration::from_secs)
-                        .unwrap_or(admin_server::IDLE_REQUEST_INTERVAL),
-                    ..Default::default()
-                };
-                Admin::Agent(ready)
-            }
+            Commands::Agent(_) => Admin::Agent(<_>::default()),
             Commands::Proxy(proxy) => {
                 let ready = components::proxy::Ready {
                     idle_request_interval: proxy
@@ -169,7 +160,6 @@ impl Cli {
             }
             Commands::Manage(_mng) => {
                 let ready = components::manage::Ready {
-                    idle_request_interval: admin_server::IDLE_REQUEST_INTERVAL,
                     is_manage: true,
                     ..Default::default()
                 };

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -55,10 +55,6 @@ pub struct Agent {
     /// If specified, additionally filters the gameserver address by its ip kind
     #[clap(long, requires("address_type"), value_enum)]
     pub ip_kind: Option<crate::config::AddrKind>,
-    /// The interval in seconds at which the agent will wait for a discovery
-    /// request from a relay server before restarting the connection.
-    #[clap(long, env = "QUILKIN_IDLE_REQUEST_INTERVAL_SECS")]
-    pub idle_request_interval_secs: Option<u64>,
     /// The ICAO code for the agent.
     #[clap(short, long, env, default_value_t = crate::config::IcaoCode::default())]
     pub icao_code: crate::config::IcaoCode,
@@ -88,7 +84,6 @@ impl Default for Agent {
             zone: <_>::default(),
             sub_zone: <_>::default(),
             provider: <_>::default(),
-            idle_request_interval_secs: None,
             icao_code: <_>::default(),
             address_type: None,
             ip_kind: None,

--- a/src/components/admin.rs
+++ b/src/components/admin.rs
@@ -46,7 +46,6 @@ impl Admin {
     pub fn idle_request_interval(&self) -> Duration {
         match self {
             Self::Proxy(config) => config.idle_request_interval,
-            Self::Agent(config) => config.idle_request_interval,
             Self::Relay(config) => config.idle_request_interval,
             _ => IDLE_REQUEST_INTERVAL,
         }

--- a/src/components/agent.rs
+++ b/src/components/agent.rs
@@ -8,7 +8,6 @@ use std::sync::{
 
 #[derive(Clone, Debug, Default)]
 pub struct Ready {
-    pub idle_request_interval: std::time::Duration,
     pub provider_is_healthy: Arc<AtomicBool>,
     pub relay_is_healthy: Arc<AtomicBool>,
     /// If true, only care about the provider being healthy, not the relay

--- a/src/components/manage.rs
+++ b/src/components/manage.rs
@@ -35,8 +35,6 @@ impl Manage {
             None,
         );
 
-        let idle_request_interval = ready.idle_request_interval;
-
         let _relay_stream = if !self.relay_servers.is_empty() {
             tracing::info!("connecting to relay server");
             let client = crate::net::xds::client::MdsClient::connect(
@@ -70,7 +68,7 @@ impl Manage {
         let server_task = tokio::spawn(crate::net::xds::server::spawn(
             self.listener,
             config,
-            idle_request_interval,
+            crate::components::admin::IDLE_REQUEST_INTERVAL,
         )?)
         .map_err(From::from)
         .and_then(std::future::ready);


### PR DESCRIPTION
This wasn't an intuitive reset, and led to confusion, so removing for now

Resolves #861 