### PR TITLE
Cap error heap usage

### DIFF
--- a/crates/gen.rs
+++ b/crates/gen.rs
@@ -1,0 +1,49 @@
+#!/bin/env/cargo run-cargo-script
+
+//! ```cargo
+//! [dependencies]
+//! base64-simd = "0.8.0"
+//! ```
+
+extern crate base64_simd;
+
+fn main() {
+    use std::io::Write as _;
+
+    let mut args = std::env::args().skip(1);
+
+    let count: u64 = args.next().unwrap().parse().unwrap();
+    let length: u8 = args.next().unwrap().parse().unwrap();
+    let length = length as usize;
+
+    let file = std::fs::File::create("./quilkin-test-config.yaml").unwrap();
+    let mut writer = std::io::BufWriter::new(file);
+
+    writeln!(
+        &mut writer,
+        r#"version: v1alpha1
+filters:
+  - name: quilkin.filters.capture.v1alpha1.Capture
+    config:
+        suffix:
+          size: {length}
+          remove: true
+  - name: quilkin.filters.token_router.v1alpha1.TokenRouter
+clusters:
+  - endpoints:
+    - address: 127.0.0.1:8078
+      metadata:
+        quilkin.dev:
+          tokens:"#
+    );
+
+    let mut s = String::new();
+    for i in 0..count {
+        s.clear();
+        base64_simd::STANDARD.encode_append(&i.to_le_bytes()[..length], &mut s);
+
+        writeln!(&mut writer, "          - '{s}'");
+    }
+
+    writeln!(&mut writer);
+}

--- a/crates/gen.rs
+++ b/crates/gen.rs
@@ -1,5 +1,21 @@
 #!/bin/env/cargo run-cargo-script
 
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 //! ```cargo
 //! [dependencies]
 //! base64-simd = "0.8.0"

--- a/crates/proto-gen/gen.rs
+++ b/crates/proto-gen/gen.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use std::{
     path::PathBuf,
     process::{Command, Stdio},

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -59,9 +59,7 @@ pub fn init_logging(level: Level, test_pkg: &'static str) -> DefaultGuard {
         )));
     let sub = tracing_subscriber::Registry::default().with(layer);
     let disp = tracing::dispatcher::Dispatch::new(sub);
-    let guard = tracing::dispatcher::set_default(&disp);
-
-    guard
+    tracing::dispatcher::set_default(&disp)
 }
 
 #[macro_export]
@@ -363,7 +361,7 @@ impl Pail {
                     endpoints.insert(quilkin::net::Endpoint::with_metadata(
                         (std::net::Ipv4Addr::UNSPECIFIED, server.port).into(),
                         quilkin::net::endpoint::Metadata {
-                            tokens: tokens.into_iter().map(|t| Vec::from(*t)).collect(),
+                            tokens: tokens.iter().map(|t| Vec::from(*t)).collect(),
                         },
                     ));
                 }
@@ -377,7 +375,7 @@ impl Pail {
 
                 let relay_servers = spc
                     .dependencies
-                    .into_iter()
+                    .iter()
                     .filter_map(|dname| {
                         let Pail::Relay(RelayPail { mds_port, .. }) = &pails[dname] else {
                             return None;
@@ -442,7 +440,7 @@ impl Pail {
 
                 let management_servers = spc
                     .dependencies
-                    .into_iter()
+                    .iter()
                     .filter_map(|dname| {
                         let Pail::Relay(RelayPail { xds_port, .. }) = &pails[dname] else {
                             return None;
@@ -474,7 +472,7 @@ impl Pail {
 
                 let endpoints: std::collections::BTreeSet<_> = spc
                     .dependencies
-                    .into_iter()
+                    .iter()
                     .filter_map(|dname| {
                         let Pail::Server(ServerPail { port, .. }) = &pails[dname] else {
                             return None;

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -502,6 +502,7 @@ impl Pail {
                         num_workers: NonZeroUsize::new(1).unwrap(),
                         mmdb: None,
                         to: Vec::new(),
+                        to_tokens: None,
                         management_servers,
                         socket,
                         qcmp,

--- a/crates/test/tests/mesh.rs
+++ b/crates/test/tests/mesh.rs
@@ -86,7 +86,6 @@ trace_test!(relay_routing, {
         let mut token = Token { inner: [0; 3] };
 
         let tokens = (0..2000)
-            .into_iter()
             .map(|i| {
                 let tok = Token::new(&mut rng);
                 if i == 1337 {
@@ -182,9 +181,8 @@ trace_test!(datacenter_discovery, {
     loop {
         let rt = sandbox.timeout(10000, proxy_delta_rx.recv()).await.unwrap();
 
-        match rt.as_ref() {
-            quilkin::xds::DATACENTER_TYPE => break,
-            _ => {}
+        if matches!(rt.as_ref(), quilkin::xds::DATACENTER_TYPE) {
+            break;
         }
     }
 
@@ -205,8 +203,8 @@ trace_test!(datacenter_discovery, {
         };
     }
 
-    assert_config(&relay_config, &datacenter);
-    assert_config(&proxy_config, &datacenter);
+    assert_config(relay_config, &datacenter);
+    assert_config(proxy_config, &datacenter);
 });
 
 trace_test!(filter_update, {
@@ -322,7 +320,7 @@ trace_test!(filter_update, {
         tracing::info!(len = token.len(), "sending bad packet");
         // send an invalid packet
         msg.truncate(5);
-        msg.extend((0..token.len()).into_iter().map(|_| b'b'));
+        msg.extend((0..token.len()).map(|_| b'b'));
         client.send_to(&msg, &proxy_address).await.unwrap();
 
         sandbox.expect_timeout(50, server_rx.recv()).await;

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -47,6 +47,8 @@ pub struct Proxy {
     #[clap(short, long, env = "QUILKIN_DEST")]
     pub to: Vec<SocketAddr>,
     /// Assigns dynamic tokens to each address in the `--to` argument
+    ///
+    /// Format is `<number of unique tokens>:<length of token suffix for each packet>`
     #[clap(short, long, env = "QUILKIN_DEST_TOKENS", requires("to"))]
     pub to_tokens: Option<String>,
     /// The interval in seconds at which the relay will send a discovery request

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -46,6 +46,9 @@ pub struct Proxy {
     /// One or more socket addresses to forward packets to.
     #[clap(short, long, env = "QUILKIN_DEST")]
     pub to: Vec<SocketAddr>,
+    /// Assigns dynamic tokens to each address in the `--to` argument
+    #[clap(short, long, env = "QUILKIN_DEST_TOKENS", requires("to"))]
+    pub to_tokens: Option<String>,
     /// The interval in seconds at which the relay will send a discovery request
     /// to an management server after receiving no updates.
     #[clap(long, env = "QUILKIN_IDLE_REQUEST_INTERVAL_SECS")]
@@ -64,6 +67,7 @@ impl Default for Proxy {
             port: PORT,
             qcmp_port: QCMP_PORT,
             to: <_>::default(),
+            to_tokens: None,
             idle_request_interval_secs: None,
             workers: None,
         }
@@ -97,10 +101,25 @@ impl Proxy {
         let qcmp = crate::net::raw_socket_with_reuse(self.qcmp_port)?;
         let phoenix = crate::net::TcpListener::bind(Some(self.qcmp_port))?;
 
+        let to_tokens = self
+            .to_tokens
+            .map(|tt| {
+                let Some((count, length)) = tt.split_once(':') else {
+                    eyre::bail!("--to-tokens `{tt}` is invalid, it must have a `:` separator")
+                };
+
+                let count = count.parse()?;
+                let length = length.parse()?;
+
+                Ok(crate::components::proxy::ToTokens { count, length })
+            })
+            .transpose()?;
+
         crate::components::proxy::Proxy {
             management_servers: self.management_server,
             mmdb: self.mmdb,
             to: self.to,
+            to_tokens,
             num_workers,
             socket,
             qcmp,

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -4,7 +4,7 @@ mod sessions;
 
 use super::RunArgs;
 use crate::pool::PoolBuffer;
-pub use error::PipelineError;
+pub use error::{ErrorMap, PipelineError};
 pub use sessions::SessionPool;
 use std::{
     net::SocketAddr,
@@ -155,7 +155,7 @@ impl Proxy {
                         }
 
                         crate::net::endpoint::Endpoint::with_metadata(
-                            sa.clone().into(),
+                            (*sa).into(),
                             crate::net::endpoint::Metadata { tokens },
                         )
                     })

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -1,8 +1,10 @@
+mod error;
 pub mod packet_router;
 mod sessions;
 
 use super::RunArgs;
 use crate::pool::PoolBuffer;
+pub use error::PipelineError;
 pub use sessions::SessionPool;
 use std::{
     net::SocketAddr,
@@ -11,23 +13,6 @@ use std::{
         Arc,
     },
 };
-
-#[derive(thiserror::Error, Debug, strum_macros::EnumDiscriminants)]
-#[strum_discriminants(derive(strum_macros::Display))]
-pub enum PipelineError {
-    #[error("No upstream endpoints available")]
-    NoUpstreamEndpoints,
-    #[error("filter {0}")]
-    Filter(#[from] crate::filters::FilterError),
-    #[error("session error: {0}")]
-    Session(#[from] eyre::Error),
-    #[error("OS level error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("Channel closed")]
-    ChannelClosed,
-    #[error("Under pressure")]
-    ChannelFull,
-}
 
 #[derive(Clone, Debug)]
 pub struct Ready {

--- a/src/components/proxy/error.rs
+++ b/src/components/proxy/error.rs
@@ -1,0 +1,176 @@
+use std::{fmt, hash::Hash};
+
+#[derive(Debug)]
+pub enum PipelineError {
+    NoUpstreamEndpoints,
+    Filter(crate::filters::FilterError),
+    Session(super::sessions::SessionError),
+    Io(std::io::Error),
+    ChannelClosed,
+    ChannelFull,
+    /// This occurs if a receive task has accumulated so many errors that the
+    /// error details had to be dropped in order to reduce memory pressure
+    AccumulatorOverflow,
+}
+
+impl PipelineError {
+    pub fn discriminant(&self) -> &'static str {
+        match self {
+            Self::NoUpstreamEndpoints => "no upstream endpoints",
+            Self::Filter(fe) => fe.discriminant(),
+            Self::Session(_) => "session",
+            Self::Io(_) => "io",
+            Self::ChannelClosed => "channel closed",
+            Self::ChannelFull => "channel full",
+            Self::AccumulatorOverflow => "error accumulator overflow",
+        }
+    }
+}
+
+impl std::error::Error for PipelineError {}
+
+impl fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoUpstreamEndpoints => f.write_str("No upstream endpoints available"),
+            Self::Filter(fe) => write!(f, "filter {fe}"),
+            Self::Session(session) => write!(f, "session error: {session}"),
+            Self::Io(io) => write!(f, "OS level error: {io}"),
+            Self::ChannelClosed => f.write_str("channel closed"),
+            Self::ChannelFull => f.write_str("channel full"),
+            Self::AccumulatorOverflow => f.write_str("error accumulator overflow"),
+        }
+    }
+}
+
+impl From<std::io::Error> for PipelineError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl From<super::sessions::SessionError> for PipelineError {
+    fn from(value: super::sessions::SessionError) -> Self {
+        Self::Session(value)
+    }
+}
+
+impl PartialEq for PipelineError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::NoUpstreamEndpoints, Self::NoUpstreamEndpoints) => true,
+            (Self::Filter(fa), Self::Filter(fb)) => fa.eq(fb),
+            (Self::Session(sa), Self::Session(sb)) => sa.eq(sb),
+            (Self::Io(ia), Self::Io(ib)) => ia.kind().eq(&ib.kind()),
+            (Self::ChannelClosed, Self::ChannelClosed) => true,
+            (Self::ChannelFull, Self::ChannelFull) => true,
+            (Self::AccumulatorOverflow, Self::AccumulatorOverflow) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for PipelineError {}
+
+impl Hash for PipelineError {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let disc = std::mem::discriminant(self);
+        Hash::hash(&disc, state);
+
+        match self {
+            Self::Filter(fe) => Hash::hash(&fe, state),
+            Self::Session(se) => Hash::hash(&se, state),
+            Self::Io(io) => Hash::hash(&io.kind(), state),
+            Self::NoUpstreamEndpoints
+            | Self::ChannelClosed
+            | Self::ChannelFull
+            | Self::AccumulatorOverflow => {}
+        }
+    }
+}
+
+pub struct SeahashBuilder;
+
+impl std::hash::BuildHasher for SeahashBuilder {
+    type Hasher = seahash::SeaHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        seahash::SeaHasher::new()
+    }
+}
+
+pub type ErrorMap = std::collections::HashMap<PipelineError, u64, SeahashBuilder>;
+
+pub type ErrorSender = tokio::sync::mpsc::Sender<ErrorMap>;
+//pub type ErrorReceiver = tokio::sync::mpsc::Receiver<ErrorMap>;
+
+/// The soft cap of errors after which we try to send them to the collation task
+const CAP_ERRORS: usize = 10 * 1024;
+/// The maximum errors that can be accumulated before being dropped and lost
+const MAX_ERRORS: usize = 100 * 1024;
+const MAX_ELAPSED: std::time::Duration = std::time::Duration::from_secs(5);
+
+use std::time::Instant;
+
+/// Accumulates errors on downstream receiver tasks before sending them for collation
+///
+/// If many errors occur and
+pub struct ErrorAccumulator {
+    map: ErrorMap,
+    tx: ErrorSender,
+    oldest: Instant,
+}
+
+impl ErrorAccumulator {
+    pub fn new(tx: ErrorSender) -> Self {
+        Self {
+            map: ErrorMap::with_hasher(SeahashBuilder),
+            tx,
+            oldest: Instant::now(),
+        }
+    }
+
+    pub fn maybe_send(&mut self) -> bool {
+        if self.map.is_empty() || self.oldest.elapsed() < MAX_ELAPSED {
+            return false;
+        }
+
+        self.do_send()
+    }
+
+    fn do_send(&mut self) -> bool {
+        let Ok(permit) = self.tx.try_reserve() else {
+            return false;
+        };
+
+        let map = std::mem::replace(&mut self.map, ErrorMap::with_hasher(SeahashBuilder));
+        permit.send(map);
+        true
+    }
+
+    pub fn push_error(&mut self, error: PipelineError) {
+        if self.map.is_empty() {
+            self.oldest = Instant::now();
+        }
+
+        *self.map.entry(error).or_default() += 1;
+
+        if self.map.len() >= CAP_ERRORS {
+            if self.do_send() {
+                return;
+            }
+
+            // If we failed to send and we've reach our max capacity, reset and
+            // note the fact that we did so
+            if self.map.len() >= MAX_ERRORS {
+                self.map.clear();
+                self.map.insert(PipelineError::AccumulatorOverflow, 1);
+                self.oldest = Instant::now();
+            }
+        }
+
+        if self.oldest.elapsed() >= MAX_ELAPSED {
+            self.do_send();
+        }
+    }
+}

--- a/src/components/proxy/error.rs
+++ b/src/components/proxy/error.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 use std::{fmt, hash::Hash};
 
 #[derive(Debug)]

--- a/src/components/proxy/error.rs
+++ b/src/components/proxy/error.rs
@@ -143,6 +143,7 @@ impl ErrorAccumulator {
             return false;
         };
 
+        #[allow(clippy::mutable_key_type)]
         let map = std::mem::replace(&mut self.map, ErrorMap::with_hasher(SeahashBuilder));
         permit.send(map);
         true

--- a/src/components/proxy/packet_router.rs
+++ b/src/components/proxy/packet_router.rs
@@ -282,8 +282,10 @@ pub async fn spawn_receivers(
     tokio::spawn(async move {
         let mut log_task = tokio::time::interval(std::time::Duration::from_secs(5));
 
+        #[allow(clippy::mutable_key_type)]
         let mut pipeline_errors = super::error::ErrorMap::with_hasher(super::error::SeahashBuilder);
 
+        #[allow(clippy::mutable_key_type)]
         fn report(errors: &mut super::error::ErrorMap) {
             for (error, instances) in errors.drain() {
                 tracing::warn!(%error, %instances, "pipeline report");

--- a/src/components/proxy/packet_router.rs
+++ b/src/components/proxy/packet_router.rs
@@ -1,6 +1,6 @@
 use super::{
     sessions::{DownstreamReceiver, SessionKey},
-    PipelineError, PipelineErrorDiscriminants, SessionPool,
+    PipelineError, SessionPool,
 };
 use crate::{
     filters::{Filter as _, ReadContext},
@@ -30,7 +30,7 @@ pub struct DownstreamReceiveWorkerConfig {
     pub port: u16,
     pub config: Arc<Config>,
     pub sessions: Arc<SessionPool>,
-    pub error_sender: mpsc::UnboundedSender<PipelineError>,
+    pub error_sender: super::error::ErrorSender,
     pub buffer_pool: Arc<crate::pool::BufferPool>,
 }
 
@@ -118,6 +118,8 @@ impl DownstreamReceiveWorkerConfig {
                 }
             }
 
+            let mut error_acc = super::error::ErrorAccumulator::new(error_sender);
+
             loop {
                 // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
                 // packet, which is the maximum value of 16 a bit integer.
@@ -146,7 +148,7 @@ impl DownstreamReceiveWorkerConfig {
                             worker_id,
                             &config,
                             &sessions,
-                            &error_sender,
+                            &mut error_acc,
                         )
                         .await;
                     }
@@ -170,7 +172,7 @@ impl DownstreamReceiveWorkerConfig {
         worker_id: usize,
         config: &Arc<Config>,
         sessions: &Arc<SessionPool>,
-        error_sender: &mpsc::UnboundedSender<PipelineError>,
+        error_acc: &mut super::error::ErrorAccumulator,
     ) {
         tracing::trace!(
             id = worker_id,
@@ -181,12 +183,15 @@ impl DownstreamReceiveWorkerConfig {
 
         let timer = metrics::processing_time(metrics::READ).start_timer();
         match Self::process_downstream_received_packet(packet, config, sessions).await {
-            Ok(()) => {}
+            Ok(()) => {
+                error_acc.maybe_send();
+            }
             Err(error) => {
-                let discriminant = PipelineErrorDiscriminants::from(&error).to_string();
-                metrics::errors_total(metrics::READ, &discriminant, &metrics::EMPTY).inc();
-                metrics::packets_dropped_total(metrics::READ, &discriminant, &metrics::EMPTY).inc();
-                let _ = error_sender.send(error);
+                let discriminant = error.discriminant();
+                metrics::errors_total(metrics::READ, discriminant, &metrics::EMPTY).inc();
+                metrics::packets_dropped_total(metrics::READ, discriminant, &metrics::EMPTY).inc();
+
+                error_acc.push_error(error);
             }
         }
 
@@ -211,7 +216,10 @@ impl DownstreamReceiveWorkerConfig {
             packet.source.into(),
             packet.contents,
         );
-        filters.read(&mut context).await?;
+        filters
+            .read(&mut context)
+            .await
+            .map_err(PipelineError::Filter)?;
 
         let ReadContext {
             destinations,
@@ -250,7 +258,7 @@ pub async fn spawn_receivers(
     upstream_receiver: DownstreamReceiver,
     buffer_pool: Arc<crate::pool::BufferPool>,
 ) -> crate::Result<Vec<Arc<tokio::sync::Notify>>> {
-    let (error_sender, mut error_receiver) = mpsc::unbounded_channel();
+    let (error_sender, mut error_receiver) = mpsc::channel(128);
 
     let port = crate::net::socket_port(&socket);
 
@@ -269,26 +277,34 @@ pub async fn spawn_receivers(
         worker_notifications.push(worker.spawn().await?);
     }
 
+    drop(error_sender);
+
     tokio::spawn(async move {
         let mut log_task = tokio::time::interval(std::time::Duration::from_secs(5));
 
-        let mut pipeline_errors = std::collections::HashMap::<String, u64>::new();
+        let mut pipeline_errors = super::error::ErrorMap::with_hasher(super::error::SeahashBuilder);
+
+        fn report(errors: &mut super::error::ErrorMap) {
+            for (error, instances) in errors.drain() {
+                tracing::warn!(%error, %instances, "pipeline report");
+            }
+        }
+
         loop {
             tokio::select! {
                 _ = log_task.tick() => {
-                    for (error, instances) in &pipeline_errors {
-                        tracing::warn!(%error, %instances, "pipeline report");
-                    }
-                    pipeline_errors.clear();
+                    report(&mut pipeline_errors);
                 }
                 received = error_receiver.recv() => {
-                    let Some(error) = received else {
+                    let Some(errors) = received else {
+                        report(&mut pipeline_errors);
                         tracing::info!("pipeline reporting task closed");
                         return;
                     };
 
-                    let entry = pipeline_errors.entry(error.to_string()).or_default();
-                    *entry += 1;
+                    for (k, v) in errors {
+                        *pipeline_errors.entry(k).or_default() += v;
+                    }
                 }
             }
         }

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -72,7 +72,7 @@ impl Filter for Capture {
             Ok(())
         } else {
             tracing::trace!(key = %self.metadata_key, "No value captured");
-            Err(FilterError::new(NoValueCaptured))
+            Err(FilterError::NoValueCaptured)
         }
     }
 }
@@ -86,10 +86,6 @@ impl StaticFilter for Capture {
         Ok(Capture::new(Self::ensure_config_exists(config)?))
     }
 }
-
-#[derive(thiserror::Error, Debug)]
-#[error("no value captured")]
-struct NoValueCaptured;
 
 #[cfg(test)]
 mod tests {

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -170,11 +170,10 @@ pub enum Direction {
 
 impl PartialEq for Direction {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Read, Self::Read) => true,
-            (Self::Write, Self::Write) => true,
-            _ => false,
-        }
+        matches!(
+            (self, other),
+            (Self::Read, Self::Read) | (Self::Write, Self::Write)
+        )
     }
 }
 

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -34,12 +34,12 @@ impl Drop {
 impl Filter for Drop {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
-        Err(FilterError::new("intentionally dropped"))
+        Err(FilterError::Dropped)
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
-        Err(FilterError::new("intentionally dropped"))
+        Err(FilterError::Dropped)
     }
 }
 

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -65,7 +65,7 @@ impl Filter for Firewall {
                     }
                     Action::Deny => {
                         debug!(action = "Deny", event = "read", source = ?ctx.source);
-                        Err(FilterError::new(PacketDenied))
+                        Err(FilterError::FirewallDenied)
                     }
                 };
             }
@@ -75,7 +75,7 @@ impl Filter for Firewall {
             event = "read",
             source = ?ctx.source.to_string()
         );
-        Err(FilterError::new(PacketDenied))
+        Err(FilterError::FirewallDenied)
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
@@ -93,7 +93,7 @@ impl Filter for Firewall {
                     }
                     Action::Deny => {
                         debug!(action = "Deny", event = "write", source = ?ctx.source);
-                        Err(FilterError::new(PacketDenied))
+                        Err(FilterError::FirewallDenied)
                     }
                 };
             }
@@ -104,13 +104,9 @@ impl Filter for Firewall {
             event = "write",
             source = ?ctx.source.to_string()
         );
-        Err(FilterError::new(PacketDenied))
+        Err(FilterError::FirewallDenied)
     }
 }
-
-#[derive(thiserror::Error, Debug)]
-#[error("packet denied")]
-pub struct PacketDenied;
 
 #[cfg(test)]
 mod tests {

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -96,9 +96,8 @@ where
 {
     match config {
         Some(config) => {
-            let value = (get_metadata)(ctx, &config.metadata_key).ok_or_else(|| {
-                FilterError::new(format!("no metadata found for {}", config.metadata_key))
-            })?;
+            let value =
+                (get_metadata)(ctx, &config.metadata_key).ok_or(FilterError::MatchNoMetadata)?;
 
             match config.branches.iter().find(|(key, _)| key == value) {
                 Some((value, instance)) => {

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -76,11 +76,11 @@ mod tests {
     #[async_trait::async_trait]
     impl Filter for TestFilter {
         async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
-            Err(FilterError::new("test error"))
+            Err(FilterError::Custom("test error"))
         }
 
         async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
-            Err(FilterError::new("test error"))
+            Err(FilterError::Custom("test error"))
         }
     }
 

--- a/src/net.rs
+++ b/src/net.rs
@@ -17,7 +17,7 @@
 /// On linux spawns a io-uring runtime + thread, everywhere else spawns a regular tokio task.
 macro_rules! uring_spawn {
     ($span:expr, $future:expr) => {{
-        let (tx, rx) = tokio::sync::oneshot::channel::<crate::Result<()>>();
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), std::io::Error>>();
         use tracing::Instrument as _;
 
         cfg_if::cfg_if! {
@@ -37,7 +37,7 @@ macro_rules! uring_spawn {
                             }
                         }
                         Err(error) => {
-                            let _ = tx.send(Err(error.into()));
+                            let _ = tx.send(Err(error));
                         }
                     };
                 }).expect("failed to spawn io-uring thread");

--- a/src/test.rs
+++ b/src/test.rs
@@ -305,6 +305,7 @@ impl TestHelper {
                 mmdb: None,
                 management_servers: Vec::new(),
                 to: Vec::new(),
+                to_tokens: None,
                 socket: crate::net::raw_socket_with_reuse(0).unwrap(),
                 qcmp,
                 phoenix,


### PR DESCRIPTION
This is a rework of #986

This resolves an unbounded memory growth issue that can occur in a particularly hostile context, ie, every packet is invalid in some way, generating an error, and CPU usage is high enough that tasks, notably

https://github.com/googleforgames/quilkin/blob/50d91e4167f9160c5be36178e47789fb7844dfc1/src/components/proxy/packet_router.rs#L272-L295

do not consistently receive CPU time. In this context, where every received packet generates an error, which is then sent to an unbounded channel before being dequeued, the dequeue task might not run quickly enough to dequeue each error, causing both the memory allocated by the error, as well as by the queue, grow quickly enough that the process can be OOM killed.

This PR changes it so that instead of each error being sent to an unbounded channel, the errors are instead accumulated by the receive tasks themselves, and those accumulations being sent to the print task once they reach a cap, or a certain amount of time since the first error was pushed has elapsed to a **bounded** channel. If the bounded channel is full and too many errors are accumulated on a particular receive task, we drop the errors and note that it happened, rather than risk consuming too much heap memory.

Previously:

![image](https://github.com/googleforgames/quilkin/assets/2316028/75526435-29d9-426b-9ed2-1544491f9776)

This PR:

![image](https://github.com/googleforgames/quilkin/assets/2316028/c6bb1e48-1ed7-4cc9-a7a6-5f03638df5a0)

While investigating I ran into a bug with xDS filterchain where the server will send empty delta updates, so now the server doesn't send updates if the resource(s) haven't changed.

Also added 2 ways to generate unique tokens, one where _n_ tokens of length _l_ are generated and written to ./quilkin-test-config.yaml that can be used with `-c`, and the other is with a new `--to-tokens` arg on proxy that can do the same, assigning unique tokens of a specific length to each address in `--to`.

Resolves: #983 