### PR TITLE
Support interop between v8 and v9+

### DIFF
--- a/crates/xds/src/config.rs
+++ b/crates/xds/src/config.rs
@@ -195,7 +195,10 @@ pub trait Configuration: Send + Sync + Sized + 'static {
         subscribed: crate::server::ControlPlane<Self>,
     ) -> impl std::future::Future<Output = ()> + Send + 'static;
 
-    fn interested_resources(&self) -> impl Iterator<Item = (&'static str, Vec<String>)>;
+    fn interested_resources(
+        &self,
+        server_version: &str,
+    ) -> impl Iterator<Item = (&'static str, Vec<String>)>;
 }
 
 pub struct DeltaDiscoveryRes {

--- a/crates/xds/src/server.rs
+++ b/crates/xds/src/server.rs
@@ -34,6 +34,8 @@ use crate::{
     net::TcpListener,
 };
 
+const VERSION_INFO: &str = "9";
+
 pub struct ControlPlane<C> {
     pub config: Arc<C>,
     pub idle_request_interval: Duration,
@@ -218,8 +220,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                         control_plane: Some(control_plane_id.clone()),
                         type_url: type_url.into(),
                         removed_resources,
-                        // Only used for debugging, not really useful
-                        system_version_info: String::new(),
+                        system_version_info: VERSION_INFO.into(),
                     };
 
                     tracing::trace!(
@@ -248,8 +249,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                     control_plane: None,
                     type_url: message.type_url,
                     removed_resources: Vec::new(),
-                    // Only used for debugging, not really useful
-                    system_version_info: String::new(),
+                    system_version_info: VERSION_INFO.into(),
                 }
             } else {
                 tracing::debug!(client = %node_id, resource_type = %message.type_url, "initial delta response");
@@ -406,17 +406,25 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
 
         tracing::info!("control plane discovery delta stream attempt");
         let mut responses = responses.into_inner();
-        let Some(identifier) = responses
+
+        fn handle_first_response(
+            res: DeltaDiscoveryResponse,
+        ) -> Result<(String, String), tonic::Status> {
+            let Some(identifier) = res.control_plane.map(|cp| cp.identifier) else {
+                return Err(tonic::Status::invalid_argument(
+                    "DeltaDiscoveryResponse.control_plane.identifier is required in the first message",
+                ));
+            };
+
+            Ok((identifier, res.system_version_info))
+        }
+
+        let first_response = responses
             .next()
             .await
-            .ok_or_else(|| tonic::Status::cancelled("received empty first response"))??
-            .control_plane
-            .map(|cp| cp.identifier)
-        else {
-            return Err(tonic::Status::invalid_argument(
-                "DeltaDiscoveryResponse.control_plane.identifier is required in the first message",
-            ));
-        };
+            .ok_or_else(|| tonic::Status::cancelled("received empty first response"))??;
+
+        let (identifier, server_version) = handle_first_response(first_response)?;
 
         tracing::info!(identifier, "new control plane delta discovery stream");
         let config = self.config.clone();
@@ -429,12 +437,16 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
                 tracing::info!(identifier, "sending initial delta discovery request");
 
                 let local = Arc::new(crate::config::LocalVersions::new(
-                    config.interested_resources().map(|(n, _)| n),
+                    config.interested_resources(&server_version).map(|(n, _)| n),
                 ));
 
-                ds.refresh(&identifier, config.interested_resources().collect(), &local)
-                    .await
-                    .map_err(|error| tonic::Status::internal(error.to_string()))?;
+                ds.refresh(
+                    &identifier,
+                    config.interested_resources(&server_version).collect(),
+                    &local,
+                )
+                .await
+                .map_err(|error| tonic::Status::internal(error.to_string()))?;
 
                 let mut response_stream = crate::config::handle_delta_discovery_responses(
                     identifier.clone(),
@@ -456,9 +468,13 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
                             .map_err(|_| tonic::Status::internal("this should not be reachable"))?;
                     } else {
                         tracing::trace!("exceeded idle interval, sending request");
-                        ds.refresh(&identifier, config.interested_resources().collect(), &local)
-                            .await
-                            .map_err(|error| tonic::Status::internal(error.to_string()))?;
+                        ds.refresh(
+                            &identifier,
+                            config.interested_resources(&server_version).collect(),
+                            &local,
+                        )
+                        .await
+                        .map_err(|error| tonic::Status::internal(error.to_string()))?;
                     }
                 }
             }

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -220,6 +220,25 @@ impl Proxy {
             shutdown_rx.clone(),
         );
 
+        const SUBS: &[(&str, &[(&str, Vec<String>)])] = &[
+            (
+                "9",
+                &[
+                    (crate::xds::CLUSTER_TYPE, Vec::new()),
+                    (crate::xds::DATACENTER_TYPE, Vec::new()),
+                    (crate::xds::FILTER_CHAIN_TYPE, Vec::new()),
+                ],
+            ),
+            (
+                "",
+                &[
+                    (crate::xds::CLUSTER_TYPE, Vec::new()),
+                    (crate::xds::DATACENTER_TYPE, Vec::new()),
+                    (crate::xds::LISTENER_TYPE, Vec::new()),
+                ],
+            ),
+        ];
+
         if !self.management_servers.is_empty() {
             {
                 let mut lock = ready.xds_is_healthy.write();
@@ -259,16 +278,7 @@ impl Proxy {
                                 ready.xds_is_healthy.read().as_ref().unwrap().clone();
 
                             let _stream = client
-                                .delta_subscribe(
-                                    config.clone(),
-                                    xds_is_healthy.clone(),
-                                    tx,
-                                    [
-                                        (crate::xds::CLUSTER_TYPE, Vec::new()),
-                                        (crate::xds::DATACENTER_TYPE, Vec::new()),
-                                        (crate::xds::FILTER_CHAIN_TYPE, Vec::new()),
-                                    ],
-                                )
+                                .delta_subscribe(config.clone(), xds_is_healthy.clone(), tx, SUBS)
                                 .await
                                 .map_err(|_| eyre::eyre!("failed to acquire delta stream"))?;
 

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -21,19 +21,25 @@ use prost_types::Any;
 pub const CLUSTER_TYPE: &str = "type.googleapis.com/quilkin.config.v1alpha1.Cluster";
 pub const DATACENTER_TYPE: &str = "type.googleapis.com/quilkin.config.v1alpha1.Datacenter";
 pub const FILTER_CHAIN_TYPE: &str = "type.googleapis.com/quilkin.config.v1alpha1.FilterChain";
+pub const LISTENER_TYPE: &str = "type.googleapis.com/envoy.config.listener.v3.Listener";
 const PREFIX: &str = "type.googleapis.com/quilkin.config.v1alpha1.";
 
 pub enum Resource {
     Cluster(proto::Cluster),
     Datacenter(proto::Datacenter),
     FilterChain(proto::FilterChain),
+    Listener(proto::FilterChain),
 }
 
 impl Resource {
     #[inline]
     pub fn try_decode(any: Any) -> Result<Self, eyre::Error> {
         let Some(suffix) = any.type_url.strip_prefix(PREFIX) else {
-            eyre::bail!("unknown resource type '{}'", any.type_url);
+            if any.type_url == LISTENER_TYPE {
+                return Self::decode_listener(&any.value);
+            } else {
+                eyre::bail!("unknown resource type '{}'", any.type_url);
+            }
         };
 
         Ok(match suffix {
@@ -42,6 +48,52 @@ impl Resource {
             "FilterChain" => Self::FilterChain(proto::FilterChain::decode(&*any.value)?),
             _ => eyre::bail!("unknown resource type '{}'", any.type_url),
         })
+    }
+
+    #[inline]
+    fn decode_listener(buf: &[u8]) -> eyre::Result<Self> {
+        use eyre::Context as _;
+
+        let mut listener =
+            quilkin_xds::generated::envoy::config::listener::v3::Listener::decode(buf)?;
+        eyre::ensure!(
+            !listener.filter_chains.is_empty(),
+            "{LISTENER_TYPE} resource had no filter chains"
+        );
+        eyre::ensure!(
+            listener.filter_chains.len() == 1,
+            "{LISTENER_TYPE} resource had more than one filter chain"
+        );
+        let filter_chain = listener.filter_chains.swap_remove(0);
+
+        let filters = filter_chain
+            .filters
+            .into_iter()
+            .map(|filter| {
+                use quilkin_xds::generated::envoy::config::listener::v3::filter::ConfigType;
+
+                let config = if let Some(config_type) = filter.config_type {
+                    let config = match config_type {
+                        ConfigType::TypedConfig(any) => any,
+                        ConfigType::ConfigDiscovery(_) => {
+                            eyre::bail!("ConfigDiscovery is not supported")
+                        }
+                    };
+
+                    Some(String::from_utf8(config.value).context("filter config was non-utf8")?)
+                } else {
+                    None
+                };
+
+                Ok(proto::Filter {
+                    name: filter.name,
+                    label: None,
+                    config,
+                })
+            })
+            .collect::<eyre::Result<Vec<_>>>()?;
+
+        Ok(Self::Listener(proto::FilterChain { filters }))
     }
 
     #[inline]
@@ -62,6 +114,31 @@ impl Resource {
                 f.encode(&mut value)?;
                 (value, FILTER_CHAIN_TYPE)
             }
+            Self::Listener(f) => {
+                let l = quilkin_xds::generated::envoy::config::listener::v3::Listener {
+                    filter_chains: vec![quilkin_xds::generated::envoy::config::listener::v3::FilterChain {
+                        filters: f.filters.iter().map(|f| {
+                            quilkin_xds::generated::envoy::config::listener::v3::Filter {
+                                name: f.name.clone(),
+                                config_type: if let Some(cfg) = &f.config {
+                                    let cfg = prost_types::Any {
+                                        type_url: f.name.clone(),
+                                        value: cfg.clone().into(),
+                                    };
+                                    Some(quilkin_xds::generated::envoy::config::listener::v3::filter::ConfigType::TypedConfig(cfg))
+                                } else {
+                                    None
+                                },
+                            }
+                        }).collect(),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                };
+                let mut value = Vec::with_capacity(l.encoded_len());
+                l.encode(&mut value)?;
+                (value, LISTENER_TYPE)
+            }
         };
 
         Ok(Any {
@@ -76,6 +153,7 @@ impl Resource {
             Self::Cluster(_) => CLUSTER_TYPE,
             Self::Datacenter(_) => DATACENTER_TYPE,
             Self::FilterChain(_) => FILTER_CHAIN_TYPE,
+            Self::Listener(_) => LISTENER_TYPE,
         }
     }
 }
@@ -85,13 +163,18 @@ pub enum ResourceType {
     Cluster,
     Datacenter,
     FilterChain,
+    Listener,
 }
 
 impl std::str::FromStr for ResourceType {
     type Err = eyre::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let Some(suffix) = s.strip_prefix(PREFIX) else {
-            eyre::bail!("unknown resource type '{s}'");
+            if s == LISTENER_TYPE {
+                return Ok(Self::Listener);
+            } else {
+                eyre::bail!("unknown resource type '{s}'");
+            }
         };
 
         Ok(match suffix {


### PR DESCRIPTION
This enables v8 proxies and relays communicate with v9+ proxies and relays. I'm not sure why the version of quilkin gets bumped to a -dev version each release, as it means we can't just do a point release of this for 0.9 easily, but I'll leave that to others to figure out.