### PR TITLE
Remove dynamic error properties

### DIFF
--- a/crates/gen.rs
+++ b/crates/gen.rs
@@ -1,0 +1,49 @@
+#!/bin/env/cargo run-cargo-script
+
+//! ```cargo
+//! [dependencies]
+//! base64-simd = "0.8.0"
+//! ```
+
+extern crate base64_simd;
+
+fn main() {
+    use std::io::Write as _;
+
+    let mut args = std::env::args().skip(1);
+
+    let count: u64 = args.next().unwrap().parse().unwrap();
+    let length: u8 = args.next().unwrap().parse().unwrap();
+    let length = length as usize;
+
+    let file = std::fs::File::create("./quilkin-test-config.yaml").unwrap();
+    let mut writer = std::io::BufWriter::new(file);
+
+    writeln!(
+        &mut writer,
+        r#"version: v1alpha1
+filters:
+  - name: quilkin.filters.capture.v1alpha1.Capture
+    config:
+        suffix:
+          size: {length}
+          remove: true
+  - name: quilkin.filters.token_router.v1alpha1.TokenRouter
+clusters:
+  - endpoints:
+    - address: 127.0.0.1:8078
+      metadata:
+        quilkin.dev:
+          tokens:"#
+    );
+
+    let mut s = String::new();
+    for i in 0..count {
+        s.clear();
+        base64_simd::STANDARD.encode_append(&i.to_le_bytes()[..length], &mut s);
+
+        writeln!(&mut writer, "          - '{s}'");
+    }
+
+    writeln!(&mut writer);
+}

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -502,6 +502,7 @@ impl Pail {
                         num_workers: NonZeroUsize::new(1).unwrap(),
                         mmdb: None,
                         to: Vec::new(),
+                        to_tokens: None,
                         management_servers,
                         socket,
                         qcmp,

--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -88,12 +88,16 @@ trace_test!(uring_receiver, {
 
     let (mut packet_rx, endpoint) = sb.server("server");
 
-    let (error_sender, mut error_receiver) = tokio::sync::mpsc::unbounded_channel();
+    let (error_sender, mut error_receiver) =
+        tokio::sync::mpsc::unbounded_channel::<quilkin::components::proxy::PipelineError>();
 
     tokio::task::spawn(
         async move {
             while let Some(error) = error_receiver.recv().await {
-                tracing::error!(%error, "error sent from DownstreamReceiverWorker");
+                tracing::error!(
+                    error = error.as_str(),
+                    "error sent from DownstreamReceiverWorker"
+                );
             }
         }
         .instrument(tracing::debug_span!("error rx")),

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -46,6 +46,9 @@ pub struct Proxy {
     /// One or more socket addresses to forward packets to.
     #[clap(short, long, env = "QUILKIN_DEST")]
     pub to: Vec<SocketAddr>,
+    /// Assigns dynamic tokens to each address in the `--to` argument
+    #[clap(short, long, env = "QUILKIN_DEST_TOKENS", requires("to"))]
+    pub to_tokens: Option<String>,
     /// The interval in seconds at which the relay will send a discovery request
     /// to an management server after receiving no updates.
     #[clap(long, env = "QUILKIN_IDLE_REQUEST_INTERVAL_SECS")]
@@ -64,6 +67,7 @@ impl Default for Proxy {
             port: PORT,
             qcmp_port: QCMP_PORT,
             to: <_>::default(),
+            to_tokens: None,
             idle_request_interval_secs: None,
             workers: None,
         }
@@ -97,10 +101,25 @@ impl Proxy {
         let qcmp = crate::net::raw_socket_with_reuse(self.qcmp_port)?;
         let phoenix = crate::net::TcpListener::bind(Some(self.qcmp_port))?;
 
+        let to_tokens = self
+            .to_tokens
+            .map(|tt| {
+                let Some((count, length)) = tt.split_once(':') else {
+                    eyre::bail!("--to-tokens `{tt}` is invalid, it must have a `:` separator")
+                };
+
+                let count = count.parse()?;
+                let length = length.parse()?;
+
+                Ok(crate::components::proxy::ToTokens { count, length })
+            })
+            .transpose()?;
+
         crate::components::proxy::Proxy {
             management_servers: self.management_server,
             mmdb: self.mmdb,
             to: self.to,
+            to_tokens,
             num_workers,
             socket,
             qcmp,

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -25,7 +25,7 @@ pub enum PipelineError {
 }
 
 impl PipelineError {
-    fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::NoUpstreamEndpoints => "no upstream endpoints",
             Self::Filter(fe) => fe.as_str(),

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -55,7 +55,7 @@ pub use self::{
     concatenate::Concatenate,
     debug::Debug,
     drop::Drop,
-    error::{ConvertProtoConfigError, CreationError, FilterError},
+    error::{io_kind_as_str, ConvertProtoConfigError, CreationError, FilterError},
     factory::{CreateFilterArgs, DynFilterFactory, FilterFactory, FilterInstance},
     firewall::Firewall,
     load_balancer::LoadBalancer,

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -72,7 +72,7 @@ impl Filter for Capture {
             Ok(())
         } else {
             tracing::trace!(key = %self.metadata_key, "No value captured");
-            Err(FilterError::new(NoValueCaptured))
+            Err(FilterError::Capture(NoValueCaptured))
         }
     }
 }
@@ -87,9 +87,19 @@ impl StaticFilter for Capture {
     }
 }
 
-#[derive(thiserror::Error, Debug)]
-#[error("no value captured")]
-struct NoValueCaptured;
+pub struct NoValueCaptured;
+
+impl NoValueCaptured {
+    pub fn as_str(&self) -> &'static str {
+        "no value captured"
+    }
+}
+
+impl std::fmt::Debug for NoValueCaptured {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -34,12 +34,12 @@ impl Drop {
 impl Filter for Drop {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
-        Err(FilterError::new("intentionally dropped"))
+        Err(FilterError::Dropped)
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
-        Err(FilterError::new("intentionally dropped"))
+        Err(FilterError::Dropped)
     }
 }
 

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -65,7 +65,7 @@ impl Filter for Firewall {
                     }
                     Action::Deny => {
                         debug!(action = "Deny", event = "read", source = ?ctx.source);
-                        Err(FilterError::new(PacketDenied))
+                        Err(FilterError::Firewall(PacketDenied))
                     }
                 };
             }
@@ -75,7 +75,7 @@ impl Filter for Firewall {
             event = "read",
             source = ?ctx.source.to_string()
         );
-        Err(FilterError::new(PacketDenied))
+        Err(FilterError::Firewall(PacketDenied))
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
@@ -93,7 +93,7 @@ impl Filter for Firewall {
                     }
                     Action::Deny => {
                         debug!(action = "Deny", event = "write", source = ?ctx.source);
-                        Err(FilterError::new(PacketDenied))
+                        Err(FilterError::Firewall(PacketDenied))
                     }
                 };
             }
@@ -104,13 +104,26 @@ impl Filter for Firewall {
             event = "write",
             source = ?ctx.source.to_string()
         );
-        Err(FilterError::new(PacketDenied))
+        Err(FilterError::Firewall(PacketDenied))
     }
 }
 
-#[derive(thiserror::Error, Debug)]
-#[error("packet denied")]
 pub struct PacketDenied;
+
+impl PacketDenied {
+    #[inline]
+    pub fn as_str(&self) -> &'static str {
+        "packet denied"
+    }
+}
+
+use std::fmt;
+
+impl fmt::Debug for PacketDenied {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -96,9 +96,8 @@ where
 {
     match config {
         Some(config) => {
-            let value = (get_metadata)(ctx, &config.metadata_key).ok_or_else(|| {
-                FilterError::new(format!("no metadata found for {}", config.metadata_key))
-            })?;
+            let value = (get_metadata)(ctx, &config.metadata_key)
+                .ok_or(FilterError::Match(Error::NoMetadataKey))?;
 
             match config.branches.iter().find(|(key, _)| key == value) {
                 Some((value, instance)) => {
@@ -156,6 +155,24 @@ impl StaticFilter for Match {
 
     fn try_from_config(config: Option<Self::Configuration>) -> Result<Self, CreationError> {
         Self::new(Self::ensure_config_exists(config)?, Metrics::new())
+    }
+}
+
+pub enum Error {
+    /// The metadata key expected by the match filter was not present
+    NoMetadataKey,
+}
+
+impl Error {
+    #[inline]
+    pub fn as_str(&self) -> &'static str {
+        "expected metadata key not present"
+    }
+}
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -76,11 +76,11 @@ mod tests {
     #[async_trait::async_trait]
     impl Filter for TestFilter {
         async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
-            Err(FilterError::new("test error"))
+            Err(FilterError::Custom("test error"))
         }
 
         async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
-            Err(FilterError::new("test error"))
+            Err(FilterError::Custom("test error"))
         }
     }
 

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -226,12 +226,6 @@ mod tests {
         // no key
         let mut ctx = new_ctx();
         assert!(filter.read(&mut ctx).await.is_err());
-
-        // wrong type key
-        let mut ctx = new_ctx();
-        ctx.metadata
-            .insert(CAPTURED_BYTES.into(), Value::String(String::from("wrong")));
-        assert!(filter.read(&mut ctx).await.is_err());
     }
 
     #[tokio::test]

--- a/src/net.rs
+++ b/src/net.rs
@@ -17,7 +17,7 @@
 /// On linux spawns a io-uring runtime + thread, everywhere else spawns a regular tokio task.
 macro_rules! uring_spawn {
     ($span:expr, $future:expr) => {{
-        let (tx, rx) = tokio::sync::oneshot::channel::<crate::Result<()>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), std::io::Error>>();
         use tracing::Instrument as _;
 
         cfg_if::cfg_if! {
@@ -37,7 +37,7 @@ macro_rules! uring_spawn {
                             }
                         }
                         Err(error) => {
-                            let _ = tx.send(Err(error.into()));
+                            let _ = tx.send(Err(error));
                         }
                     };
                 }).expect("failed to spawn io-uring thread");

--- a/src/test.rs
+++ b/src/test.rs
@@ -305,6 +305,7 @@ impl TestHelper {
                 mmdb: None,
                 management_servers: Vec::new(),
                 to: Vec::new(),
+                to_tokens: None,
                 socket: crate::net::raw_socket_with_reuse(0).unwrap(),
                 qcmp,
                 phoenix,


### PR DESCRIPTION
I'm opening this as a draft as I want to confirm if this resolves the issue for the original reporter, as I had difficulty solidly reproing the bug, but was able to in a certain scenario, that when repeated with the changes I made resulted in (basically) flat heap usage. This isn't a total fix, as I believe the issue is that in the case of invalid traffic, the case in question being _every_ packet being received generating an error due to it not matching an endpoint results in a pipeline error being sent here https://github.com/googleforgames/quilkin/blob/50d91e4167f9160c5be36178e47789fb7844dfc1/src/components/proxy/packet_router.rs#L189 The problem is that, under load, the task that receives those errors may be starved of CPU time, resulting in the both the channel queue growing unbounded (it is an unboundedchannel after all), as well as causing all of the memory allocated by the error itself (in the case of TokenRouter, the base64 encoded token string) to be kept until the error can be popped off the queue.

Eg. what it looks like before this change
![image](https://github.com/googleforgames/quilkin/assets/2316028/75f90c60-2f37-4a65-b368-a0513c4dc3df)

Even if the errors were popped quickly enough, every _unique_ error would result in a hash map entry, which means in the token router case, random traffic would cause the heap to grow up to the size of the of the token length given enough traffic.

While investigating I ran into a bug with xDS filterchain where the server will send empty delta updates, so now the server doesn't send updates if the resource(s) haven't changed.

Also added 2 ways to generate unique tokens, one where _n_ tokens of length _l_ are generated and written to ./quilkin-test-config.yaml that can be used with `-c`, and the other is with a new `--to-tokens` arg on proxy that can do the same, assigning unique tokens of a specific length to each address in `--to`.

Resolves: #983 