### PR TITLE
Update crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 name = "agones"
 version = "0.1.0"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "futures",
  "k8s-openapi",
  "kube",
@@ -187,6 +187,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.49.3"
+version = "0.51.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
+checksum = "dd93a9f06ec296ca66b4c26fafa9ed63f32c473d7a708a5f28563ee64c948515"
 dependencies = [
  "hashbrown 0.14.3",
  "instant",
@@ -378,7 +384,7 @@ version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -637,7 +643,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.60",
@@ -927,6 +933,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,10 +983,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hickory-proto"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07698b8420e2f0d6447a436ba999ec85d8fbf2a398bbd737b82cac4a2e96e512"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "rustls 0.21.11",
+ "rustls-pemfile 1.0.4",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28757f23aa75c98f254cf0405e6d8c25b831b32921b050a66692427679b1f243"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "rustls 0.21.11",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tracing",
+]
 
 [[package]]
 name = "home"
@@ -1061,7 +1145,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1084,9 +1168,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1115,23 +1201,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.28",
- "log",
- "rustls 0.21.11",
- "rustls-native-certs 0.6.3",
- "tokio",
- "tokio-rustls 0.24.1",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "908bb38696d7a037a01ebcc68a00634112ac2bbf8ca74e30a2c3d2f4f021302b"
@@ -1142,11 +1211,12 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.23.5",
- "rustls-native-certs 0.7.0",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1277,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.5.13"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd1e1a01cfb924fd8c5c43b6827965db394f5a3a16c599ce03452266e1cf984c"
+checksum = "595a0399f411a508feb2ec1e970a4a30c249351e30208960d58298de8660b0e5"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -1418,7 +1488,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.3.1",
  "hyper-openssl",
- "hyper-rustls 0.27.1",
+ "hyper-rustls",
  "hyper-timeout 0.5.1",
  "hyper-util",
  "jsonpath-rust",
@@ -2050,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "log",
  "multimap",
@@ -2129,7 +2199,7 @@ dependencies = [
  "async-channel",
  "async-stream",
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "base64-serde",
  "bytes",
  "cached",
@@ -2143,8 +2213,11 @@ dependencies = [
  "fixedstr",
  "form_urlencoded",
  "futures",
- "hyper 0.14.28",
- "hyper-rustls 0.24.2",
+ "hickory-resolver",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls",
+ "hyper-util",
  "ipnetwork",
  "k8s-openapi",
  "kube",
@@ -2161,7 +2234,6 @@ dependencies = [
  "pretty_assertions",
  "prometheus",
  "prost",
- "prost-build",
  "prost-types",
  "quilkin-macros",
  "quilkin-proto",
@@ -2187,12 +2259,11 @@ dependencies = [
  "tokio-stream",
  "tokio-uring",
  "tonic",
- "tonic-build",
+ "tower",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
  "tracing-test",
- "trust-dns-resolver",
  "tryhard",
  "url",
  "uuid",
@@ -2395,18 +2466,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
@@ -2519,12 +2578,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2811,17 +2864,17 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -3057,14 +3110,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-uring"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5e02bb137e030b3a547c65a3bd2f1836d66a97369fdcc69034002b10e155ef"
+checksum = "748482e3e13584a34664a710168ad5068e8cb1d968aa4ffa887e83ca6dd27967"
 dependencies = [
  "bytes",
+ "futures-util",
  "io-uring",
  "libc",
- "scoped-tls",
  "slab",
  "socket2 0.4.10",
  "tokio",
@@ -3087,16 +3140,16 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
 dependencies = [
  "async-stream",
  "async-trait",
  "axum",
  "base64 0.21.7",
  "bytes",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -3110,19 +3163,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 2.0.60",
 ]
 
 [[package]]
@@ -3296,63 +3336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2",
- "http 0.2.12",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "rustls 0.21.11",
- "rustls-pemfile 1.0.4",
- "rustls-webpki 0.101.7",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tokio-rustls 0.24.1",
- "tracing",
- "url",
- "webpki-roots",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "rustls 0.21.11",
- "smallvec",
- "thiserror",
- "tokio",
- "tokio-rustls 0.24.1",
- "tracing",
- "trust-dns-proto",
- "webpki-roots",
-]
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3486,9 +3469,12 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.4"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "widestring"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,12 @@ enum-map.workspace = true
 eyre.workspace = true
 fixedstr.workspace = true
 futures.workspace = true
-hyper = { version = "0.14.27", features = ["http2"] }
-hyper-rustls = { version = "0.24.1", features = ["http2", "webpki-roots"] }
+http-body-util = "0.1"
+hyper = { version = "1.3", features = ["http2", "http1", "server"] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http2",
+    "webpki-roots",
+] }
 ipnetwork = "0.20.0"
 k8s-openapi.workspace = true
 lz4_flex = { version = "0.11", default-features = false }
@@ -114,6 +118,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
+tower.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
@@ -123,21 +128,24 @@ uuid.workspace = true
 lasso = { version = "0.7.2", features = ["multi-threaded"] }
 kube.workspace = true
 kube-core.workspace = true
-trust-dns-resolver = { version = "0.23.0", features = [
-    "tokio",
-    "tokio-rustls",
+hickory-resolver = { version = "0.24", features = [
     "dns-over-https-rustls",
+    "system-config",
 ] }
 async-trait = "0.1.73"
-strum = "0.25.0"
-strum_macros = "0.25.2"
+strum = "0.26"
+strum_macros = "0.26"
 cfg-if = "1.0.0"
 libflate = "2.0.0"
 form_urlencoded = "1.2.1"
 
+[dependencies.hyper-util]
+version = "0.1"
+features = ["client", "client-legacy"]
+
 [target.'cfg(target_os = "linux")'.dependencies]
 sys-info = "0.9.1"
-tokio-uring = { version = "0.4.0", features = ["bytes"] }
+tokio-uring = { version = "0.5", features = ["bytes"] }
 pprof = { version = "0.13.0", features = ["prost", "prost-codec"] }
 
 [dev-dependencies]
@@ -149,13 +157,6 @@ regex = "1.9.6"
 tracing-test = "0.2.4"
 tempfile.workspace = true
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-
-[build-dependencies]
-tonic-build = { version = "0.10.2", default_features = false, features = [
-    "transport",
-    "prost",
-] }
-prost-build = "0.12.1"
 
 [features]
 default = []
@@ -177,8 +178,8 @@ edition = "2021"
 arc-swap = { version = "1.6.0", features = ["serde"] }
 async-channel = "2.1.0"
 async-stream = "0.3.5"
-base64 = "0.21.0"
-cached = { version = "0.49", default-features = false }
+base64 = "0.22.0"
+cached = { version = "0.51", default-features = false }
 eyre = "0.6.8"
 enum-map = "2.6.3"
 futures = "0.3.28"
@@ -211,7 +212,8 @@ tokio = { version = "1.32.0", features = [
     "parking_lot",
     "tracing",
 ] }
-tonic = "0.10.2"
+tonic = "0.11"
+tower = "0.4"
 tracing = "0.1.37"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-subscriber = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -26,29 +26,25 @@ all-features = true
 ignore = []
 
 [bans]
-multiple-versions = "deny"
 deny = [
     { crate = "openssl-sys", use-instead = "rustls" },
     { crate = "openssl", use-instead = "rustls" },
+    { crate = "cmake", use-instead = "cc" },
     { crate = "chrono", use-instead = "time", wrappers = [
         "k8s-openapi",
         "kube-client",
         "kube-core",
     ] },
 ]
+multiple-versions = "deny"
 skip = [
-    { crate = "bitflags@1.3.2", reason = "multiple crates use this old version" },
-    { crate = "syn@1.0", reason = "multiple crates use this old version" },
-    { crate = "syn@1.0", reason = "multiple crates use this old version" },
-    { crate = "indexmap@1.9", reason = "tower is the sole user of this old version" },
-    { crate = "hashbrown@0.12", reason = "used by the old version of indexmap" },
-    { crate = "hashbrown@0.13", reason = "used by lasso/libflate" },
-    { crate = "idna@0.4", reason = "trust-dns uses an old version" },
-    { crate = "socket2@0.4", reason = "tokio-uring is the sole user of this old version" },
+    { crate = "heck@0.4.1", reason = "several crates use this old version" },
 ]
 skip-tree = [
     { crate = "regex-automata@0.1", reason = "matchers is using an old version, https://github.com/hawkw/matchers/pull/5, but it's also barely maintained..." },
-    { crate = "kube@0.91", reason = "We need the newer version of kube, but rustls crates in other deps aren't updated yet." },
+    { crate = "tonic@0.11.0", reason = "Uses _many_ outdated crates" },
+    # Much like trust-dns this pulls in a ton of outdated dependencies, but it's _slightly_ better
+    { crate = "hickory-resolver@0.24.1", reason = "Uses _many_ outdated crates" },
 ]
 
 # This section is considered when running `cargo deny check licenses`

--- a/src/components/admin.rs
+++ b/src/components/admin.rs
@@ -108,7 +108,7 @@ impl Admin {
                             }
                         });
 
-                    Ok(http_task.await??)
+                    http_task.await?
                 })
             })
             .expect("failed to spawn admin-http thread")

--- a/src/components/admin/health.rs
+++ b/src/components/admin/health.rs
@@ -16,7 +16,7 @@
 
 use std::sync::atomic::AtomicBool;
 
-use hyper::{Body, Response, StatusCode};
+use hyper::{Response, StatusCode};
 use std::panic;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
@@ -44,12 +44,12 @@ impl Health {
     }
 
     /// returns a HTTP 200 response if the proxy is healthy.
-    pub fn check_liveness(&self) -> Response<Body> {
+    pub fn check_liveness(&self) -> Response<http_body_util::Full<bytes::Bytes>> {
         if self.healthy.load(Relaxed) {
             return Response::new("ok".into());
         };
 
-        let mut response = Response::new(Body::empty());
+        let mut response = Response::new(http_body_util::Full::new(bytes::Bytes::new()));
         *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
         response
     }

--- a/src/net/endpoint/address.rs
+++ b/src/net/endpoint/address.rs
@@ -21,9 +21,9 @@ use std::{
     str::FromStr,
 };
 
+use hickory_resolver::TokioAsyncResolver;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
-use trust_dns_resolver::{AsyncResolver, TokioAsyncResolver};
 
 use crate::generated::envoy::config::core::v3::{
     address::Address as EnvoyAddress, SocketAddress as EnvoySocketAddress,
@@ -62,7 +62,7 @@ impl EndpointAddress {
     /// if present.
     pub async fn to_socket_addr(&self) -> std::io::Result<SocketAddr> {
         static DNS: Lazy<TokioAsyncResolver> =
-            Lazy::new(|| AsyncResolver::tokio_from_system_conf().unwrap());
+            Lazy::new(|| TokioAsyncResolver::tokio_from_system_conf().unwrap());
 
         let ip = match &self.host {
             AddressKind::Ip(ip) => *ip,


### PR DESCRIPTION
Unfortunately this isn't as big of a win as I would have hoped, primarily due to tonic and hickory-resolver both using many outdated crates, but it is a step in the right direction.

- hyper -> 1.3 - This aligns better with some crates eg. kube-client, but misaligns us with tonic/axum. This is also annoying because 1.0 re/moved a lot of functionality so we have new dependencies on small utility crates, but it is what it is
- trust-dns-resolver -> hickory-resolver - trust-dns-resolver was a major source of outdated crates, hickory-resolver, being a fork of that project, carries on the tradition, though is _slightly_ better, as well as just being the future as opposed to trust-dns