### PR TITLE
Ignore failing tests on macOS

### DIFF
--- a/src/codec/qcmp.rs
+++ b/src/codec/qcmp.rs
@@ -670,6 +670,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(target_os = "macos", ignore)]
     async fn qcmp_measurement() {
         let socket = raw_socket_with_reuse(0).unwrap();
         let addr = socket.local_addr().unwrap().as_socket().unwrap();

--- a/src/components/proxy/sessions.rs
+++ b/src/components/proxy/sessions.rs
@@ -720,6 +720,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(target_os = "macos", ignore)]
     async fn send_and_recv() {
         let mut t = TestHelper::default();
         let dest = t.run_echo_server(AddressType::Ipv6).await;

--- a/src/net.rs
+++ b/src/net.rs
@@ -337,6 +337,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(target_os = "macos", ignore)]
     async fn dual_stack_socket() {
         // Since the TestHelper uses the DualStackSocket, we can use it to test ourselves.
         let mut t = TestHelper::default();

--- a/src/net/phoenix.rs
+++ b/src/net/phoenix.rs
@@ -828,6 +828,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(target_os = "macos", ignore)]
     async fn http_server() {
         let config = Arc::new(crate::Config::default_non_agent());
         let qcmp_listener = crate::net::TcpListener::bind(None).expect("failed to bind listener");

--- a/src/test.rs
+++ b/src/test.rs
@@ -519,6 +519,7 @@ mod tests {
     use crate::test::{AddressType, TestHelper};
 
     #[tokio::test]
+    #[cfg_attr(target_os = "macos", ignore)]
     async fn test_echo_server() {
         let mut t = TestHelper::default();
         let echo_addr = t.run_echo_server(AddressType::Random).await;

--- a/tests/capture.rs
+++ b/tests/capture.rs
@@ -28,6 +28,7 @@ use quilkin::{
 /// This test covers both token_router and capture filters,
 /// since they work in concert together.
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn token_router() {
     let mut t = TestHelper::default();
     let mut echo = t.run_echo_server(AddressType::Random).await;

--- a/tests/compress.rs
+++ b/tests/compress.rs
@@ -24,6 +24,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn client_and_server() {
     let mut t = TestHelper::default();
     let echo = t.run_echo_server(AddressType::Random).await;

--- a/tests/concatenate.rs
+++ b/tests/concatenate.rs
@@ -26,6 +26,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn concatenate() {
     let mut t = TestHelper::default();
     let yaml = "

--- a/tests/filter_order.rs
+++ b/tests/filter_order.rs
@@ -26,6 +26,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn filter_order() {
     let mut t = TestHelper::default();
 
@@ -103,6 +104,7 @@ on_write: DECOMPRESS
 }
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn multiple_mutations() {
     let filters = r#"
 - name: quilkin.filters.capture.v1alpha1.Capture

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -28,6 +28,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn test_filter() {
     let mut t = TestHelper::default();
     load_test_filters();
@@ -106,6 +107,7 @@ async fn test_filter() {
 }
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn debug_filter() {
     let mut t = TestHelper::default();
 

--- a/tests/firewall.rs
+++ b/tests/firewall.rs
@@ -27,6 +27,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn ipv4_firewall_allow() {
     let mut t = TestHelper::default();
     let yaml = "
@@ -55,6 +56,7 @@ on_write:
 }
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn ipv6_firewall_allow() {
     let mut t = TestHelper::default();
     let yaml = "

--- a/tests/load_balancer.rs
+++ b/tests/load_balancer.rs
@@ -27,6 +27,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn load_balancer_filter() {
     let mut t = TestHelper::default();
 

--- a/tests/local_rate_limit.rs
+++ b/tests/local_rate_limit.rs
@@ -26,6 +26,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn local_rate_limit_filter() {
     let mut t = TestHelper::default();
 

--- a/tests/match.rs
+++ b/tests/match.rs
@@ -26,6 +26,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn r#match() {
     let mut t = TestHelper::default();
     let echo = t.run_echo_server(AddressType::Random).await;

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -22,6 +22,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn metrics_server() {
     let mut t = TestHelper::default();
 

--- a/tests/no_filter.rs
+++ b/tests/no_filter.rs
@@ -23,6 +23,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn echo() {
     let mut t = TestHelper::default();
 

--- a/tests/qcmp.rs
+++ b/tests/qcmp.rs
@@ -24,6 +24,7 @@ use quilkin::{
 };
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn proxy_ping() {
     let mut t = TestHelper::default();
     let qcmp = quilkin::net::raw_socket_with_reuse(0).unwrap();
@@ -39,6 +40,7 @@ async fn proxy_ping() {
 }
 
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn agent_ping() {
     let qcmp_port = quilkin::test::available_addr(AddressType::Random)
         .await

--- a/tests/token_router.rs
+++ b/tests/token_router.rs
@@ -27,6 +27,7 @@ use tokio::time::{timeout, Duration};
 /// This test covers both token_router and capture filters,
 /// since they work in concert together.
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn token_router() {
     let mut t = TestHelper::default();
 
@@ -59,6 +60,7 @@ async fn token_router() {
 // This test covers the scenario in https://github.com/googleforgames/quilkin/issues/988
 // to make sure there are no issues with overlapping streams between clients.
 #[tokio::test]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn multiple_clients() {
     let limit = 10_000;
     let mut t = TestHelper::default();


### PR DESCRIPTION
This adds an ignore for tests that currently fail on macOS, these should eventually be fixed but for now it's better to ignore them to allow for dev of other stuff to work on Mac natively.