### PR TITLE
Remove short args for --to and --to_tokens because they conflict

### DIFF
--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -44,12 +44,12 @@ pub struct Proxy {
     #[clap(short, long, env = "QUILKIN_QCMP_PORT", default_value_t = QCMP_PORT)]
     pub qcmp_port: u16,
     /// One or more socket addresses to forward packets to.
-    #[clap(short, long, env = "QUILKIN_DEST")]
+    #[clap(long, env = "QUILKIN_DEST")]
     pub to: Vec<SocketAddr>,
     /// Assigns dynamic tokens to each address in the `--to` argument
     ///
     /// Format is `<number of unique tokens>:<length of token suffix for each packet>`
-    #[clap(short, long, env = "QUILKIN_DEST_TOKENS", requires("to"))]
+    #[clap(long, env = "QUILKIN_DEST_TOKENS", requires("to"))]
     pub to_tokens: Option<String>,
     /// The interval in seconds at which the relay will send a discovery request
     /// to an management server after receiving no updates.


### PR DESCRIPTION
If you use either you currently get this error at runtime.

```
thread 'main' panicked at /home/ep/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.13/src/builder/debug_asserts.rs:112:17:
Command proxy: Short option names must be unique for each argument, but '-t' is in use by both 'to' and 'to_tokens'
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```