### PR TITLE
Remove destination address allocation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[target.'cfg(all())']
+rustflags = [
+    "-Ctarget-feature=+aes,+avx2",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -1707,7 +1707,7 @@ dependencies = [
  "kube-core",
  "openssl",
  "pem",
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "rustls-pemfile 2.2.0",
  "secrecy",
  "serde",
@@ -2750,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",
@@ -3444,7 +3444,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.17",
+ "rustls 0.23.18",
  "rustls-pki-types",
  "tokio",
 ]
@@ -3744,9 +3744,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna 1.0.3",

--- a/src/components/proxy/io_uring_shared.rs
+++ b/src/components/proxy/io_uring_shared.rs
@@ -254,6 +254,7 @@ pub enum PacketProcessorCtx {
         sessions: Arc<crate::components::proxy::SessionPool>,
         error_acc: super::error::ErrorAccumulator,
         worker_id: usize,
+        destinations: Vec<crate::net::EndpointAddress>,
     },
     SessionPool {
         pool: Arc<crate::components::proxy::SessionPool>,
@@ -326,6 +327,7 @@ fn process_packet(
             sessions,
             worker_id,
             error_acc,
+            destinations,
         } => {
             let received_at = UtcTimestamp::now();
             if let Some(last_received_at) = last_received_at {
@@ -340,7 +342,12 @@ fn process_packet(
             };
 
             crate::components::proxy::packet_router::DownstreamReceiveWorkerConfig::process_task(
-                ds_packet, *worker_id, config, sessions, error_acc,
+                ds_packet,
+                *worker_id,
+                config,
+                sessions,
+                error_acc,
+                destinations,
             );
 
             packet_processed_event.write(1);

--- a/src/components/proxy/packet_router/io_uring.rs
+++ b/src/components/proxy/packet_router/io_uring.rs
@@ -45,6 +45,7 @@ impl super::DownstreamReceiveWorkerConfig {
                     sessions,
                     error_acc: super::super::error::ErrorAccumulator::new(error_sender),
                     worker_id,
+                    destinations: Vec::with_capacity(1),
                 },
                 io_uring_shared::PacketReceiver::Router(upstream_receiver),
                 buffer_pool,

--- a/src/components/proxy/packet_router/reference.rs
+++ b/src/components/proxy/packet_router/reference.rs
@@ -108,6 +108,7 @@ impl super::DownstreamReceiveWorkerConfig {
 
             let mut error_acc =
                 crate::components::proxy::error::ErrorAccumulator::new(error_sender);
+            let mut destinations = Vec::with_capacity(1);
 
             loop {
                 // Initialize a buffer for the UDP packet. We use the maximum size of a UDP
@@ -131,7 +132,14 @@ impl super::DownstreamReceiveWorkerConfig {
                         }
                         last_received_at = Some(received_at);
 
-                        Self::process_task(packet, worker_id, &config, &sessions, &mut error_acc);
+                        Self::process_task(
+                            packet,
+                            worker_id,
+                            &config,
+                            &sessions,
+                            &mut error_acc,
+                            &mut destinations,
+                        );
                     }
                     Err(error) => {
                         tracing::error!(%error, "error receiving packet");

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -194,7 +194,7 @@ impl<T: JsonSchema + Default> JsonSchema for Slot<T> {
 }
 
 impl<T: crate::filters::Filter + Default> crate::filters::Filter for Slot<T> {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         self.load().read(ctx)
     }
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -208,7 +208,7 @@ pub trait Filter: Send + Sync {
     /// This function should return an `Some` if the packet processing should
     /// proceed. If the packet should be rejected, it will return [`None`]
     /// instead. By default, the context passes through unchanged.
-    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, _: &mut ReadContext<'_>) -> Result<(), FilterError> {
         Ok(())
     }
 

--- a/src/filters/concatenate.rs
+++ b/src/filters/concatenate.rs
@@ -43,7 +43,7 @@ impl Concatenate {
 }
 
 impl Filter for Concatenate {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         match self.on_read {
             Strategy::Append => {
                 ctx.contents.extend_from_slice(&self.bytes);

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -38,7 +38,7 @@ impl Debug {
 
 impl Filter for Debug {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         info!(id = ?self.config.id, source = ?&ctx.source, contents = ?String::from_utf8_lossy(&ctx.contents), "Read filter event");
         Ok(())
     }

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -32,7 +32,7 @@ impl Drop {
 
 impl Filter for Drop {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, _: &mut ReadContext<'_>) -> Result<(), FilterError> {
         Err(FilterError::Dropped)
     }
 

--- a/src/filters/local_rate_limit.rs
+++ b/src/filters/local_rate_limit.rs
@@ -148,7 +148,7 @@ impl LocalRateLimit {
 }
 
 impl Filter for LocalRateLimit {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         if self.acquire_token(&ctx.source) {
             Ok(())
         } else {
@@ -235,7 +235,13 @@ mod tests {
             .into(),
         );
 
-        let mut context = ReadContext::new(endpoints.into(), address.clone(), alloc_buffer([9]));
+        let mut dest = Vec::new();
+        let mut context = ReadContext::new(
+            endpoints.into(),
+            address.clone(),
+            alloc_buffer([9]),
+            &mut dest,
+        );
         let result = r.read(&mut context);
 
         if should_succeed {

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -119,7 +119,7 @@ fn match_filter<'config, 'ctx, Ctx>(
 
 impl Filter for Match {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         tracing::trace!(metadata=?ctx.metadata);
         match_filter(
             &self.on_read_filters,
@@ -197,10 +197,12 @@ mod tests {
         let endpoints = crate::net::cluster::ClusterMap::new_default(
             [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
         );
+        let mut dest = Vec::new();
         let mut ctx = ReadContext::new(
             endpoints.into(),
             ([127, 0, 0, 1], 7000).into(),
             alloc_buffer(contents),
+            &mut dest,
         );
         ctx.metadata.insert(key, "abc".into());
 
@@ -211,10 +213,12 @@ mod tests {
         let endpoints = crate::net::cluster::ClusterMap::new_default(
             [Endpoint::new("127.0.0.1:81".parse().unwrap())].into(),
         );
+        let mut dest = Vec::new();
         let mut ctx = ReadContext::new(
             endpoints.into(),
             ([127, 0, 0, 1], 7000).into(),
             alloc_buffer(contents),
+            &mut dest,
         );
         ctx.metadata.insert(key, "xyz".into());
 

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -31,7 +31,7 @@ impl Pass {
 
 impl Filter for Pass {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, _: &mut ReadContext<'_>) -> Result<(), FilterError> {
         Ok(())
     }
 

--- a/src/filters/read.rs
+++ b/src/filters/read.rs
@@ -28,11 +28,11 @@ use crate::{
 
 /// The input arguments to [`Filter::read`].
 #[non_exhaustive]
-pub struct ReadContext {
+pub struct ReadContext<'ctx> {
     /// The upstream endpoints that the packet will be forwarded to.
     pub endpoints: Arc<ClusterMap>,
     /// The upstream endpoints that the packet will be forwarded to.
-    pub destinations: Vec<EndpointAddress>,
+    pub destinations: &'ctx mut Vec<EndpointAddress>,
     /// The source of the received packet.
     pub source: EndpointAddress,
     /// Contents of the received packet.
@@ -41,13 +41,18 @@ pub struct ReadContext {
     pub metadata: DynamicMetadata,
 }
 
-impl ReadContext {
+impl<'ctx> ReadContext<'ctx> {
     /// Creates a new [`ReadContext`].
     #[inline]
-    pub fn new(endpoints: Arc<ClusterMap>, source: EndpointAddress, contents: PoolBuffer) -> Self {
+    pub fn new(
+        endpoints: Arc<ClusterMap>,
+        source: EndpointAddress,
+        contents: PoolBuffer,
+        destinations: &'ctx mut Vec<EndpointAddress>,
+    ) -> Self {
         Self {
             endpoints,
-            destinations: Vec::new(),
+            destinations,
             source,
             contents,
             metadata: <_>::default(),

--- a/src/filters/read.rs
+++ b/src/filters/read.rs
@@ -27,7 +27,6 @@ use crate::{
 };
 
 /// The input arguments to [`Filter::read`].
-#[non_exhaustive]
 pub struct ReadContext<'ctx> {
     /// The upstream endpoints that the packet will be forwarded to.
     pub endpoints: Arc<ClusterMap>,

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -74,7 +74,7 @@ mod tests {
     struct TestFilter {}
 
     impl Filter for TestFilter {
-        fn read(&self, _: &mut ReadContext) -> Result<(), FilterError> {
+        fn read(&self, _: &mut ReadContext<'_>) -> Result<(), FilterError> {
             Err(FilterError::Custom("test error"))
         }
 
@@ -105,11 +105,13 @@ mod tests {
         let endpoint = Endpoint::new(addr.clone());
 
         let endpoints = crate::net::cluster::ClusterMap::new_default([endpoint.clone()].into());
+        let mut dest = Vec::new();
         assert!(filter
             .read(&mut ReadContext::new(
                 endpoints.into(),
                 addr.clone(),
                 alloc_buffer([]),
+                &mut dest,
             ))
             .is_ok());
         assert!(filter

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -87,7 +87,7 @@ impl TryFrom<Config> for Timestamp {
 }
 
 impl Filter for Timestamp {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         self.observe(&ctx.metadata, Direction::Read);
         Ok(())
     }
@@ -157,10 +157,12 @@ mod tests {
     async fn basic() {
         const TIMESTAMP_KEY: &str = "BASIC";
         let filter = Timestamp::from_config(Config::new(TIMESTAMP_KEY).into());
+        let mut dest = Vec::new();
         let mut ctx = ReadContext::new(
             <_>::default(),
             (std::net::Ipv4Addr::UNSPECIFIED, 0).into(),
             alloc_buffer(b"hello"),
+            &mut dest,
         );
         ctx.metadata.insert(
             TIMESTAMP_KEY.into(),
@@ -188,10 +190,12 @@ mod tests {
         );
         let timestamp = Timestamp::from_config(Config::new(TIMESTAMP_KEY).into());
         let source = (std::net::Ipv4Addr::UNSPECIFIED, 0);
+        let mut dest = Vec::new();
         let mut ctx = ReadContext::new(
             <_>::default(),
             source.into(),
             alloc_buffer([0, 0, 0, 0, 99, 81, 55, 181]),
+            &mut dest,
         );
 
         capture.read(&mut ctx).unwrap();

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -33,12 +33,12 @@ pub struct TokenRouter {
 impl TokenRouter {
     /// Non-async version of [`Filter::read`], as this filter does no actual async
     /// operations. Used in benchmarking.
-    pub fn sync_read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    pub fn sync_read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         match ctx.metadata.get(&self.config.metadata_key) {
             Some(metadata::Value::Bytes(token)) => {
                 let tok = crate::net::cluster::Token::new(token);
 
-                ctx.destinations = ctx.endpoints.addresses_for_token(tok);
+                ctx.endpoints.addresses_for_token(tok, ctx.destinations);
 
                 if ctx.destinations.is_empty() {
                     Err(FilterError::TokenRouter(RouterError::NoEndpointMatch {
@@ -69,7 +69,7 @@ impl StaticFilter for TokenRouter {
 }
 
 impl Filter for TokenRouter {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         self.sync_read(ctx)
     }
 }
@@ -89,7 +89,7 @@ impl StaticFilter for HashedTokenRouter {
 }
 
 impl Filter for HashedTokenRouter {
-    fn read(&self, ctx: &mut ReadContext) -> Result<(), FilterError> {
+    fn read(&self, ctx: &mut ReadContext<'_>) -> Result<(), FilterError> {
         self.0.sync_read(ctx)
     }
 }
@@ -256,7 +256,8 @@ mod tests {
             }
             .into(),
         );
-        let mut ctx = new_ctx();
+        let mut dest = Vec::new();
+        let mut ctx = new_ctx(&mut dest);
         ctx.metadata
             .insert(TOKEN_KEY.into(), Value::Bytes(b"123".to_vec().into()));
         assert_read(&filter, ctx);
@@ -265,7 +266,8 @@ mod tests {
     #[tokio::test]
     async fn factory_empty_config() {
         let filter = TokenRouter::from_config(None);
-        let mut ctx = new_ctx();
+        let mut dest = Vec::new();
+        let mut ctx = new_ctx(&mut dest);
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"123".to_vec().into()));
         assert_read(&filter, ctx);
@@ -278,21 +280,22 @@ mod tests {
             metadata_key: CAPTURED_BYTES.into(),
         };
         let filter = TokenRouter::from_config(config.into());
+        let mut dest = Vec::new();
 
-        let mut ctx = new_ctx();
+        let mut ctx = new_ctx(&mut dest);
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"123".to_vec().into()));
         assert_read(&filter, ctx);
 
         // invalid key
-        let mut ctx = new_ctx();
+        let mut ctx = new_ctx(&mut dest);
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"567".to_vec().into()));
 
         assert!(filter.read(&mut ctx).is_err());
 
         // no key
-        let mut ctx = new_ctx();
+        let mut ctx = new_ctx(&mut dest);
         assert!(filter.read(&mut ctx).is_err());
     }
 
@@ -305,7 +308,7 @@ mod tests {
         assert_write_no_change(&filter);
     }
 
-    fn new_ctx() -> ReadContext {
+    fn new_ctx<'ctx>(dest: &'ctx mut Vec<crate::net::EndpointAddress>) -> ReadContext<'ctx> {
         let endpoint1 = Endpoint::with_metadata(
             "127.0.0.1:80".parse().unwrap(),
             Metadata {
@@ -327,10 +330,11 @@ mod tests {
             endpoints.into(),
             "127.0.0.1:100".parse().unwrap(),
             pool.alloc_slice(b"hello"),
+            dest,
         )
     }
 
-    fn assert_read<F>(filter: &F, mut ctx: ReadContext)
+    fn assert_read<F>(filter: &F, mut ctx: ReadContext<'_>)
     where
         F: Filter + ?Sized,
     {

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -310,7 +310,7 @@ mod tests {
         assert_write_no_change(&filter);
     }
 
-    fn new_ctx<'ctx>(dest: &'ctx mut Vec<crate::net::EndpointAddress>) -> ReadContext<'ctx> {
+    fn new_ctx(dest: &mut Vec<crate::net::EndpointAddress>) -> ReadContext<'_> {
         let endpoint1 = Endpoint::with_metadata(
             "127.0.0.1:80".parse().unwrap(),
             Metadata {

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -286,6 +286,7 @@ mod tests {
         ctx.metadata
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"123".to_vec().into()));
         assert_read(&filter, ctx);
+        dest.clear();
 
         // invalid key
         let mut ctx = new_ctx(&mut dest);
@@ -293,6 +294,7 @@ mod tests {
             .insert(CAPTURED_BYTES.into(), Value::Bytes(b"567".to_vec().into()));
 
         assert!(filter.read(&mut ctx).is_err());
+        dest.clear();
 
         // no key
         let mut ctx = new_ctx(&mut dest);

--- a/src/net/cluster.rs
+++ b/src/net/cluster.rs
@@ -505,10 +505,10 @@ where
         ret
     }
 
-    pub fn addresses_for_token(&self, token: Token) -> Vec<EndpointAddress> {
-        self.token_map
-            .get(&token.0)
-            .map_or(Vec::new(), |addrs| addrs.value().to_vec())
+    pub fn addresses_for_token(&self, token: Token, addrs: &mut Vec<EndpointAddress>) {
+        if let Some(ma) = self.token_map.get(&token.0) {
+            addrs.extend(ma.value().into_iter().cloned());
+        }
     }
 }
 

--- a/src/net/cluster.rs
+++ b/src/net/cluster.rs
@@ -507,7 +507,7 @@ where
 
     pub fn addresses_for_token(&self, token: Token, addrs: &mut Vec<EndpointAddress>) {
         if let Some(ma) = self.token_map.get(&token.0) {
-            addrs.extend(ma.value().into_iter().cloned());
+            addrs.extend(ma.value().iter().cloned());
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -370,7 +370,9 @@ where
         .unwrap()]));
     let source = "127.0.0.1:90".parse().unwrap();
     let contents = b"hello";
-    let mut context = ReadContext::new(endpoints.clone(), source, alloc_buffer(contents));
+    let mut dest = Vec::new();
+    let mut context =
+        ReadContext::new(endpoints.clone(), source, alloc_buffer(contents), &mut dest);
 
     filter.read(&mut context).unwrap();
     assert!(context.destinations.is_empty());


### PR DESCRIPTION
This removes the unnecessary heap allocation for the destination address(es) for downstream packets by just making it a mutable reference that is passed from the packet router driver.