### PR TITLE
perf: make filters synchronous

### DIFF
--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -134,7 +134,7 @@ trace_test!(uring_receiver, {
     // Drop the socket, otherwise it can
     drop(ws);
 
-    let _ = sb.timeout(500, ready).await;
+    let _ = ready.recv().unwrap();
 
     let msg = "hello-downstream";
     tracing::debug!("sending packet");
@@ -185,7 +185,7 @@ trace_test!(
         .unwrap();
 
         for wn in workers {
-            let _ = sb.timeout(200, wn).await;
+            let _ = wn.recv().unwrap();
         }
 
         let socket = std::sync::Arc::new(sb.client());

--- a/docs/src/services/proxy/filters/writing_custom_filters.md
+++ b/docs/src/services/proxy/filters/writing_custom_filters.md
@@ -41,13 +41,12 @@ sent to a downstream client.
 use quilkin::filters::prelude::*;
 
 /// Appends data to each packet
-#[async_trait::async_trait]
 impl Filter for Greet {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         ctx.contents.extend_from_slice(b"Hello");
         Ok(())
     }
-    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         ctx.contents.extend_from_slice(b"Goodbye");
         Ok(())
     }

--- a/examples/quilkin-filter-example/src/main.rs
+++ b/examples/quilkin-filter-example/src/main.rs
@@ -54,14 +54,13 @@ struct Greet {
     config: Config,
 }
 
-#[async_trait::async_trait]
 impl Filter for Greet {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         ctx.contents
             .prepend_from_slice(format!("{} ", self.config.greeting).as_bytes());
         Ok(())
     }
-    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         ctx.contents
             .prepend_from_slice(format!("{} ", self.config.greeting).as_bytes());
         Ok(())

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -311,7 +311,7 @@ impl Proxy {
         )?;
 
         for notification in worker_notifications {
-            let _ = notification.await;
+            let _ = notification.recv();
         }
 
         tracing::info!("Quilkin is ready");

--- a/src/components/proxy/io_uring_shared.rs
+++ b/src/components/proxy/io_uring_shared.rs
@@ -252,16 +252,18 @@ pub enum PacketProcessorCtx {
     Router {
         config: Arc<crate::config::Config>,
         sessions: Arc<crate::components::proxy::SessionPool>,
-        error_sender: super::error::ErrorSender,
-        /// Receiver for upstream packets being sent to this downstream
-        upstream_receiver: crate::components::proxy::sessions::DownstreamReceiver,
+        error_acc: super::error::ErrorAccumulator,
         worker_id: usize,
     },
     SessionPool {
         pool: Arc<crate::components::proxy::SessionPool>,
-        downstream_receiver: tokio::sync::mpsc::Receiver<proxy::SendPacket>,
         port: u16,
     },
+}
+
+pub enum PacketReceiver {
+    Router(crate::components::proxy::sessions::DownstreamReceiver),
+    SessionPool(tokio::sync::mpsc::Receiver<proxy::SendPacket>),
 }
 
 /// Spawns worker tasks
@@ -271,14 +273,11 @@ pub enum PacketProcessorCtx {
 /// the io-uring loop when there are 1 or more packets available to be sent
 fn spawn_workers(
     rt: &tokio::runtime::Runtime,
-    ctx: PacketProcessorCtx,
+    receiver: PacketReceiver,
     pending_sends: PendingSends,
-    packet_processed_event: EventFdWriter,
     mut shutdown_rx: crate::ShutdownRx,
     shutdown_event: EventFdWriter,
-) -> tokio::sync::mpsc::Sender<RecvPacket> {
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<RecvPacket>(1);
-
+) {
     // Spawn a task that just monitors the shutdown receiver to notify the io-uring loop to exit
     rt.spawn(async move {
         // The result is uninteresting, either a shutdown has been signalled, or all senders have been dropped
@@ -287,44 +286,8 @@ fn spawn_workers(
         shutdown_event.write(1);
     });
 
-    match ctx {
-        PacketProcessorCtx::Router {
-            config,
-            sessions,
-            error_sender,
-            worker_id,
-            upstream_receiver,
-        } => {
-            rt.spawn(async move {
-                let mut last_received_at = None;
-
-                let mut error_acc = super::error::ErrorAccumulator::new(error_sender);
-
-                while let Some(packet) = rx.recv().await {
-                    let received_at = UtcTimestamp::now();
-                    if let Some(last_received_at) = last_received_at {
-                        metrics::packet_jitter(metrics::READ, &metrics::EMPTY)
-                            .set((received_at - last_received_at).nanos());
-                    }
-                    last_received_at = Some(received_at);
-
-                    let ds_packet = proxy::packet_router::DownstreamPacket {
-                        contents: packet.buffer,
-                        source: packet.source,
-                    };
-
-                    crate::components::proxy::packet_router::DownstreamReceiveWorkerConfig::process_task(
-                        ds_packet,
-                        worker_id,
-                        &config,
-                        &sessions,
-                        &mut error_acc,
-                    );
-
-                    packet_processed_event.write(1);
-                }
-            });
-
+    match receiver {
+        PacketReceiver::Router(upstream_receiver) => {
             rt.spawn(async move {
                 while let Ok(packet) = upstream_receiver.recv().await {
                     let packet = SendPacket {
@@ -336,27 +299,7 @@ fn spawn_workers(
                 }
             });
         }
-        PacketProcessorCtx::SessionPool {
-            pool,
-            port,
-            mut downstream_receiver,
-        } => {
-            rt.spawn(async move {
-                let mut last_received_at = None;
-
-                while let Some(packet) = rx.recv().await {
-                    pool.process_received_upstream_packet(
-                        packet.buffer,
-                        packet.source,
-                        port,
-                        &mut last_received_at,
-                    )
-                    .await;
-
-                    packet_processed_event.write(1);
-                }
-            });
-
+        PacketReceiver::SessionPool(mut downstream_receiver) => {
             rt.spawn(async move {
                 while let Some(packet) = downstream_receiver.recv().await {
                     let packet = SendPacket {
@@ -369,8 +312,52 @@ fn spawn_workers(
             });
         }
     }
+}
 
-    tx
+fn process_packet(
+    ctx: &mut PacketProcessorCtx,
+    packet_processed_event: &EventFdWriter,
+    packet: RecvPacket,
+    last_received_at: &mut Option<UtcTimestamp>,
+) {
+    match ctx {
+        PacketProcessorCtx::Router {
+            config,
+            sessions,
+            worker_id,
+            error_acc,
+        } => {
+            let received_at = UtcTimestamp::now();
+            if let Some(last_received_at) = last_received_at {
+                metrics::packet_jitter(metrics::READ, &metrics::EMPTY)
+                    .set((received_at - *last_received_at).nanos());
+            }
+            *last_received_at = Some(received_at);
+
+            let ds_packet = proxy::packet_router::DownstreamPacket {
+                contents: packet.buffer,
+                source: packet.source,
+            };
+
+            crate::components::proxy::packet_router::DownstreamReceiveWorkerConfig::process_task(
+                ds_packet, *worker_id, config, sessions, error_acc,
+            );
+
+            packet_processed_event.write(1);
+        }
+        PacketProcessorCtx::SessionPool { pool, port, .. } => {
+            let mut last_received_at = None;
+
+            pool.process_received_upstream_packet(
+                packet.buffer,
+                packet.source,
+                *port,
+                &mut last_received_at,
+            );
+
+            packet_processed_event.write(1);
+        }
+    }
 }
 
 #[inline]
@@ -542,7 +529,8 @@ impl IoUringLoop {
     pub fn spawn(
         self,
         thread_name: String,
-        ctx: PacketProcessorCtx,
+        mut ctx: PacketProcessorCtx,
+        receiver: PacketReceiver,
         buffer_pool: Arc<crate::pool::BufferPool>,
         shutdown: crate::ShutdownRx,
     ) -> Result<std::sync::mpsc::Receiver<()>, PipelineError> {
@@ -588,11 +576,10 @@ impl IoUringLoop {
 
                 // Spawn the worker tasks that process in an async context unlike
                 // our io-uring loop below
-                let process_packet_tx = spawn_workers(
+                spawn_workers(
                     &rt,
-                    ctx,
+                    receiver,
                     pending_sends.clone(),
-                    process_event.writer(),
                     shutdown,
                     shutdown_event.writer(),
                 );
@@ -618,6 +605,8 @@ impl IoUringLoop {
 
                 // Notify that we have set everything up
                 let _ = tx.send(());
+                let mut last_received_at = None;
+                let process_event_writer = process_event.writer();
 
                 // The core io uring loop
                 'io: loop {
@@ -659,9 +648,12 @@ impl IoUringLoop {
                                 }
 
                                 let packet = packet.finalize_recv(ret as usize);
-                                if process_packet_tx.blocking_send(packet).is_err() {
-                                    unreachable!("packet process thread has a pending packet");
-                                }
+                                process_packet(
+                                    &mut ctx,
+                                    &process_event_writer,
+                                    packet,
+                                    &mut last_received_at,
+                                );
 
                                 // Queue the wait for the processing of the packet to finish
                                 loop_ctx.push_with_token(

--- a/src/components/proxy/io_uring_shared.rs
+++ b/src/components/proxy/io_uring_shared.rs
@@ -370,8 +370,6 @@ enum Token {
     Recv { key: usize },
     /// Packet sent
     Send { key: usize },
-    /// Recv packet processed
-    RecvPacketProcessed,
     /// One or more packets are ready to be sent
     PendingsSends,
     /// Loop shutdown requested
@@ -549,7 +547,7 @@ impl IoUringLoop {
         // Used to notify the uring when a received packet has finished
         // processing and we can perform another recv, as we (currently) only
         // ever process a single packet at a time
-        let mut process_event = EventFd::new()?;
+        let process_event = EventFd::new()?;
         // Used to notify the uring loop to shutdown
         let mut shutdown_event = EventFd::new()?;
 
@@ -655,13 +653,6 @@ impl IoUringLoop {
                                     &mut last_received_at,
                                 );
 
-                                // Queue the wait for the processing of the packet to finish
-                                loop_ctx.push_with_token(
-                                    process_event.io_uring_entry(),
-                                    Token::RecvPacketProcessed,
-                                );
-                            }
-                            Token::RecvPacketProcessed => {
                                 loop_ctx.enqueue_recv(buffer_pool.clone().alloc());
                             }
                             Token::PendingsSends => {

--- a/src/components/proxy/io_uring_shared.rs
+++ b/src/components/proxy/io_uring_shared.rs
@@ -319,8 +319,7 @@ fn spawn_workers(
                         &config,
                         &sessions,
                         &mut error_acc,
-                    )
-                    .await;
+                    );
 
                     packet_processed_event.write(1);
                 }
@@ -546,9 +545,9 @@ impl IoUringLoop {
         ctx: PacketProcessorCtx,
         buffer_pool: Arc<crate::pool::BufferPool>,
         shutdown: crate::ShutdownRx,
-    ) -> Result<tokio::sync::oneshot::Receiver<()>, PipelineError> {
+    ) -> Result<std::sync::mpsc::Receiver<()>, PipelineError> {
         let dispatcher = tracing::dispatcher::get_default(|d| d.clone());
-        let (tx, rx) = tokio::sync::oneshot::channel();
+        let (tx, rx) = std::sync::mpsc::channel();
 
         let rt = self.runtime;
         let socket = self.socket;

--- a/src/components/proxy/packet_router.rs
+++ b/src/components/proxy/packet_router.rs
@@ -55,7 +55,7 @@ pub struct DownstreamReceiveWorkerConfig {
 
 impl DownstreamReceiveWorkerConfig {
     #[inline]
-    pub(crate) async fn process_task(
+    pub(crate) fn process_task(
         packet: DownstreamPacket,
         worker_id: usize,
         config: &Arc<Config>,
@@ -70,7 +70,7 @@ impl DownstreamReceiveWorkerConfig {
         );
 
         let timer = metrics::processing_time(metrics::READ).start_timer();
-        match Self::process_downstream_received_packet(packet, config, sessions).await {
+        match Self::process_downstream_received_packet(packet, config, sessions) {
             Ok(()) => {
                 error_acc.maybe_send();
             }
@@ -88,7 +88,7 @@ impl DownstreamReceiveWorkerConfig {
 
     /// Processes a packet by running it through the filter chain.
     #[inline]
-    async fn process_downstream_received_packet(
+    fn process_downstream_received_packet(
         packet: DownstreamPacket,
         config: &Arc<Config>,
         sessions: &Arc<SessionPool>,
@@ -123,7 +123,7 @@ impl DownstreamReceiveWorkerConfig {
                 dest: epa.to_socket_addr()?,
             };
 
-            sessions.send(session_key, contents.clone()).await?;
+            sessions.send(session_key, contents.clone())?;
         }
 
         Ok(())
@@ -143,7 +143,7 @@ pub async fn spawn_receivers(
     upstream_receiver: DownstreamReceiver,
     buffer_pool: Arc<crate::pool::BufferPool>,
     shutdown: crate::ShutdownRx,
-) -> crate::Result<Vec<tokio::sync::oneshot::Receiver<()>>> {
+) -> crate::Result<Vec<std::sync::mpsc::Receiver<()>>> {
     let (error_sender, mut error_receiver) = mpsc::channel(128);
 
     let port = crate::net::socket_port(&socket);

--- a/src/components/proxy/packet_router.rs
+++ b/src/components/proxy/packet_router.rs
@@ -104,10 +104,7 @@ impl DownstreamReceiveWorkerConfig {
             packet.source.into(),
             packet.contents,
         );
-        filters
-            .read(&mut context)
-            .await
-            .map_err(PipelineError::Filter)?;
+        filters.read(&mut context).map_err(PipelineError::Filter)?;
 
         let ReadContext {
             destinations,
@@ -123,7 +120,7 @@ impl DownstreamReceiveWorkerConfig {
         for epa in destinations {
             let session_key = SessionKey {
                 source: packet.source,
-                dest: epa.to_socket_addr().await?,
+                dest: epa.to_socket_addr()?,
             };
 
             sessions.send(session_key, contents.clone()).await?;

--- a/src/components/proxy/packet_router/io_uring.rs
+++ b/src/components/proxy/packet_router/io_uring.rs
@@ -43,10 +43,10 @@ impl super::DownstreamReceiveWorkerConfig {
                 io_uring_shared::PacketProcessorCtx::Router {
                     config,
                     sessions,
-                    error_sender,
-                    upstream_receiver,
+                    error_acc: super::super::error::ErrorAccumulator::new(error_sender),
                     worker_id,
                 },
+                io_uring_shared::PacketReceiver::Router(upstream_receiver),
                 buffer_pool,
                 shutdown,
             )

--- a/src/components/proxy/packet_router/io_uring.rs
+++ b/src/components/proxy/packet_router/io_uring.rs
@@ -20,7 +20,7 @@ impl super::DownstreamReceiveWorkerConfig {
     pub async fn spawn(
         self,
         shutdown: crate::ShutdownRx,
-    ) -> eyre::Result<tokio::sync::oneshot::Receiver<()>> {
+    ) -> eyre::Result<std::sync::mpsc::Receiver<()>> {
         use crate::components::proxy::io_uring_shared;
 
         let Self {

--- a/src/components/proxy/sessions.rs
+++ b/src/components/proxy/sessions.rs
@@ -159,7 +159,7 @@ impl SessionPool {
         self.create_session_from_existing_socket(key, downstream_sender, port)
     }
 
-    pub(crate) async fn process_received_upstream_packet(
+    pub(crate) fn process_received_upstream_packet(
         self: &Arc<Self>,
         packet: PoolBuffer,
         mut recv_addr: SocketAddr,

--- a/src/components/proxy/sessions.rs
+++ b/src/components/proxy/sessions.rs
@@ -201,7 +201,6 @@ impl SessionPool {
                 asn_info,
                 packet,
             )
-            .await
         };
 
         if let Err((asn_info, error)) = result {
@@ -334,7 +333,7 @@ impl SessionPool {
     }
 
     /// process_recv_packet processes a packet that is received by this session.
-    async fn process_recv_packet(
+    fn process_recv_packet(
         config: Arc<crate::Config>,
         downstream_sender: &DownstreamSender,
         source: SocketAddr,
@@ -346,7 +345,7 @@ impl SessionPool {
 
         let mut context = crate::filters::WriteContext::new(source.into(), dest.into(), packet);
 
-        if let Err(err) = config.filters.load().write(&mut context).await {
+        if let Err(err) = config.filters.load().write(&mut context) {
             return Err((asn_info, err.into()));
         }
 
@@ -723,7 +722,7 @@ mod tests {
     async fn send_and_recv() {
         let mut t = TestHelper::default();
         let dest = t.run_echo_server(AddressType::Ipv6).await;
-        let mut dest = dest.to_socket_addr().await.unwrap();
+        let mut dest = dest.to_socket_addr().unwrap();
         crate::test::map_addr_to_localhost(&mut dest);
         let source = available_addr(AddressType::Ipv6).await;
         let socket = tokio::net::UdpSocket::bind(source).await.unwrap();

--- a/src/components/proxy/sessions/io_uring.rs
+++ b/src/components/proxy/sessions/io_uring.rs
@@ -40,11 +40,8 @@ impl super::SessionPool {
 
         io_loop.spawn(
             format!("session-{id}"),
-            io_uring_shared::PacketProcessorCtx::SessionPool {
-                pool,
-                downstream_receiver,
-                port,
-            },
+            io_uring_shared::PacketProcessorCtx::SessionPool { pool, port },
+            io_uring_shared::PacketReceiver::SessionPool(downstream_receiver),
             buffer_pool,
             shutdown,
         )

--- a/src/components/proxy/sessions/io_uring.rs
+++ b/src/components/proxy/sessions/io_uring.rs
@@ -24,7 +24,7 @@ impl super::SessionPool {
         raw_socket: socket2::Socket,
         port: u16,
         downstream_receiver: tokio::sync::mpsc::Receiver<crate::components::proxy::SendPacket>,
-    ) -> Result<tokio::sync::oneshot::Receiver<()>, crate::components::proxy::PipelineError> {
+    ) -> Result<std::sync::mpsc::Receiver<()>, crate::components::proxy::PipelineError> {
         use crate::components::proxy::io_uring_shared;
 
         let pool = self;

--- a/src/components/proxy/sessions/reference.rs
+++ b/src/components/proxy/sessions/reference.rs
@@ -20,7 +20,7 @@ impl super::SessionPool {
         raw_socket: socket2::Socket,
         port: u16,
         mut downstream_receiver: tokio::sync::mpsc::Receiver<crate::components::proxy::SendPacket>,
-    ) -> Result<tokio::sync::oneshot::Receiver<()>, crate::components::proxy::PipelineError> {
+    ) -> Result<std::sync::mpsc::Receiver<()>, crate::components::proxy::PipelineError> {
         let pool = self;
 
         let rx = uring_spawn!(

--- a/src/components/proxy/sessions/reference.rs
+++ b/src/components/proxy/sessions/reference.rs
@@ -101,7 +101,7 @@ impl super::SessionPool {
                                     tracing::trace!(%error, "error receiving packet");
                                     crate::metrics::errors_total(crate::metrics::WRITE, &error.to_string(), &crate::metrics::EMPTY).inc();
                                 },
-                                Ok((_size, recv_addr)) => pool.process_received_upstream_packet(buf, recv_addr, port, &mut last_received_at).await,
+                                Ok((_size, recv_addr)) => pool.process_received_upstream_packet(buf, recv_addr, port, &mut last_received_at),
                             }
                         }
                         _ = shutdown_rx.changed() => {

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -193,14 +193,13 @@ impl<T: JsonSchema + Default> JsonSchema for Slot<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: crate::filters::Filter + Default> crate::filters::Filter for Slot<T> {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
-        self.load().read(ctx).await
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+        self.load().read(ctx)
     }
 
-    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
-        self.load().write(ctx).await
+    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+        self.load().write(ctx)
     }
 }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -83,13 +83,12 @@ pub use self::chain::FilterChain;
 /// struct Greet;
 ///
 /// /// Prepends data on each packet
-/// #[async_trait::async_trait]
 /// impl Filter for Greet {
-///     async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+///     fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
 ///         ctx.contents.prepend_from_slice(b"Hello ");
 ///         Ok(())
 ///     }
-///     async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+///     fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
 ///         ctx.contents.prepend_from_slice(b"Goodbye ");
 ///         Ok(())
 ///     }
@@ -208,7 +207,6 @@ where
 ///   `write` implementation to execute.
 ///   * Labels
 ///     * `filter` The name of the filter being executed.
-#[async_trait::async_trait]
 pub trait Filter: Send + Sync {
     /// [`Filter::read`] is invoked when the proxy receives data from a
     /// downstream connection on the listening port.
@@ -216,7 +214,7 @@ pub trait Filter: Send + Sync {
     /// This function should return an `Some` if the packet processing should
     /// proceed. If the packet should be rejected, it will return [`None`]
     /// instead. By default, the context passes through unchanged.
-    async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
         Ok(())
     }
 
@@ -226,7 +224,7 @@ pub trait Filter: Send + Sync {
     ///
     /// This function should return an `Some` if the packet processing should
     /// proceed. If the packet should be rejected, it will return [`None`]
-    async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
         Ok(())
     }
 }

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -56,10 +56,9 @@ impl Capture {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for Capture {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         let capture = self.capture.capture(&mut ctx.contents);
         ctx.metadata.insert(
             self.is_present_key,
@@ -109,7 +108,7 @@ mod tests {
             }
         });
         let filter = Capture::from_config(Some(serde_json::from_value(config).unwrap()));
-        assert_end_strategy(&filter, TOKEN_KEY.into(), true).await;
+        assert_end_strategy(&filter, TOKEN_KEY.into(), true);
     }
 
     #[tokio::test]
@@ -121,7 +120,7 @@ mod tests {
         });
 
         let filter = Capture::from_config(Some(serde_json::from_value(config).unwrap()));
-        assert_end_strategy(&filter, CAPTURED_BYTES.into(), false).await;
+        assert_end_strategy(&filter, CAPTURED_BYTES.into(), false);
     }
 
     #[test]
@@ -145,7 +144,7 @@ mod tests {
         };
 
         let filter = Capture::from_config(config.into());
-        assert_end_strategy(&filter, TOKEN_KEY.into(), true).await;
+        assert_end_strategy(&filter, TOKEN_KEY.into(), true);
     }
 
     #[tokio::test]
@@ -167,7 +166,6 @@ mod tests {
                 (std::net::Ipv4Addr::LOCALHOST, 80).into(),
                 alloc_buffer(b"abc"),
             ))
-            .await
             .is_err());
     }
 
@@ -181,7 +179,7 @@ mod tests {
             metadata_key: TOKEN_KEY.into(),
         };
         let filter = Capture::from_config(config.into());
-        assert_write_no_change(&filter).await;
+        assert_write_no_change(&filter);
     }
 
     #[test]
@@ -232,7 +230,7 @@ mod tests {
         assert_eq!(b"hello", &*contents);
     }
 
-    async fn assert_end_strategy<F>(filter: &F, key: metadata::Key, remove: bool)
+    fn assert_end_strategy<F>(filter: &F, key: metadata::Key, remove: bool)
     where
         F: Filter + ?Sized,
     {
@@ -245,7 +243,7 @@ mod tests {
             alloc_buffer(b"helloabc"),
         );
 
-        filter.read(&mut context).await.unwrap();
+        filter.read(&mut context).unwrap();
 
         if remove {
             assert_eq!(b"hello", &*context.contents);

--- a/src/filters/concatenate.rs
+++ b/src/filters/concatenate.rs
@@ -42,9 +42,8 @@ impl Concatenate {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for Concatenate {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         match self.on_read {
             Strategy::Append => {
                 ctx.contents.extend_from_slice(&self.bytes);
@@ -58,7 +57,7 @@ impl Filter for Concatenate {
         Ok(())
     }
 
-    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         match self.on_write {
             Strategy::Append => {
                 ctx.contents.extend_from_slice(&self.bytes);

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -36,16 +36,15 @@ impl Debug {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for Debug {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         info!(id = ?self.config.id, source = ?&ctx.source, contents = ?String::from_utf8_lossy(&ctx.contents), "Read filter event");
         Ok(())
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         info!(
             id = ?self.config.id,
             source = ?&ctx.source,
@@ -98,7 +97,7 @@ mod tests {
     #[tokio::test]
     async fn read() {
         let df = Debug::new(None);
-        assert_filter_read_no_change(&df).await;
+        assert_filter_read_no_change(&df);
         assert!(logs_contain("Read filter event"));
     }
 
@@ -106,7 +105,7 @@ mod tests {
     #[tokio::test]
     async fn write() {
         let df = Debug::new(None);
-        assert_write_no_change(&df).await;
+        assert_write_no_change(&df);
         assert!(logs_contain("Write filter event"));
         assert!(logs_contain("quilkin::filters::debug")); // the given name to the the logger by tracing
     }

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -30,15 +30,14 @@ impl Drop {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for Drop {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
         Err(FilterError::Dropped)
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
         Err(FilterError::Dropped)
     }
 }

--- a/src/filters/load_balancer.rs
+++ b/src/filters/load_balancer.rs
@@ -37,9 +37,8 @@ impl LoadBalancer {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for LoadBalancer {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         self.endpoint_chooser.choose_endpoints(ctx);
         Ok(())
     }
@@ -65,7 +64,7 @@ mod tests {
         test::alloc_buffer,
     };
 
-    async fn get_response_addresses(
+    fn get_response_addresses(
         filter: &dyn Filter,
         input_addresses: &[EndpointAddress],
         source: EndpointAddress,
@@ -78,7 +77,7 @@ mod tests {
         let endpoints = crate::net::cluster::ClusterMap::new_default(endpoints);
         let mut context = ReadContext::new(endpoints.into(), source, alloc_buffer([]));
 
-        filter.read(&mut context).await.unwrap();
+        filter.read(&mut context).unwrap();
 
         context.destinations
     }
@@ -104,14 +103,11 @@ mod tests {
             assert_eq!(expected_sequence, {
                 let mut responses = Vec::new();
                 for _ in 0..addresses.len() {
-                    responses.push(
-                        get_response_addresses(
-                            &filter,
-                            &addresses,
-                            "127.0.0.1:8080".parse().unwrap(),
-                        )
-                        .await,
-                    );
+                    responses.push(get_response_addresses(
+                        &filter,
+                        &addresses,
+                        "127.0.0.1:8080".parse().unwrap(),
+                    ));
                 }
                 responses
             });
@@ -135,10 +131,11 @@ policy: RANDOM
         let mut result_sequences = vec![];
         for _ in 0..10 {
             for _ in 0..addresses.len() {
-                result_sequences.push(
-                    get_response_addresses(&filter, &addresses, "127.0.0.1:8080".parse().unwrap())
-                        .await,
-                );
+                result_sequences.push(get_response_addresses(
+                    &filter,
+                    &addresses,
+                    "127.0.0.1:8080".parse().unwrap(),
+                ));
             }
         }
 
@@ -178,10 +175,11 @@ policy: RANDOM
         let mut result_sequences = vec![];
         for _ in 0..10 {
             for _ in 0..addresses.len() {
-                result_sequences.push(
-                    get_response_addresses(&filter, &addresses, (Ipv4Addr::LOCALHOST, 8080).into())
-                        .await,
-                );
+                result_sequences.push(get_response_addresses(
+                    &filter,
+                    &addresses,
+                    (Ipv4Addr::LOCALHOST, 8080).into(),
+                ));
             }
         }
 
@@ -204,8 +202,7 @@ policy: RANDOM
                     &filter,
                     &addresses,
                     (Ipv4Addr::LOCALHOST, port).into()
-                )
-                .await;
+                );
                 addresses.len()
             ]);
         }
@@ -231,8 +228,7 @@ policy: RANDOM
                         &filter,
                         &addresses,
                         (ip, port).into()
-                    )
-                    .await;
+                    );
                     addresses.len()
                 ]);
             }

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -29,15 +29,14 @@ impl Pass {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for Pass {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
         Ok(())
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
         Ok(())
     }
 }

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -73,13 +73,12 @@ mod tests {
     #[allow(dead_code)]
     struct TestFilter {}
 
-    #[async_trait::async_trait]
     impl Filter for TestFilter {
-        async fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+        fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
             Err(FilterError::Custom("test error"))
         }
 
-        async fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
+        fn write(&self, _: &mut WriteContext) -> Result<(), FilterError> {
             Err(FilterError::Custom("test error"))
         }
     }
@@ -112,11 +111,9 @@ mod tests {
                 addr.clone(),
                 alloc_buffer([]),
             ))
-            .await
             .is_ok());
         assert!(filter
             .write(&mut WriteContext::new(addr.clone(), addr, alloc_buffer([])))
-            .await
             .is_ok());
     }
 }

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -86,14 +86,13 @@ impl TryFrom<Config> for Timestamp {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for Timestamp {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         self.observe(&ctx.metadata, Direction::Read);
         Ok(())
     }
 
-    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         self.observe(&ctx.metadata, Direction::Write);
         Ok(())
     }
@@ -168,7 +167,7 @@ mod tests {
             Value::Number(crate::time::UtcTimestamp::now().unix() as u64),
         );
 
-        filter.read(&mut ctx).await.unwrap();
+        filter.read(&mut ctx).unwrap();
 
         assert_eq!(1, filter.metric(Direction::Read).get_sample_count());
     }
@@ -195,8 +194,8 @@ mod tests {
             alloc_buffer([0, 0, 0, 0, 99, 81, 55, 181]),
         );
 
-        capture.read(&mut ctx).await.unwrap();
-        timestamp.read(&mut ctx).await.unwrap();
+        capture.read(&mut ctx).unwrap();
+        timestamp.read(&mut ctx).unwrap();
 
         assert_eq!(1, timestamp.metric(Direction::Read).get_sample_count());
     }

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -68,9 +68,8 @@ impl StaticFilter for TokenRouter {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for TokenRouter {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         self.sync_read(ctx)
     }
 }
@@ -89,9 +88,8 @@ impl StaticFilter for HashedTokenRouter {
     }
 }
 
-#[async_trait::async_trait]
 impl Filter for HashedTokenRouter {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         self.0.sync_read(ctx)
     }
 }
@@ -261,7 +259,7 @@ mod tests {
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(TOKEN_KEY.into(), Value::Bytes(b"123".to_vec().into()));
-        assert_read(&filter, ctx).await;
+        assert_read(&filter, ctx);
     }
 
     #[tokio::test]
@@ -270,7 +268,7 @@ mod tests {
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"123".to_vec().into()));
-        assert_read(&filter, ctx).await;
+        assert_read(&filter, ctx);
     }
 
     #[tokio::test]
@@ -284,18 +282,18 @@ mod tests {
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"123".to_vec().into()));
-        assert_read(&filter, ctx).await;
+        assert_read(&filter, ctx);
 
         // invalid key
         let mut ctx = new_ctx();
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"567".to_vec().into()));
 
-        assert!(filter.read(&mut ctx).await.is_err());
+        assert!(filter.read(&mut ctx).is_err());
 
         // no key
         let mut ctx = new_ctx();
-        assert!(filter.read(&mut ctx).await.is_err());
+        assert!(filter.read(&mut ctx).is_err());
     }
 
     #[tokio::test]
@@ -304,7 +302,7 @@ mod tests {
             metadata_key: CAPTURED_BYTES.into(),
         };
         let filter = TokenRouter::from_config(config.into());
-        assert_write_no_change(&filter).await;
+        assert_write_no_change(&filter);
     }
 
     fn new_ctx() -> ReadContext {
@@ -332,11 +330,11 @@ mod tests {
         )
     }
 
-    async fn assert_read<F>(filter: &F, mut ctx: ReadContext)
+    fn assert_read<F>(filter: &F, mut ctx: ReadContext)
     where
         F: Filter + ?Sized,
     {
-        filter.read(&mut ctx).await.unwrap();
+        filter.read(&mut ctx).unwrap();
 
         assert_eq!(b"hello", ctx.contents.as_ref());
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -18,7 +18,7 @@
 #[cfg(not(target_os = "linux"))]
 macro_rules! uring_spawn {
     ($span:expr, $future:expr) => {{
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
         use tracing::Instrument as _;
 
         use tracing::instrument::WithSubscriber as _;

--- a/src/net.rs
+++ b/src/net.rs
@@ -345,7 +345,7 @@ mod tests {
         let (mut rx, socket) = t.open_socket_and_recv_multiple_packets().await;
 
         let msg = "hello";
-        let addr = echo_addr.to_socket_addr().await.unwrap();
+        let addr = echo_addr.to_socket_addr().unwrap();
 
         socket.send_to(msg.as_bytes(), &addr).await.unwrap();
         assert_eq!(

--- a/src/net/endpoint/address.rs
+++ b/src/net/endpoint/address.rs
@@ -60,7 +60,7 @@ impl EndpointAddress {
 
     /// Returns the socket address for the endpoint, resolving any DNS entries
     /// if present.
-    pub async fn to_socket_addr(&self) -> std::io::Result<SocketAddr> {
+    pub fn to_socket_addr(&self) -> std::io::Result<SocketAddr> {
         static DNS: Lazy<TokioAsyncResolver> =
             Lazy::new(|| TokioAsyncResolver::tokio_from_system_conf().unwrap());
 
@@ -73,9 +73,9 @@ impl EndpointAddress {
                 match CACHE.get(name) {
                     Some(ip) => **ip,
                     None => {
-                        let set = DNS
-                            .lookup_ip(&**name)
-                            .await?
+                        let handle = tokio::runtime::Handle::current();
+                        let set = handle
+                            .block_on(DNS.lookup_ip(&**name))?
                             .iter()
                             .collect::<std::collections::HashSet<_>>();
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -98,9 +98,8 @@ fn get_address(address_type: AddressType, socket: &DualStackLocalSocket) -> Sock
 // TestFilter is useful for testing that commands are executing filters appropriately.
 pub struct TestFilter;
 
-#[async_trait::async_trait]
 impl Filter for TestFilter {
-    async fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
         // append values on each run
         ctx.metadata
             .entry("downstream".into())
@@ -112,7 +111,7 @@ impl Filter for TestFilter {
         Ok(())
     }
 
-    async fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
+    fn write(&self, ctx: &mut WriteContext) -> Result<(), FilterError> {
         // append values on each run
         ctx.metadata
             .entry("upstream".into())
@@ -361,7 +360,7 @@ pub fn alloc_buffer(data: impl AsRef<[u8]>) -> crate::pool::PoolBuffer {
 
 /// assert that read makes no changes
 #[cfg(test)]
-pub async fn assert_filter_read_no_change<F>(filter: &F)
+pub fn assert_filter_read_no_change<F>(filter: &F)
 where
     F: Filter,
 {
@@ -373,14 +372,14 @@ where
     let contents = b"hello";
     let mut context = ReadContext::new(endpoints.clone(), source, alloc_buffer(contents));
 
-    filter.read(&mut context).await.unwrap();
+    filter.read(&mut context).unwrap();
     assert!(context.destinations.is_empty());
     assert_eq!(endpoints, context.endpoints);
     assert_eq!(contents, &*context.contents);
 }
 
 /// assert that write makes no changes
-pub async fn assert_write_no_change<F>(filter: &F)
+pub fn assert_write_no_change<F>(filter: &F)
 where
     F: Filter,
 {
@@ -392,12 +391,12 @@ where
         alloc_buffer(contents),
     );
 
-    filter.write(&mut context).await.unwrap();
+    filter.write(&mut context).unwrap();
     assert_eq!(contents, &*context.contents);
 }
 
-pub async fn map_to_localhost(address: &mut EndpointAddress) {
-    let mut socket_addr = address.to_socket_addr().await.unwrap();
+pub fn map_to_localhost(address: &mut EndpointAddress) {
+    let mut socket_addr = address.to_socket_addr().unwrap();
     map_addr_to_localhost(&mut socket_addr);
     *address = socket_addr.into();
 }
@@ -526,7 +525,7 @@ mod tests {
         let msg = "hello";
         endpoint
             .socket
-            .send_to(msg.as_bytes(), &echo_addr.to_socket_addr().await.unwrap())
+            .send_to(msg.as_bytes(), &echo_addr.to_socket_addr().unwrap())
             .await
             .unwrap();
         assert_eq!(

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -31,7 +31,7 @@ use quilkin::{
 async fn token_router() {
     let mut t = TestHelper::default();
     let mut echo = t.run_echo_server(AddressType::Random).await;
-    quilkin::test::map_to_localhost(&mut echo).await;
+    quilkin::test::map_to_localhost(&mut echo);
 
     let server_config = std::sync::Arc::new(quilkin::Config::default_non_agent());
     server_config.filters.store(

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -53,7 +53,7 @@ on_write: DECOMPRESS
         })
         .await;
 
-    quilkin::test::map_to_localhost(&mut echo).await;
+    quilkin::test::map_to_localhost(&mut echo);
     let server_config = std::sync::Arc::new(quilkin::Config::default_non_agent());
     server_config
         .clusters
@@ -128,7 +128,7 @@ async fn multiple_mutations() {
         })
         .await;
 
-    quilkin::test::map_to_localhost(&mut echo).await;
+    quilkin::test::map_to_localhost(&mut echo);
     let server_config = std::sync::Arc::new(quilkin::Config::default_non_agent());
     server_config
         .clusters

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -120,7 +120,7 @@ async fn multiple_clients() {
 // start an echo server and return what port it's on.
 async fn echo_server(t: &mut TestHelper) -> SocketAddr {
     let mut echo = t.run_echo_server(AddressType::Ipv6).await;
-    quilkin::test::map_to_localhost(&mut echo).await;
+    quilkin::test::map_to_localhost(&mut echo);
 
     let capture_yaml = "
 suffix:


### PR DESCRIPTION
This is a test to check whether making the filters synchronous makes a difference to the performance under the new raw io-uring implementation.