### PR TITLE
Fix relay listener updates

### DIFF
--- a/crates/test/tests/mesh.rs
+++ b/crates/test/tests/mesh.rs
@@ -278,7 +278,7 @@ trace_test!(filter_update, {
                 [Endpoint::with_metadata(
                     server_addr.into(),
                     quilkin::net::endpoint::Metadata {
-                        tokens: Some(dbg!(&token).clone()).into_iter().collect(),
+                        tokens: Some(token.clone()).into_iter().collect(),
                     },
                 )]
                 .into(),
@@ -286,7 +286,7 @@ trace_test!(filter_update, {
         });
 
         let mut updates = 0x0;
-        while (dbg!(updates) & 0x11) != 0x11 {
+        while (updates & 0x11) != 0x11 {
             let rt = sandbox.timeout(10000, proxy_delta_rx.recv()).await.unwrap();
 
             match rt {

--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -14,7 +14,7 @@ trace_test!(server, {
     let mut server1_rx = sb.packet_rx("server1");
     let mut server2_rx = sb.packet_rx("server2");
 
-    let addr = sb.proxy_addr();
+    let (addr, _) = sb.proxy("proxy");
 
     tracing::trace!(%addr, "sending packet");
     let msg = "hello";
@@ -45,7 +45,7 @@ trace_test!(client, {
     let mut sb = sc.spinup().await;
 
     let mut dest_rx = sb.packet_rx("dest");
-    let local_addr = sb.proxy_addr();
+    let (local_addr, _) = sb.proxy("proxy");
     let client = sb.client();
 
     let msg = "hello";
@@ -68,7 +68,7 @@ trace_test!(with_filter, {
     );
 
     let mut sb = sc.spinup().await;
-    let local_addr = sb.proxy_addr();
+    let (local_addr, _) = sb.proxy("proxy");
     let mut rx = sb.packet_rx("server");
     let client = sb.client();
 

--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -406,8 +406,8 @@ impl AdsClient {
     /// management server does not support delta xDS we return the client as an error
     pub async fn delta_subscribe<C: crate::config::Configuration>(
         self,
-        config: Arc<Config>,
-        rt_config: crate::components::proxy::Ready,
+        config: Arc<C>,
+        is_healthy: Arc<AtomicBool>,
         notifier: Option<tokio::sync::mpsc::UnboundedSender<ResourceType>>,
         resources: impl IntoIterator<Item = (ResourceType, Vec<String>)>,
     ) -> Result<DeltaSubscription, Self> {

--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -248,7 +248,8 @@ impl MdsClient {
                         );
 
                         let change_watcher = tokio::spawn({
-                            let this = control_plane.clone();
+                            let mut this = control_plane.clone();
+                            this.is_relay = true; // This is a lie, but means we don't unneccessarily watch for filter changes on the agent, which doesn't perform them
                             control_plane.config.on_changed(this)
                         });
 

--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -258,7 +258,7 @@ impl MdsClient {
 
                         while let Some(result) = stream.next().await {
                             let response = result?;
-                            tracing::debug!("received delta discovery response");
+                            tracing::trace!("received delta discovery response");
                             ds.send_response(response).await?;
                         }
 
@@ -277,7 +277,7 @@ impl MdsClient {
                         DeltaServerStream::connect(new_client, identifier.clone()).await?;
                 }
             }
-            .instrument(tracing::debug_span!("handle_delta_discovery_response", id)),
+            .instrument(tracing::trace_span!("handle_delta_discovery_response", id)),
         );
 
         Ok(DeltaSubscription { handle })
@@ -511,7 +511,7 @@ impl AdsClient {
                         .await?;
                 }
             }
-            .instrument(tracing::debug_span!("xds_client_stream", id)),
+            .instrument(tracing::trace_span!("xds_client_stream", id)),
         );
 
         Ok(DeltaSubscription { handle })

--- a/crates/xds/src/resource.rs
+++ b/crates/xds/src/resource.rs
@@ -18,8 +18,6 @@ use prost::Message;
 
 use crate::generated::envoy::config::listener::v3::Listener;
 
-pub type ResourceMap<V> = enum_map::EnumMap<ResourceType, V>;
-
 macro_rules! type_urls {
      ($($base_url:literal : {$($const_name:ident = $type_url:literal),+ $(,)?})+) => {
          $(

--- a/crates/xds/src/server.rs
+++ b/crates/xds/src/server.rs
@@ -36,98 +36,115 @@ use crate::{
     ResourceType,
 };
 
-#[tracing::instrument(skip_all)]
-pub fn spawn<C: crate::config::Configuration>(
-    listener: TcpListener,
-    config: std::sync::Arc<C>,
+#[derive(Clone)]
+pub struct ControlPlane {
+    config: Arc<Config>,
     idle_request_interval: Duration,
-) -> io::Result<impl std::future::Future<Output = crate::Result<()>>> {
-    let server = AggregatedDiscoveryServiceServer::new(ControlPlane::from_arc(
-        config,
-        idle_request_interval,
-    ))
-    .max_encoding_message_size(crate::config::max_grpc_message_size());
-    let server = tonic::transport::Server::builder().add_service(server);
-    tracing::info!("serving management server on port `{}`", listener.port());
-    Ok(server
-        .serve_with_incoming(listener.into_stream()?)
-        .map_err(From::from))
+    tx: tokio::sync::broadcast::Sender<ResourceType>,
+    is_relay: bool,
 }
 
-pub fn control_plane_discovery_server<C: crate::config::Configuration>(
-    listener: TcpListener,
-    config: Arc<C>,
-    idle_request_interval: Duration,
-) -> io::Result<impl std::future::Future<Output = crate::Result<()>>> {
-    let server = AggregatedControlPlaneDiscoveryServiceServer::new(ControlPlane::from_arc(
-        config,
-        idle_request_interval,
-    ))
-    .max_encoding_message_size(crate::config::max_grpc_message_size());
-    let server = tonic::transport::Server::builder().add_service(server);
-    tracing::info!("serving relay server on port `{}`", listener.port());
-    Ok(server
-        .serve_with_incoming(listener.into_stream()?)
-        .map_err(From::from))
-}
+impl ControlPlane {
+    pub fn from_arc(config: Arc<Config>, idle_request_interval: Duration) -> Self {
+        let (tx, _) = tokio::sync::broadcast::channel(10);
 
-pub struct ControlPlane<C> {
-    pub config: Arc<C>,
-    idle_request_interval: Duration,
-    watchers: Arc<crate::resource::ResourceMap<Watchers>>,
-}
-
-impl<C> Clone for ControlPlane<C> {
-    fn clone(&self) -> Self {
         Self {
-            config: self.config.clone(),
-            idle_request_interval: self.idle_request_interval,
-            watchers: self.watchers.clone(),
-        }
-    }
-}
-
-struct Watchers {
-    sender: tokio::sync::watch::Sender<()>,
-    receiver: tokio::sync::watch::Receiver<()>,
-    version: std::sync::atomic::AtomicU64,
-}
-
-impl Default for Watchers {
-    fn default() -> Self {
-        let (sender, receiver) = tokio::sync::watch::channel(());
-        Self {
-            sender,
-            receiver,
-            version: <_>::default(),
-        }
-    }
-}
-
-impl<C: crate::config::Configuration> ControlPlane<C> {
-    pub fn from_arc(config: Arc<C>, idle_request_interval: Duration) -> Self {
-        let this = Self {
             config,
             idle_request_interval,
-            watchers: Default::default(),
-        };
-
-        tokio::spawn({
-            let this2 = this.clone();
-            this.config.on_changed(this2)
-        });
-
-        this
+            tx,
+            is_relay: false,
+        }
     }
 
-    pub fn push_update(&self, resource_type: ResourceType) {
-        let watchers = &self.watchers[resource_type];
-        watchers
-            .version
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        tracing::trace!(%resource_type, watchers=watchers.sender.receiver_count(), "pushing update");
-        if let Err(error) = watchers.sender.send(()) {
-            tracing::warn!(%error, "pushing update failed");
+    fn subscribe_to_config_changes(&self) {
+        let id = self.config.id.load().to_string();
+
+        tokio::spawn({
+            let this = self.clone();
+            async move {
+                let mut cluster_watcher = this.config.clusters.watch();
+                tracing::debug!("waiting for changes");
+
+                match &this.config.datacenter {
+                    crate::config::DatacenterConfig::Agent {..} => {
+                        loop {
+                            match cluster_watcher.changed().await {
+                                Ok(()) => this.push_update(ResourceType::Cluster),
+                                Err(error) => tracing::error!(%error, "error watching changes"),
+                            }
+                        }
+                    }
+                    crate::config::DatacenterConfig::NonAgent { datacenters } => {
+                        let mut dc_watcher = datacenters.watch();
+                        loop {
+                            tokio::select! {
+                                result = cluster_watcher.changed() => {
+                                    match result {
+                                        Ok(()) => this.push_update(ResourceType::Cluster),
+                                        Err(error) => tracing::error!(%error, "error watching changes"),
+                                    }
+                                }
+                                result = dc_watcher.changed() => {
+                                    match result {
+                                        Ok(()) => this.push_update(ResourceType::Datacenter),
+                                        Err(error) => tracing::error!(%error, "error watching changes"),
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .instrument(tracing::debug_span!("control_plane_watch_cluster", id, is_relay = self.is_relay))
+        });
+
+        if !self.is_relay {
+            self.config.filters.watch({
+                let this = self.clone();
+                move |_| {
+                    this.push_update(ResourceType::Listener);
+                }
+            });
+        }
+    }
+
+    pub fn management_server(
+        mut self,
+        listener: TcpListener,
+    ) -> io::Result<impl std::future::Future<Output = crate::Result<()>>> {
+        self.is_relay = false;
+        self.subscribe_to_config_changes();
+
+        let server = AggregatedDiscoveryServiceServer::new(self)
+            .max_encoding_message_size(crate::config::max_grpc_message_size());
+        let server = tonic::transport::Server::builder().add_service(server);
+        tracing::info!("serving management server on port `{}`", listener.port());
+        Ok(server
+            .serve_with_incoming(listener.into_stream()?)
+            .map_err(From::from))
+    }
+
+    pub(crate) fn relay_server(
+        mut self,
+        listener: TcpListener,
+    ) -> io::Result<impl std::future::Future<Output = crate::Result<()>>> {
+        self.is_relay = true;
+        self.subscribe_to_config_changes();
+
+        let server = AggregatedControlPlaneDiscoveryServiceServer::new(self)
+            .max_encoding_message_size(crate::config::max_grpc_message_size());
+        let server = tonic::transport::Server::builder().add_service(server);
+        tracing::info!("serving relay server on port `{}`", listener.port());
+        Ok(server
+            .serve_with_incoming(listener.into_stream()?)
+            .map_err(From::from))
+    }
+
+    #[inline]
+    fn push_update(&self, resource_type: ResourceType) {
+        tracing::debug!(%resource_type, id=%self.config.id.load(), is_relay = self.is_relay, "pushing update");
+        if self.tx.send(resource_type).is_err() {
+            tracing::debug!("no client connections currently subscribed");
         }
     }
 
@@ -162,15 +179,26 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
 
         let mut pending_acks = cached::TimedSizedCache::with_size_and_lifespan(50, 1);
         let this = Self::clone(self);
+        let mut rx = this.tx.subscribe();
 
-        let control_plane_id = crate::core::ControlPlane {
-            identifier: this.config.identifier(),
+        let id = (*this.config.id.load()).clone();
+        tracing::debug!(
+            id,
+            client = node_id,
+            count = this.tx.receiver_count(),
+            is_relay = this.is_relay,
+            "subscribed to config updates"
+        );
+
+        let control_plane_id = crate::net::xds::core::ControlPlane {
+            identifier: id.clone(),
         };
 
         struct ResourceTypeTracker {
             client: ClientVersions,
             subscribed: BTreeSet<String>,
             kind: ResourceType,
+            subbed: bool,
         }
 
         // Keep track of the resource versions that the client has so we can only
@@ -180,12 +208,14 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                 client: ClientVersions::new(ResourceType::Cluster),
                 subscribed: BTreeSet::new(),
                 kind: ResourceType::Cluster,
+                subbed: false,
             },
             ResourceType::Listener => {
                 ResourceTypeTracker {
                     client: ClientVersions::new(ResourceType::Listener),
                     subscribed: BTreeSet::new(),
                     kind: ResourceType::Listener,
+                    subbed: false,
                 }
             },
             ResourceType::FilterChain => {
@@ -193,6 +223,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                     client: ClientVersions::new(ResourceType::FilterChain),
                     subscribed: BTreeSet::new(),
                     kind: ResourceType::FilterChain,
+                    subbed: false,
                 }
             },
             ResourceType::Datacenter => {
@@ -200,23 +231,19 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                     client: ClientVersions::new(ResourceType::Datacenter),
                     subscribed: BTreeSet::new(),
                     kind: ResourceType::Datacenter,
+                    subbed: false,
                 }
             }
         };
 
-        let mut cluster_rx = self.watchers[ResourceType::Cluster].receiver.clone();
-        let mut listener_rx = self.watchers[ResourceType::Listener].receiver.clone();
-        let mut fc_rx = self.watchers[ResourceType::FilterChain].receiver.clone();
-        let mut dc_rx = self.watchers[ResourceType::Datacenter].receiver.clone();
-
-        let id = node_id.clone();
+        let client = node_id.clone();
         let responder =
             move |req: Option<DeltaDiscoveryRequest>,
                   tracker: &mut ResourceTypeTracker,
                   pending_acks: &mut cached::TimedSizedCache<uuid::Uuid, AwaitingAck>|
                   -> Result<DeltaDiscoveryResponse, tonic::Status> {
                 if let Some(req) = req {
-                    metrics::delta_discovery_requests(&id, tracker.kind.type_url()).inc();
+                    metrics::delta_discovery_requests(&client, tracker.kind.type_url()).inc();
 
                     // If the request has filled out the initial_versions field, it means the connected management servers has
                     // already had a connection with a control plane, so hard reset our state to what it says it has
@@ -247,7 +274,11 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                             tracker.client.remove(sub);
                         }
                     }
+                } else {
+                    tracing::debug!(kind = %tracker.kind, "sending delta update");
                 }
+
+                tracker.subbed = true;
 
                 let req = this
                     .config
@@ -276,9 +307,11 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                 Ok(response)
             };
 
+        let nid = node_id.clone();
+
         let response = {
             if message.type_url == "ignore-me" {
-                tracing::debug!(id = %node_id, "initial delta response");
+                tracing::debug!(id, client = nid, "initial delta response");
                 DeltaDiscoveryResponse {
                     resources: Vec::new(),
                     nonce: String::new(),
@@ -290,7 +323,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                 }
             } else {
                 let resource_type: ResourceType = message.type_url.parse()?;
-                tracing::debug!(id = %node_id, %resource_type, "initial delta response");
+                tracing::debug!(client = %node_id, %resource_type, "initial delta response");
                 responder(
                     Some(message),
                     &mut trackers[resource_type],
@@ -299,7 +332,6 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
             }
         };
 
-        let nid = node_id.clone();
         let stream = async_stream::try_stream! {
             yield response;
 
@@ -307,25 +339,23 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                 tokio::select! {
                     // The resource(s) have changed, inform the connected client, but only
                     // send the changed resources that the client doesn't already have
-                    _ = cluster_rx.changed() => {
-                        tracing::trace!("sending new cluster delta discovery response");
-
-                        yield responder(None, &mut trackers[ResourceType::Cluster], &mut pending_acks)?;
-                    }
-                    _ = listener_rx.changed() => {
-                        tracing::trace!("sending new listener delta discovery response");
-
-                        yield responder(None, &mut trackers[ResourceType::Listener], &mut pending_acks)?;
-                    }
-                    _ = fc_rx.changed() => {
-                        tracing::trace!("sending new filter chain delta discovery response");
-
-                        yield responder(None, &mut trackers[ResourceType::FilterChain], &mut pending_acks)?;
-                    }
-                    _ = dc_rx.changed() => {
-                        tracing::trace!("sending new datacenter delta discovery response");
-
-                        yield responder(None, &mut trackers[ResourceType::Datacenter], &mut pending_acks)?;
+                    res = rx.recv() => {
+                        match res {
+                            Ok(rt) => {
+                                let tracker = &mut trackers[rt];
+                                if tracker.subbed {
+                                    yield responder(None, tracker, &mut pending_acks)?;
+                                }
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                                for (_, tracker) in &mut trackers {
+                                    if tracker.subbed {
+                                        yield responder(None, tracker, &mut pending_acks)?;
+                                    }
+                                }
+                            }
+                        }
                     }
                     client_request = streaming.next() => {
                         let client_request = match client_request.transpose() {
@@ -350,7 +380,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                             }
                         };
 
-                        tracing::trace!(id, %resource_type, "new delta message");
+                        tracing::trace!(%resource_type, "new delta message");
 
                         let tracker = &mut trackers[resource_type];
 
@@ -374,12 +404,14 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                 }
             }
 
-            tracing::info!("terminating delta stream");
+            tracing::info!("terminating stream");
         };
 
-        Ok(Box::pin(stream.instrument(
-            tracing::info_span!("xds_delta_stream", id = %nid),
-        )))
+        Ok(Box::pin(stream.instrument(tracing::info_span!(
+            "xds_server_stream",
+            id,
+            client = nid
+        ))))
     }
 }
 
@@ -484,6 +516,7 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
                     config.clone(),
                     local.clone(),
                     Some(remote_addr),
+                    None,
                 );
 
                 loop {
@@ -530,8 +563,8 @@ mod tests {
     use super::*;
     use crate::{
         core::Node,
-        //     listener::v3::{FilterChain, Listener},
-        // },
+            listener::v3::{FilterChain, Listener},
+        },
         listener::{FilterChain, Listener},
         ResourceType,
     };

--- a/crates/xds/src/server.rs
+++ b/crates/xds/src/server.rs
@@ -238,11 +238,10 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                             tracker.client.remove(sub);
                         }
                     }
+                    tracing::debug!(kind = %tracker.kind, "sending delta for resource update");
                 } else {
                     tracing::debug!(kind = %tracker.kind, "sending delta update");
                 }
-
-                tracker.subbed = true;
 
                 let req = this
                     .config
@@ -347,6 +346,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                         tracing::trace!(%resource_type, "new delta message");
 
                         let tracker = &mut trackers[resource_type];
+                        tracker.subbed = true;
 
                         if let Some(error) = &client_request.error_detail {
                             metrics::nacks(id, resource_type.type_url()).inc();

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -105,6 +105,7 @@ impl Proxy {
             socket,
             qcmp,
             phoenix,
+            notifier: None,
         }
         .run(
             crate::components::RunArgs {

--- a/src/components/manage.rs
+++ b/src/components/manage.rs
@@ -57,11 +57,13 @@ impl Manage {
         };
 
         use futures::TryFutureExt as _;
-        let server_task = tokio::spawn(crate::net::xds::server::spawn(
-            self.listener,
-            config,
-            crate::components::admin::IDLE_REQUEST_INTERVAL,
-        )?)
+        let server_task = tokio::spawn(
+            crate::net::xds::server::ControlPlane::from_arc(
+                config,
+                crate::components::admin::IDLE_REQUEST_INTERVAL,
+            )
+            .management_server(self.listener)?,
+        )
         .map_err(From::from)
         .and_then(std::future::ready);
 

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -183,7 +183,7 @@ impl Proxy {
                             let _stream = client
                                 .delta_subscribe(
                                     config.clone(),
-                                    ready.clone(),
+                                    xds_is_healthy.clone(),
                                     tx,
                                     [
                                         (ResourceType::Cluster, Vec::new()),

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -155,7 +155,7 @@ impl Proxy {
                     let config = config.clone();
                     let mut shutdown_rx = shutdown_rx.clone();
                     let management_servers = self.management_servers.clone();
-                    let tx = self.notifier.as_ref().map(|n| n.clone());
+                    let tx = self.notifier.clone();
 
                     move || {
                         let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/config.rs
+++ b/src/config.rs
@@ -505,7 +505,7 @@ impl Config {
         match resource_type {
             ResourceType::Listener => {
                 for res in resources {
-                    let (resource, _) = res?;
+                    let (resource, version) = res?;
                     let Resource::Listener(mut listener) = resource else {
                         return Err(eyre::eyre!("a non-listener resource was present"));
                     };
@@ -518,8 +518,11 @@ impl Config {
                         )?
                     };
 
+                    //dbg!(&chain, self.id.load());
+
                     self.filters.store(Arc::new(chain));
-                    local_versions.insert(listener.name, "".into());
+                    //dbg!(self.filters.load(), self.id.load());
+                    local_versions.insert(listener.name, version);
                 }
             }
             ResourceType::FilterChain => {
@@ -529,11 +532,11 @@ impl Config {
                         return Err(eyre::eyre!("a non-filterchain resource was present"));
                     };
 
-                    self.filters
-                        .store(Arc::new(crate::filters::FilterChain::try_create_fallible(
-                            fc.filters.into_iter(),
-                        )?));
-                    local_versions.insert(String::new(), "".into());
+                    let fc =
+                        crate::filters::FilterChain::try_create_fallible(fc.filters.into_iter())?;
+
+                    self.filters.store(Arc::new(fc));
+                    local_versions.insert(String::new(), "0".into());
                 }
             }
             ResourceType::Datacenter => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -521,10 +521,7 @@ impl Config {
                         )?
                     };
 
-                    //dbg!(&chain, self.id.load());
-
                     self.filters.store(Arc::new(chain));
-                    //dbg!(self.filters.load(), self.id.load());
                     local_versions.insert(listener.name, version);
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,12 +129,15 @@ impl xds::config::Configuration for Config {
         control_plane: xds::server::ControlPlane<Self>,
     ) -> impl std::future::Future<Output = ()> + Send + 'static {
         let mut cluster_watcher = self.clusters.watch();
-        self.filters.watch({
-            let this = control_plane.clone();
-            move |_| {
-                this.push_update(ResourceType::Listener);
-            }
-        });
+
+        if !control_plane.is_relay {
+            self.filters.watch({
+                let this = control_plane.clone();
+                move |_| {
+                    this.push_update(ResourceType::Listener);
+                }
+            });
+        }
 
         tracing::trace!("waiting for changes");
 

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -46,6 +46,10 @@ impl<T> Slot<T> {
     /// Adds a watcher to to the slot. The watcher will fire whenever slot's
     /// value changes.
     pub fn watch(&self, watcher: impl Fn(&T) + Send + Sync + 'static) {
+        if self.watcher.load().is_some() {
+            panic!("watcher is already set for this slot");
+        }
+
         tracing::trace!("Adding new watcher");
         self.watcher.store(Some(Arc::new(Box::new(watcher))));
     }

--- a/src/config/watch/fs.rs
+++ b/src/config/watch/fs.rs
@@ -31,7 +31,8 @@ pub async fn watch(
     locality: Option<crate::net::endpoint::Locality>,
 ) -> crate::Result<()> {
     let path = path.into();
-    let span = tracing::info_span!("config_provider", path = %path.display());
+    let span =
+        tracing::info_span!("config_provider", path = %path.display(), id = %config.id.load());
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
     async fn watch_inner(

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -170,6 +170,21 @@ where
                 .transpose()?,
         })
     }
+
+    #[inline]
+    fn as_labeled_filter_config(
+        config: impl Into<Option<Self::Configuration>>,
+        label: String,
+    ) -> Result<crate::config::Filter, CreationError> {
+        Ok(crate::config::Filter {
+            name: Self::NAME.into(),
+            label: Some(label),
+            config: config
+                .into()
+                .map(|config| serde_json::to_value(&config))
+                .transpose()?,
+        })
+    }
 }
 
 /// Trait for routing and manipulating packets.

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -126,7 +126,7 @@ impl Router for HashedTokenRouter {
 
                 let tok = crate::net::cluster::Token::new(token);
 
-                for ep in ctx.endpoints.iter() {
+                for ep in dbg!(&ctx.endpoints).iter() {
                     ep.value().addresses_for_token(tok, &mut destinations);
 
                     if !destinations.is_empty() {
@@ -139,7 +139,7 @@ impl Router for HashedTokenRouter {
                 if ctx.destinations.is_empty() {
                     Err(FilterError::new(Error::NoEndpointMatch(
                         self.config.metadata_key,
-                        crate::codec::base64::encode(token),
+                        crate::codec::base64::encode(dbg!(token)),
                     )))
                 } else {
                     Ok(())

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -126,7 +126,7 @@ impl Router for HashedTokenRouter {
 
                 let tok = crate::net::cluster::Token::new(token);
 
-                for ep in dbg!(&ctx.endpoints).iter() {
+                for ep in ctx.endpoints.iter() {
                     ep.value().addresses_for_token(tok, &mut destinations);
 
                     if !destinations.is_empty() {
@@ -139,7 +139,7 @@ impl Router for HashedTokenRouter {
                 if ctx.destinations.is_empty() {
                     Err(FilterError::new(Error::NoEndpointMatch(
                         self.config.metadata_key,
-                        crate::codec::base64::encode(dbg!(token)),
+                        crate::codec::base64::encode(token),
                     )))
                 } else {
                     Ok(())

--- a/src/test.rs
+++ b/src/test.rs
@@ -308,6 +308,7 @@ impl TestHelper {
                 socket: crate::net::raw_socket_with_reuse(0).unwrap(),
                 qcmp,
                 phoenix,
+                notifier: None,
             }
         });
 


### PR DESCRIPTION
This was caused by `config.filters` being a `Slot<>`, which only allows one closure at a time to be notified when the value changes. The relay creates both a relay and management service, which both subscribed to changes, meaning the management closure was dropped and replaced by the relay one, which meant the delta stream would never send updates for filters unless the client did a refresh if the interval was surpassed.

Resolves: #960 