### PR TITLE
Fix infinite loop

### DIFF
--- a/docs/src/services/proxy/filters/writing_custom_filters.md
+++ b/docs/src/services/proxy/filters/writing_custom_filters.md
@@ -189,6 +189,19 @@ prost-types = "0.7"
 
 3. Generate Rust code from the proto file:
 
+### Generated - Recommended
+
+Use something like [proto-gen](https://github.com/EmbarkStudios/proto-gen) to generate Rust code for the protobuf.
+
+At that point it is just normal rust code and can be included from where you placed the generated code, eg. `generated`.
+
+```rust,no_run,noplayground,ignore
+mod generated;
+use generated::greet as proto;
+```
+
+### At build time
+
 There are a few ways to generate [Prost] code from proto, we will use the [prost_build] crate in this example.
 
 Add the following required crates to `Cargo.toml`, and then add a
@@ -205,17 +218,30 @@ prost-build = "0.7"
 
 ```rust,no_run,noplayground,ignore
 // src/build.rs
-{{#include ../../../../../examples/quilkin-filter-example/build.rs:build}}
+fn main() {
+    // Remove if you already have `protoc` installed in your system.
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
+    prost_build::compile_protos(&["src/greet.proto"], &["src/"]).unwrap();
+}
 ```
 
-To include the generated code, we'll use [`tonic::include_proto`], then we just
-need to implement [std::convert::TryFrom] for converting the protobuf message to
-equivalvent configuration.
+To include the generated code, we'll use [`tonic::include_proto`].
 
 ```rust,no_run,noplayground,ignore
 // src/main.rs
-{{#include ../../../../../examples/quilkin-filter-example/src/main.rs:include_proto}}
+#[allow(warnings, clippy::all)]
+// ANCHOR: include_proto
+mod proto {
+    tonic::include_proto!("greet");
+}
+```
 
+4. Then we just need to implement [std::convert::TryFrom] for converting the protobuf message to
+equivalent configuration.
+
+```rust,no_run,noplayground,ignore
+// src/main.rs
 {{#include ../../../../../examples/quilkin-filter-example/src/main.rs:TryFrom}}
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,6 +116,7 @@ impl Cli {
                 .from_env_lossy();
             let subscriber = tracing_subscriber::fmt()
                 .with_file(true)
+                .with_thread_ids(true)
                 .with_env_filter(env_filter);
 
             match self.log_format {

--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -211,7 +211,7 @@ impl Measurement for QcmpMeasurement {
 pub fn spawn(socket: socket2::Socket, mut shutdown_rx: crate::ShutdownRx) {
     let port = crate::net::socket_port(&socket);
 
-    uring_spawn!(tracing::debug_span!("qcmp"), async move {
+    uring_spawn!(uring_span!(tracing::debug_span!("qcmp")), async move {
         let mut input_buf = vec![0; 1 << 16];
         let socket = DualStackLocalSocket::new(port).unwrap();
         let mut output_buf = QcmpPacket::default();


### PR DESCRIPTION
The changes with regard to tracing spans and uring_spawn! are due to tracing_subscriber's use of shared_slab, which has a default limit of [4096 threads](https://github.com/hawkw/sharded-slab/blob/ee45b4cfa79408fc46893a67f2d3005f79e4e04c/src/cfg.rs#L140) after which it will panic. This just changes it so that spans are not present in release mode which is unfortunate, but means that we won't get panics at runtime when "too many" unique connections are made to a proxy.

Other than that, the change was fairly simple, when the senders are closed, and thus the receiver will never get anything again, we exit the loop/task. In addition, when the downstream loop is closed, we also exit the upstream loop, as previously the loop would have just sat there infinitely until shutdown, taking system resources.

Resolves: #952 