### PR TITLE
Ignore submit_and_wait failing if it is interrupted

### DIFF
--- a/src/components/proxy/io_uring_shared.rs
+++ b/src/components/proxy/io_uring_shared.rs
@@ -625,6 +625,9 @@ impl IoUringLoop {
                     match submitter.submit_and_wait(1) {
                         Ok(_) => {}
                         Err(ref err) if err.raw_os_error() == Some(libc::EBUSY) => {}
+                        Err(ref err) if err.raw_os_error() == Some(libc::EINTR) => {
+                            continue;
+                        }
                         Err(error) => {
                             tracing::error!(%error, "io-uring submit_and_wait failed");
                             return;


### PR DESCRIPTION
I spent some time trying to repro #1019 but was unable to, in a non-k8s context. AFAICT there is no segfault or the like introduced in the io-uring refactor that would result in a failure, and that it's most likely just the normal pod lifecycle where a `SIGTERM` was sent to shutdown the pod, but it resulted in errors instead of gracefully shutting down. This code just ignores the submit_and_wait syscall failing due to an interrupt, which actually more closely matches what tokio-uring does.

https://github.com/tokio-rs/tokio-uring/blob/7761222aa7f4bd48c559ca82e9535d47aac96d53/src/runtime/driver/mod.rs#L70C58-L71

Resolves: #1019