### PR TITLE
Guide: Show command options for `manage providers`

### DIFF
--- a/docs/preprocessor.sh
+++ b/docs/preprocessor.sh
@@ -22,6 +22,8 @@ cargo run -q --manifest-path ../Cargo.toml -- -q generate-config-schema -o ../ta
 cargo run -q --manifest-path ../Cargo.toml &> ../target/quilkin.commands || true
 cargo run -q --manifest-path ../Cargo.toml -- proxy --help &> ../target/quilkin.proxy.commands || true
 cargo run -q --manifest-path ../Cargo.toml -- manage --help &> ../target/quilkin.manage.commands || true
+cargo run -q --manifest-path ../Cargo.toml -- manage agones --help &> ../target/quilkin.manage.agones.commands || true
+cargo run -q --manifest-path ../Cargo.toml -- manage file --help &> ../target/quilkin.manage.file.commands || true
 cargo run -q --manifest-path ../Cargo.toml -- relay --help &> ../target/quilkin.relay.commands || true
 cargo run -q --manifest-path ../Cargo.toml -- agent --help &> ../target/quilkin.agent.commands || true
 

--- a/docs/src/services/xds/providers/agones.md
+++ b/docs/src/services/xds/providers/agones.md
@@ -7,6 +7,12 @@ This provider watches for changes in Agones
 [`GameServer` resources](https://agones.dev/site/docs/getting-started/create-gameserver/) in a cluster, and
 utilises that information to provide [Endpoint][Endpoints] information to connected Quilkin proxies.
 
+To view all the options for the agones provider subcommand, run:
+```shell
+$ quilkin manage agones --help
+{{#include ../../../../../target/quilkin.manage.agones.commands}}
+```
+
 > Currently, the Agones provider can only discover resources within the cluster it is running in.
 
 ## Endpoint Configuration

--- a/docs/src/services/xds/providers/filesystem.md
+++ b/docs/src/services/xds/providers/filesystem.md
@@ -2,7 +2,13 @@
 
 The filesystem provider watches a configuration file on disk and sends updates to proxies whenever that file changes.
 
-It can be started with using subcommand `manage file` as the following:
+To view all the options for the file provider subcommand, run:
+```shell
+$ quilkin manage agones --help
+{{#include ../../../../../target/quilkin.manage.file.commands}}
+```
+
+For example:
 ```sh
 quilkin manage file quilkin.yaml
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug

/kind cleanup

> /kind documentation
> /kind feature
> /kind hotfix

**What this PR does / Why we need it**:

Adding the `--help` output for each provider to the guide for each managed provider.

This just ensures we always have up-to-date command docs for each provider.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
N/A

**Special notes for your reviewer**:

Was more useful when we had some more args, but I've been wanting to do this for a while, just to make sure if new options show up they are always documented immeadiately.
