### PR TITLE
Reduce ASN related allocations

### DIFF
--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -2,7 +2,7 @@ pub mod packet_router;
 mod sessions;
 
 use super::RunArgs;
-use crate::{net::maxmind_db::IpNetEntry, pool::PoolBuffer};
+use crate::pool::PoolBuffer;
 pub use sessions::SessionPool;
 use std::{
     net::SocketAddr,
@@ -129,8 +129,11 @@ impl Proxy {
         let id = config.id.load();
         let num_workers = self.num_workers.get();
 
-        let (upstream_sender, upstream_receiver) =
-            async_channel::bounded::<(PoolBuffer, Option<IpNetEntry>, SocketAddr)>(250);
+        let (upstream_sender, upstream_receiver) = async_channel::bounded::<(
+            PoolBuffer,
+            Option<crate::net::maxmind_db::MetricsIpNetEntry>,
+            SocketAddr,
+        )>(250);
         let buffer_pool = Arc::new(crate::pool::BufferPool::new(num_workers, 64 * 1024));
         let sessions = SessionPool::new(
             config.clone(),

--- a/src/net/maxmind_db.rs
+++ b/src/net/maxmind_db.rs
@@ -139,46 +139,35 @@ impl std::ops::DerefMut for MaxmindDb {
     }
 }
 
-#[derive(Clone, Debug, serde::Deserialize)]
+#[derive(Clone, serde::Deserialize)]
 pub struct IpNetEntry {
-    #[serde(default)]
-    pub allocation: String,
-    #[serde(default)]
-    pub allocation_cc: String,
-    #[serde(default)]
-    pub allocation_registry: String,
-    #[serde(default)]
-    pub allocation_status: String,
-    #[serde(default)]
-    pub r#as: u64,
+    #[serde(default, rename = "as")]
+    pub id: u64,
     #[serde(default)]
     pub as_cc: String,
     #[serde(default)]
-    pub as_entity: String,
-    #[serde(default)]
     pub as_name: String,
-    #[serde(default)]
-    pub as_private: bool,
-    #[serde(default)]
-    pub as_registry: String,
-    #[serde(default)]
-    pub prefix: String,
-    #[serde(default)]
-    pub prefix_asset: Vec<String>,
-    #[serde(default)]
-    pub prefix_assignment: String,
-    #[serde(default)]
-    pub prefix_bogon: bool,
     #[serde(default)]
     pub prefix_entity: String,
     #[serde(default)]
     pub prefix_name: String,
     #[serde(default)]
-    pub prefix_origins: Vec<u64>,
-    #[serde(default)]
-    pub prefix_registry: String,
-    #[serde(default)]
-    pub rpki_status: String,
+    pub prefix: String,
+}
+
+#[derive(Clone)]
+pub struct MetricsIpNetEntry {
+    pub prefix: String,
+    pub id: u64,
+}
+
+impl<'a> From<&'a IpNetEntry> for MetricsIpNetEntry {
+    fn from(value: &'a IpNetEntry) -> Self {
+        Self {
+            prefix: value.prefix.clone(),
+            id: value.id,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
I noticed this while doing a different change so split this out since it was unrelated but didn't want to forget it.

Basically, the `IpNetEntry` has been drastically slimmed down to only deserialize/allocate the fields that are actually used, and additionally added a `MetricsIpNetEntry` which is even further slimmed down to the only 2 fields that are used in _all_ of the metrics _except_ for the session counter. Additionally we use metrics::AsnInfo to just have a stack buffer with the stringized ASN which avoids several heap allocations in places where packets are sent/received and emit multiple metrics.

This should get rid of several m/billion allocations over the lifecycle of a proxy