### PR TITLE
Allow `Option::deserialize` to fail.

### DIFF
--- a/src/config/providers/k8s/agones.rs
+++ b/src/config/providers/k8s/agones.rs
@@ -284,10 +284,10 @@ where
     T: Default + Deserialize<'de>,
     D: serde::de::Deserializer<'de>,
 {
-    match Option::deserialize(deserializer) {
+    Ok(match Option::deserialize(deserializer) {
         Ok(opt) => opt.unwrap_or_default(),
-        Err(_) => Ok(T::default()),
-    }
+        Err(_) => T::default(),
+    })
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]

--- a/src/config/providers/k8s/agones.rs
+++ b/src/config/providers/k8s/agones.rs
@@ -284,8 +284,10 @@ where
     T: Default + Deserialize<'de>,
     D: serde::de::Deserializer<'de>,
 {
-    let opt = Option::deserialize(deserializer)?;
-    Ok(opt.unwrap_or_default())
+    match Option::deserialize(deserializer) {
+        Ok(opt) => opt.unwrap_or_default(),
+        Err(_) => Ok(T::default()),
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]


### PR DESCRIPTION
This allows the changes to work with older versions of agones.
