### PR TITLE
Remove async channels for pushing buffers to be sent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - name: Build
         run: cargo build -p qt -p quilkin -p quilkin-xds --tests
-      - run: cargo nextest run -p qt -p quilkin -p quilkin-xds quilkin
+      - run: cargo nextest run --no-tests=pass -p qt -p quilkin -p quilkin-xds quilkin
 
   build:
     name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,18 +143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,7 +2422,6 @@ dependencies = [
 name = "qt"
 version = "0.1.0"
 dependencies = [
- "async-channel",
  "once_cell",
  "quilkin",
  "rand",
@@ -2457,7 +2444,6 @@ name = "quilkin"
 version = "0.10.0-dev"
 dependencies = [
  "arc-swap",
- "async-channel",
  "async-stream",
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,6 @@ quilkin-proto.workspace = true
 
 # Crates.io
 arc-swap.workspace = true
-async-channel.workspace = true
 async-stream.workspace = true
 base64.workspace = true
 base64-serde = "0.8.0"
@@ -194,7 +193,6 @@ edition = "2021"
 
 [workspace.dependencies]
 arc-swap = { version = "1.7.1", features = ["serde"] }
-async-channel = "2.3.1"
 async-stream = "0.3.6"
 base64 = "0.22.1"
 cached = { version = "0.54", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ base64.workspace = true
 base64-serde = "0.8.0"
 bytes = { version = "1.8.0", features = ["serde"] }
 cached.workspace = true
+cfg-if = "1.0"
 crossbeam-utils = { version = "0.8", optional = true }
 clap = { version = "4.5.21", features = ["cargo", "derive", "env"] }
 dashmap = { version = "6.1", features = ["serde"] }
@@ -153,7 +154,6 @@ hickory-resolver = { version = "0.24", features = [
 async-trait = "0.1.83"
 strum = "0.26"
 strum_macros = "0.26"
-cfg-if = "1.0.0"
 libflate = "2.1.0"
 form_urlencoded = "1.2.1"
 enum_dispatch = "0.3.13"

--- a/crates/test/Cargo.toml
+++ b/crates/test/Cargo.toml
@@ -24,7 +24,6 @@ publish = false
 workspace = true
 
 [dependencies]
-async-channel.workspace = true
 once_cell.workspace = true
 quilkin.workspace = true
 rand.workspace = true

--- a/src/collections/ttl.rs
+++ b/src/collections/ttl.rs
@@ -55,11 +55,13 @@ impl<V> Value<V> {
     /// Get the expiration time for this value. The returned value is the
     /// number of seconds relative to some reference point (e.g UNIX_EPOCH), based
     /// on the clock being used.
+    #[inline]
     fn expiration_secs(&self) -> u64 {
         self.expires_at.load(Ordering::Relaxed)
     }
 
     /// Update the value's expiration time to (now + TTL).
+    #[inline]
     fn update_expiration(&self, ttl: Duration) {
         match self.clock.compute_expiration_secs(ttl) {
             Ok(new_expiration_time) => {
@@ -160,6 +162,7 @@ where
     /// Returns the current time as the number of seconds relative to some initial
     /// reference point (e.g UNIX_EPOCH), based on the clock implementation being used.
     /// In tests, this will be driven by [`tokio::time`]
+    #[inline]
     pub(crate) fn now_relative_secs(&self) -> u64 {
         self.0.clock.now_relative_secs().unwrap_or_default()
     }
@@ -235,6 +238,12 @@ where
     /// Removes a key-value pair from the map.
     pub fn remove(&self, key: K) -> bool {
         self.0.inner.remove(&key).is_some()
+    }
+
+    /// Removes all entries from the map
+    #[inline]
+    pub fn clear(&self) {
+        self.0.inner.clear();
     }
 
     /// Returns an entry for in-place updates of the specified key-value pair.

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -40,7 +40,7 @@ pub struct PendingSends {
 }
 
 impl PendingSends {
-    pub(crate) fn new(capacity: usize) -> std::io::Result<(Self, PacketSendReceiver)> {
+    pub fn new(capacity: usize) -> std::io::Result<(Self, PacketSendReceiver)> {
         #[cfg(target_os = "linux")]
         let (notify, rx) = {
             let rx = io_uring_shared::EventFd::new()?;

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -18,8 +18,79 @@ mod error;
 pub mod packet_router;
 mod sessions;
 
-#[cfg(target_os = "linux")]
-pub(crate) mod io_uring_shared;
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        pub(crate) mod io_uring_shared;
+        pub(crate) type PacketSendReceiver = io_uring_shared::EventFd;
+        pub(crate) type PacketSendSender = io_uring_shared::EventFdWriter;
+    } else {
+        pub(crate) type PacketSendReceiver = tokio::sync::watch::Receiver<bool>;
+        pub(crate) type PacketSendSender = tokio::sync::watch::Sender<bool>;
+    }
+}
+
+/// A simple packet queue that signals when a packet is pushed
+///
+/// For io_uring this notifies an eventfd that will be processed on the next
+/// completion loop
+#[derive(Clone)]
+pub struct PendingSends {
+    packets: Arc<parking_lot::Mutex<Vec<SendPacket>>>,
+    notify: PacketSendSender,
+}
+
+impl PendingSends {
+    pub(crate) fn new(capacity: usize) -> std::io::Result<(Self, PacketSendReceiver)> {
+        #[cfg(target_os = "linux")]
+        let (notify, rx) = {
+            let rx = io_uring_shared::EventFd::new()?;
+            (rx.writer(), rx)
+        };
+        #[cfg(not(target_os = "linux"))]
+        let (notify, rx) = tokio::sync::watch::channel(true);
+
+        Ok((
+            Self {
+                packets: Arc::new(parking_lot::Mutex::new(Vec::with_capacity(capacity))),
+                notify,
+            },
+            rx,
+        ))
+    }
+
+    #[inline]
+    pub(crate) fn capacity(&self) -> usize {
+        self.packets.lock().capacity()
+    }
+
+    /// Pushes a packet onto the queue to be sent, signalling a sender that
+    /// it's available
+    #[inline]
+    pub(crate) fn push(&self, packet: SendPacket) {
+        self.packets.lock().push(packet);
+        #[cfg(target_os = "linux")]
+        self.notify.write(1);
+        #[cfg(not(target_os = "linux"))]
+        let _ = self.notify.send(true);
+    }
+
+    /// Called to shutdown the consumer side of the sends (ie the io loop that is
+    /// actually dequing and sending packets)
+    #[inline]
+    pub(crate) fn shutdown_receiver(&self) {
+        #[cfg(target_os = "linux")]
+        self.notify.write(0xdeadbeef);
+        #[cfg(not(target_os = "linux"))]
+        let _ = self.notify.send(false);
+    }
+
+    /// Swaps the current queue with an empty one so we only lock for a pointer swap
+    #[inline]
+    pub fn swap(&self, mut swap: Vec<SendPacket>) -> Vec<SendPacket> {
+        swap.clear();
+        std::mem::replace(&mut self.packets.lock(), swap)
+    }
+}
 
 use super::RunArgs;
 pub use error::{ErrorMap, PipelineError};
@@ -33,8 +104,11 @@ use std::{
 };
 
 pub struct SendPacket {
-    pub destination: SocketAddr,
+    /// The destination address of the packet
+    pub destination: socket2::SockAddr,
+    /// The packet data being sent
     pub data: crate::pool::FrozenPoolBuffer,
+    /// The asn info for the sender, used for metrics
     pub asn_info: Option<crate::net::maxmind_db::MetricsIpNetEntry>,
 }
 
@@ -208,18 +282,6 @@ impl Proxy {
              ));
         }
 
-        let id = config.id.load();
-        let num_workers = self.num_workers.get();
-
-        let (upstream_sender, upstream_receiver) = async_channel::bounded(250);
-        let buffer_pool = Arc::new(crate::pool::BufferPool::new(num_workers, 64 * 1024));
-        let sessions = SessionPool::new(
-            config.clone(),
-            upstream_sender,
-            buffer_pool.clone(),
-            shutdown_rx.clone(),
-        );
-
         #[allow(clippy::type_complexity)]
         const SUBS: &[(&str, &[(&str, Vec<String>)])] = &[
             (
@@ -246,6 +308,8 @@ impl Proxy {
                 let check: Arc<AtomicBool> = <_>::default();
                 *lock = Some(check.clone());
             }
+
+            let id = config.id.load();
 
             std::thread::Builder::new()
                 .name("proxy-subscription".into())
@@ -291,14 +355,25 @@ impl Proxy {
                 .expect("failed to spawn proxy-subscription thread");
         }
 
-        let worker_notifications = packet_router::spawn_receivers(
+        let num_workers = self.num_workers.get();
+        let buffer_pool = Arc::new(crate::pool::BufferPool::new(num_workers, 2 * 1024));
+
+        let mut worker_sends = Vec::with_capacity(num_workers);
+        let mut session_sends = Vec::with_capacity(num_workers);
+        for _ in 0..num_workers {
+            let psends = PendingSends::new(15)?;
+            session_sends.push(psends.0.clone());
+            worker_sends.push(psends);
+        }
+
+        let sessions = SessionPool::new(config.clone(), session_sends, buffer_pool.clone());
+
+        packet_router::spawn_receivers(
             config.clone(),
             self.socket,
-            num_workers,
+            worker_sends,
             &sessions,
-            upstream_receiver,
             buffer_pool,
-            shutdown_rx.clone(),
         )
         .await?;
 
@@ -310,10 +385,6 @@ impl Proxy {
             crate::net::phoenix::Phoenix::new(crate::codec::qcmp::QcmpMeasurement::new()?),
         )?;
 
-        for notification in worker_notifications {
-            let _ = notification.recv();
-        }
-
         tracing::info!("Quilkin is ready");
         if let Some(initialized) = initialized {
             let _ = initialized.send(());
@@ -324,17 +395,7 @@ impl Proxy {
             .await
             .map_err(|error| eyre::eyre!(error))?;
 
-        if *shutdown_rx.borrow() == crate::ShutdownKind::Normal {
-            tracing::info!(sessions=%sessions.sessions().len(), "waiting for active sessions to expire");
-
-            let interval = std::time::Duration::from_millis(100);
-
-            while sessions.sessions().is_not_empty() {
-                tokio::time::sleep(interval).await;
-                tracing::debug!(sessions=%sessions.sessions().len(), "sessions still active");
-            }
-            tracing::info!("all sessions expired");
-        }
+        sessions.shutdown(*shutdown_rx.borrow() == crate::ShutdownKind::Normal);
 
         Ok(())
     }

--- a/src/components/proxy/io_uring_shared.rs
+++ b/src/components/proxy/io_uring_shared.rs
@@ -37,7 +37,7 @@ use std::{
 ///
 /// We use eventfd to signal to io uring loops from async tasks, it is essentially
 /// the equivalent of a signalling 64 bit cross-process atomic
-pub(crate) struct EventFd {
+pub struct EventFd {
     fd: std::os::fd::OwnedFd,
     val: u64,
 }

--- a/src/components/proxy/packet_router.rs
+++ b/src/components/proxy/packet_router.rs
@@ -129,7 +129,7 @@ impl DownstreamReceiveWorkerConfig {
 /// This function also spawns the set of worker tasks responsible for consuming packets
 /// off the aforementioned queue and processing them through the filter chain and session
 /// pipeline.
-pub(crate) async fn spawn_receivers(
+pub async fn spawn_receivers(
     config: Arc<Config>,
     socket: socket2::Socket,
     worker_sends: Vec<(super::PendingSends, super::PacketSendReceiver)>,

--- a/src/components/proxy/packet_router.rs
+++ b/src/components/proxy/packet_router.rs
@@ -14,10 +14,7 @@
  *  limitations under the License.
  */
 
-use super::{
-    sessions::{DownstreamReceiver, SessionKey},
-    PipelineError, SessionPool,
-};
+use super::{sessions::SessionKey, PipelineError, SessionPool};
 use crate::{
     filters::{Filter as _, ReadContext},
     metrics,
@@ -44,8 +41,6 @@ pub(crate) struct DownstreamPacket {
 pub struct DownstreamReceiveWorkerConfig {
     /// ID of the worker.
     pub worker_id: usize,
-    /// Socket with reused port from which the worker receives packets.
-    pub upstream_receiver: DownstreamReceiver,
     pub port: u16,
     pub config: Arc<Config>,
     pub sessions: Arc<SessionPool>,
@@ -134,24 +129,20 @@ impl DownstreamReceiveWorkerConfig {
 /// This function also spawns the set of worker tasks responsible for consuming packets
 /// off the aforementioned queue and processing them through the filter chain and session
 /// pipeline.
-pub async fn spawn_receivers(
+pub(crate) async fn spawn_receivers(
     config: Arc<Config>,
     socket: socket2::Socket,
-    num_workers: usize,
+    worker_sends: Vec<(super::PendingSends, super::PacketSendReceiver)>,
     sessions: &Arc<SessionPool>,
-    upstream_receiver: DownstreamReceiver,
     buffer_pool: Arc<crate::pool::BufferPool>,
-    shutdown: crate::ShutdownRx,
-) -> crate::Result<Vec<std::sync::mpsc::Receiver<()>>> {
+) -> crate::Result<()> {
     let (error_sender, mut error_receiver) = mpsc::channel(128);
 
     let port = crate::net::socket_port(&socket);
 
-    let mut worker_notifications = Vec::with_capacity(num_workers);
-    for worker_id in 0..num_workers {
+    for (worker_id, ws) in worker_sends.into_iter().enumerate() {
         let worker = DownstreamReceiveWorkerConfig {
             worker_id,
-            upstream_receiver: upstream_receiver.clone(),
             port,
             config: config.clone(),
             sessions: sessions.clone(),
@@ -159,7 +150,7 @@ pub async fn spawn_receivers(
             buffer_pool: buffer_pool.clone(),
         };
 
-        worker_notifications.push(worker.spawn(shutdown.clone()).await?);
+        worker.spawn(ws).await?;
     }
 
     drop(error_sender);
@@ -197,5 +188,5 @@ pub async fn spawn_receivers(
         }
     });
 
-    Ok(worker_notifications)
+    Ok(())
 }

--- a/src/components/proxy/packet_router/io_uring.rs
+++ b/src/components/proxy/packet_router/io_uring.rs
@@ -18,7 +18,7 @@ use crate::components::proxy;
 use eyre::Context as _;
 
 impl super::DownstreamReceiveWorkerConfig {
-    pub(crate) async fn spawn(
+    pub async fn spawn(
         self,
         pending_sends: (proxy::PendingSends, proxy::PacketSendReceiver),
     ) -> eyre::Result<()> {

--- a/src/components/proxy/packet_router/io_uring.rs
+++ b/src/components/proxy/packet_router/io_uring.rs
@@ -14,18 +14,18 @@
  *  limitations under the License.
  */
 
+use crate::components::proxy;
 use eyre::Context as _;
 
 impl super::DownstreamReceiveWorkerConfig {
-    pub async fn spawn(
+    pub(crate) async fn spawn(
         self,
-        shutdown: crate::ShutdownRx,
-    ) -> eyre::Result<std::sync::mpsc::Receiver<()>> {
+        pending_sends: (proxy::PendingSends, proxy::PacketSendReceiver),
+    ) -> eyre::Result<()> {
         use crate::components::proxy::io_uring_shared;
 
         let Self {
             worker_id,
-            upstream_receiver,
             port,
             config,
             sessions,
@@ -47,9 +47,8 @@ impl super::DownstreamReceiveWorkerConfig {
                     worker_id,
                     destinations: Vec::with_capacity(1),
                 },
-                io_uring_shared::PacketReceiver::Router(upstream_receiver),
+                pending_sends,
                 buffer_pool,
-                shutdown,
             )
             .context("failed to spawn io-uring loop")
     }

--- a/src/components/proxy/sessions.rs
+++ b/src/components/proxy/sessions.rs
@@ -18,38 +18,38 @@ use std::{
     collections::{HashMap, HashSet},
     fmt,
     net::SocketAddr,
-    sync::Arc,
+    sync::{atomic, Arc},
     time::Duration,
 };
 
-use tokio::{sync::mpsc, time::Instant};
+use tokio::time::Instant;
 
 use crate::{
-    components::proxy::{PipelineError, SendPacket},
+    components::proxy::SendPacket,
     config::Config,
     filters::Filter,
     metrics,
     net::maxmind_db::{IpNetEntry, MetricsIpNetEntry},
     pool::{BufferPool, FrozenPoolBuffer, PoolBuffer},
     time::UtcTimestamp,
-    Loggable, ShutdownRx,
+    Loggable,
 };
 
 use parking_lot::RwLock;
+
+use super::PendingSends;
 
 pub(crate) mod inner_metrics;
 
 pub type SessionMap = crate::collections::ttl::TtlMap<SessionKey, Session>;
 
-#[cfg(target_os = "linux")]
-mod io_uring;
-#[cfg(not(target_os = "linux"))]
-mod reference;
-
-type UpstreamSender = mpsc::Sender<super::SendPacket>;
-
-type DownstreamSender = async_channel::Sender<super::SendPacket>;
-pub type DownstreamReceiver = async_channel::Receiver<super::SendPacket>;
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        mod io_uring;
+    } else {
+        mod reference;
+    }
+}
 
 #[derive(PartialEq, Eq, Hash)]
 pub enum SessionError {
@@ -90,13 +90,13 @@ impl fmt::Debug for SessionError {
 /// Traffic from different gameservers is then demuxed using their address to
 /// send back to the original client.
 pub struct SessionPool {
-    ports_to_sockets: RwLock<HashMap<u16, UpstreamSender>>,
+    ports_to_sockets: RwLock<HashMap<u16, PendingSends>>,
     storage: Arc<RwLock<SocketStorage>>,
     session_map: SessionMap,
-    downstream_sender: DownstreamSender,
     buffer_pool: Arc<BufferPool>,
-    shutdown_rx: ShutdownRx,
     config: Arc<Config>,
+    downstream_sends: Vec<PendingSends>,
+    downstream_index: atomic::AtomicUsize,
 }
 
 /// The wrapper struct responsible for holding all of the socket related mappings.
@@ -114,21 +114,20 @@ impl SessionPool {
     /// to release their sockets back to the parent.
     pub fn new(
         config: Arc<Config>,
-        downstream_sender: DownstreamSender,
+        downstream_sends: Vec<PendingSends>,
         buffer_pool: Arc<BufferPool>,
-        shutdown_rx: ShutdownRx,
     ) -> Arc<Self> {
         const SESSION_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
         const SESSION_EXPIRY_POLL_INTERVAL: Duration = Duration::from_secs(60);
 
         Arc::new(Self {
             config,
-            downstream_sender,
-            shutdown_rx,
             ports_to_sockets: <_>::default(),
             storage: <_>::default(),
             session_map: SessionMap::new(SESSION_TIMEOUT_SECONDS, SESSION_EXPIRY_POLL_INTERVAL),
             buffer_pool,
+            downstream_sends,
+            downstream_index: atomic::AtomicUsize::new(0),
         })
     }
 
@@ -136,7 +135,7 @@ impl SessionPool {
     fn create_new_session_from_new_socket<'pool>(
         self: &'pool Arc<Self>,
         key: SessionKey,
-    ) -> Result<(Option<MetricsIpNetEntry>, UpstreamSender), super::PipelineError> {
+    ) -> Result<(Option<MetricsIpNetEntry>, PendingSends), super::PipelineError> {
         tracing::trace!(source=%key.source, dest=%key.dest, "creating new socket for session");
         let raw_socket = crate::net::raw_socket_with_reuse(0)?;
         let port = raw_socket
@@ -144,19 +143,15 @@ impl SessionPool {
             .as_socket()
             .ok_or(SessionError::SocketAddressUnavailable)?
             .port();
-        let (downstream_sender, downstream_receiver) = mpsc::channel::<super::SendPacket>(15);
 
-        let initialised = self
-            .clone()
-            .spawn_session(raw_socket, port, downstream_receiver)?;
-        initialised
-            .recv()
-            .map_err(|_err| PipelineError::ChannelClosed)?;
+        let (pending_sends, srecv) = super::PendingSends::new(15)?;
+        self.clone()
+            .spawn_session(raw_socket, port, (pending_sends.clone(), srecv))?;
 
         self.ports_to_sockets
             .write()
-            .insert(port, downstream_sender.clone());
-        self.create_session_from_existing_socket(key, downstream_sender, port)
+            .insert(port, pending_sends.clone());
+        self.create_session_from_existing_socket(key, pending_sends, port)
     }
 
     pub(crate) fn process_received_upstream_packet(
@@ -192,7 +187,6 @@ impl SessionPool {
             let _timer = metrics::processing_time(metrics::WRITE).start_timer();
             Self::process_recv_packet(
                 self.config.clone(),
-                &self.downstream_sender,
                 recv_addr,
                 downstream_addr,
                 asn_info,
@@ -200,13 +194,25 @@ impl SessionPool {
             )
         };
 
-        if let Err((asn_info, error)) = result {
-            error.log();
-            let label = format!("proxy::Session::process_recv_packet: {error}");
-            let asn_metric_info = asn_info.as_ref().into();
+        match result {
+            Ok(packet) => {
+                let index = self
+                    .downstream_index
+                    .fetch_add(1, atomic::Ordering::Relaxed)
+                    % self.downstream_sends.len();
+                // SAFETY: we've ensured it's within bounds via the %
+                unsafe {
+                    self.downstream_sends.get_unchecked(index).push(packet);
+                }
+            }
+            Err((asn_info, error)) => {
+                error.log();
+                let label = format!("proxy::Session::process_recv_packet: {error}");
+                let asn_metric_info = asn_info.as_ref().into();
 
-            metrics::packets_dropped_total(metrics::WRITE, &label, &asn_metric_info).inc();
-            metrics::errors_total(metrics::WRITE, &label, &asn_metric_info).inc();
+                metrics::packets_dropped_total(metrics::WRITE, &label, &asn_metric_info).inc();
+                metrics::errors_total(metrics::WRITE, &label, &asn_metric_info).inc();
+            }
         }
     }
 
@@ -217,14 +223,14 @@ impl SessionPool {
     pub fn get<'pool>(
         self: &'pool Arc<Self>,
         key @ SessionKey { dest, .. }: SessionKey,
-    ) -> Result<(Option<MetricsIpNetEntry>, UpstreamSender), super::PipelineError> {
+    ) -> Result<(Option<MetricsIpNetEntry>, PendingSends), super::PipelineError> {
         tracing::trace!(source=%key.source, dest=%key.dest, "SessionPool::get");
         // If we already have a session for the key pairing, return that session.
         if let Some(entry) = self.session_map.get(&key) {
             tracing::trace!("returning existing session");
             return Ok((
                 entry.asn_info.as_ref().map(MetricsIpNetEntry::from),
-                entry.upstream_sender.clone(),
+                entry.pending_sends.clone(),
             ));
         }
 
@@ -278,9 +284,9 @@ impl SessionPool {
     fn create_session_from_existing_socket<'session>(
         self: &'session Arc<Self>,
         key: SessionKey,
-        upstream_sender: UpstreamSender,
+        pending_sends: PendingSends,
         socket_port: u16,
-    ) -> Result<(Option<MetricsIpNetEntry>, UpstreamSender), super::PipelineError> {
+    ) -> Result<(Option<MetricsIpNetEntry>, PendingSends), super::PipelineError> {
         tracing::trace!(source=%key.source, dest=%key.dest, "reusing socket for session");
         let asn_info = {
             let mut storage = self.storage.write();
@@ -313,7 +319,7 @@ impl SessionPool {
 
         let session = Session::new(
             key,
-            upstream_sender.clone(),
+            pending_sends.clone(),
             socket_port,
             self.clone(),
             asn_info,
@@ -321,18 +327,17 @@ impl SessionPool {
         tracing::trace!("inserting session into map");
         self.session_map.insert(key, session);
         tracing::trace!("session inserted");
-        Ok((asn_metrics_info, upstream_sender))
+        Ok((asn_metrics_info, pending_sends))
     }
 
     /// process_recv_packet processes a packet that is received by this session.
     fn process_recv_packet(
         config: Arc<crate::Config>,
-        downstream_sender: &DownstreamSender,
         source: SocketAddr,
         dest: SocketAddr,
         asn_info: Option<MetricsIpNetEntry>,
         packet: PoolBuffer,
-    ) -> Result<(), (Option<MetricsIpNetEntry>, Error)> {
+    ) -> Result<SendPacket, (Option<MetricsIpNetEntry>, Error)> {
         tracing::trace!(%source, %dest, length = packet.len(), "received packet from upstream");
 
         let mut context = crate::filters::WriteContext::new(source.into(), dest.into(), packet);
@@ -341,21 +346,11 @@ impl SessionPool {
             return Err((asn_info, err.into()));
         }
 
-        let packet = context.contents.freeze();
-        tracing::trace!(%source, %dest, length = packet.len(), "sending packet downstream");
-        downstream_sender
-            .try_send(SendPacket {
-                data: packet,
-                destination: dest,
-                asn_info,
-            })
-            .map_err(|error| match error {
-                async_channel::TrySendError::Closed(packet) => {
-                    (packet.asn_info, Error::ChannelClosed)
-                }
-                async_channel::TrySendError::Full(packet) => (packet.asn_info, Error::ChannelFull),
-            })?;
-        Ok(())
+        Ok(SendPacket {
+            data: context.contents.freeze(),
+            destination: dest.into(),
+            asn_info,
+        })
     }
 
     /// Returns a map of active sessions.
@@ -364,25 +359,30 @@ impl SessionPool {
     }
 
     /// Sends packet data to the appropiate session based on its `key`.
+    #[inline]
     pub fn send(
         self: &Arc<Self>,
         key: SessionKey,
         packet: FrozenPoolBuffer,
     ) -> Result<(), super::PipelineError> {
-        use tokio::sync::mpsc::error::TrySendError;
+        self.send_inner(key, packet)?;
+        Ok(())
+    }
 
+    #[inline]
+    fn send_inner(
+        self: &Arc<Self>,
+        key: SessionKey,
+        packet: FrozenPoolBuffer,
+    ) -> Result<PendingSends, super::PipelineError> {
         let (asn_info, sender) = self.get(key)?;
 
-        sender
-            .try_send(crate::components::proxy::SendPacket {
-                data: packet,
-                asn_info,
-                destination: key.dest,
-            })
-            .map_err(|error| match error {
-                TrySendError::Closed(_) => super::PipelineError::ChannelClosed,
-                TrySendError::Full(_) => super::PipelineError::ChannelFull,
-            })
+        sender.push(SendPacket {
+            destination: key.dest.into(),
+            data: packet,
+            asn_info,
+        });
+        Ok(sender)
     }
 
     /// Returns whether the pool contains any sockets allocated to a destination.
@@ -405,7 +405,7 @@ impl SessionPool {
     }
 
     /// Handles the logic of releasing a socket back into the pool.
-    async fn release_socket(
+    fn release_socket(
         self: Arc<Self>,
         SessionKey {
             ref source,
@@ -440,11 +440,28 @@ impl SessionPool {
         storage.destination_to_sources.remove(&(*dest, port));
         tracing::trace!("socket released");
     }
+
+    /// Closes all active sessions, and all downstream listeners
+    pub(crate) fn shutdown(self: Arc<Self>, wait: bool) {
+        // Disable downstream listeners first so sessions aren't spawned while
+        // we are trying to reap the active sessions
+        for downstream_listener in &self.downstream_sends {
+            downstream_listener.shutdown_receiver();
+        }
+
+        if wait && !self.session_map.is_empty() {
+            tracing::info!(sessions=%self.session_map.len(), "waiting for active sessions to expire");
+            self.session_map.clear();
+        }
+    }
 }
 
 impl Drop for SessionPool {
     fn drop(&mut self) {
-        drop(std::mem::take(&mut self.session_map));
+        let map = std::mem::take(&mut self.session_map);
+        std::thread::spawn(move || {
+            drop(map);
+        });
     }
 }
 
@@ -456,8 +473,8 @@ pub struct Session {
     key: SessionKey,
     /// The socket port of the session.
     socket_port: u16,
-    /// The socket of the session.
-    upstream_sender: UpstreamSender,
+    /// The queue of packets being sent to the upstream (server)
+    pending_sends: PendingSends,
     /// The GeoIP information of the source.
     asn_info: Option<IpNetEntry>,
     /// The socket pool of the session.
@@ -467,14 +484,14 @@ pub struct Session {
 impl Session {
     pub fn new(
         key: SessionKey,
-        upstream_sender: UpstreamSender,
+        pending_sends: PendingSends,
         socket_port: u16,
         pool: Arc<SessionPool>,
         asn_info: Option<IpNetEntry>,
     ) -> Self {
         let s = Self {
             key,
-            upstream_sender,
+            pending_sends,
             pool,
             socket_port,
             asn_info,
@@ -503,17 +520,18 @@ impl Session {
         inner_metrics::active_sessions(self.asn_info.as_ref())
     }
 
-    fn async_drop(&mut self) -> impl std::future::Future<Output = ()> {
+    fn release(&mut self) {
         self.active_session_metric().dec();
         inner_metrics::duration_secs().observe(self.created_at.elapsed().as_secs() as f64);
         tracing::debug!(source = %self.key.source, dest_address = %self.key.dest, "Session closed");
-        SessionPool::release_socket(self.pool.clone(), self.key, self.socket_port)
+        self.pending_sends.shutdown_receiver();
+        SessionPool::release_socket(self.pool.clone(), self.key, self.socket_port);
     }
 }
 
 impl Drop for Session {
     fn drop(&mut self) {
-        tokio::spawn(self.async_drop());
+        self.release()
     }
 }
 
@@ -532,10 +550,6 @@ impl From<(SocketAddr, SocketAddr)> for SessionKey {
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("downstream channel closed")]
-    ChannelClosed,
-    #[error("downstream channel full")]
-    ChannelFull,
     #[error("filter {0}")]
     Filter(#[from] crate::filters::FilterError),
 }
@@ -550,30 +564,24 @@ impl Loggable for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        test::{alloc_buffer, available_addr, AddressType, TestHelper},
-        ShutdownTx,
-    };
+    use crate::test::{alloc_buffer, available_addr, AddressType, TestHelper};
     use std::sync::Arc;
 
-    async fn new_pool() -> (Arc<SessionPool>, ShutdownTx, DownstreamReceiver) {
-        let (tx, rx) = crate::make_shutdown_channel(crate::ShutdownKind::Testing);
-        let (sender, receiver) = async_channel::unbounded();
+    async fn new_pool() -> (Arc<SessionPool>, PendingSends) {
+        let (pending_sends, _srecv) = PendingSends::new(1).unwrap();
         (
             SessionPool::new(
                 Arc::new(Config::default_agent()),
-                sender,
+                vec![pending_sends.clone()],
                 Arc::new(BufferPool::default()),
-                rx,
             ),
-            tx,
-            receiver,
+            pending_sends,
         )
     }
 
     #[tokio::test]
     async fn insert_and_release_single_socket() {
-        let (pool, _sender, _receiver) = new_pool().await;
+        let (pool, _receiver) = new_pool().await;
         let key = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -589,7 +597,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_and_release_multiple_sockets() {
-        let (pool, _sender, _receiver) = new_pool().await;
+        let (pool, _receiver) = new_pool().await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -614,7 +622,7 @@ mod tests {
 
     #[tokio::test]
     async fn same_address_uses_different_sockets() {
-        let (pool, _sender, _receiver) = new_pool().await;
+        let (pool, _receiver) = new_pool().await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -639,7 +647,7 @@ mod tests {
 
     #[tokio::test]
     async fn different_addresses_uses_same_socket() {
-        let (pool, _sender, _receiver) = new_pool().await;
+        let (pool, _receiver) = new_pool().await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -662,7 +670,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_safe_same_destination() {
-        let (pool, _sender, _receiver) = new_pool().await;
+        let (pool, _receiver) = new_pool().await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -687,7 +695,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_safe_different_destination() {
-        let (pool, _sender, _receiver) = new_pool().await;
+        let (pool, _receiver) = new_pool().await;
         let key1 = (
             (std::net::Ipv4Addr::LOCALHOST, 8080u16).into(),
             (std::net::Ipv4Addr::UNSPECIFIED, 8080u16).into(),
@@ -721,18 +729,14 @@ mod tests {
         let socket = tokio::net::UdpSocket::bind(source).await.unwrap();
         let mut source = socket.local_addr().unwrap();
         crate::test::map_addr_to_localhost(&mut source);
-        let (pool, _sender, receiver) = new_pool().await;
+        let (pool, _pending_sends) = new_pool().await;
 
         let key: SessionKey = (source, dest).into();
         let msg = b"helloworld";
 
-        pool.send(key, alloc_buffer(msg).freeze()).unwrap();
+        let pending = pool.send_inner(key, alloc_buffer(msg).freeze()).unwrap();
+        let pending = pending.swap(Vec::new());
 
-        let packet = tokio::time::timeout(std::time::Duration::from_secs(1), receiver.recv())
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert_eq!(msg, &*packet.data);
+        assert_eq!(msg, &*pending[0].data);
     }
 }

--- a/src/components/proxy/sessions/io_uring.rs
+++ b/src/components/proxy/sessions/io_uring.rs
@@ -14,6 +14,7 @@
  *  limitations under the License.
  */
 
+use crate::components::proxy;
 use std::sync::Arc;
 
 static SESSION_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
@@ -23,9 +24,9 @@ impl super::SessionPool {
         self: Arc<Self>,
         raw_socket: socket2::Socket,
         port: u16,
-        downstream_receiver: tokio::sync::mpsc::Receiver<crate::components::proxy::SendPacket>,
-    ) -> Result<std::sync::mpsc::Receiver<()>, crate::components::proxy::PipelineError> {
-        use crate::components::proxy::io_uring_shared;
+        pending_sends: (proxy::PendingSends, proxy::io_uring_shared::EventFd),
+    ) -> Result<(), proxy::PipelineError> {
+        use proxy::io_uring_shared;
 
         let pool = self;
         let id = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -36,14 +37,12 @@ impl super::SessionPool {
             crate::net::DualStackLocalSocket::from_raw(raw_socket),
         )?;
         let buffer_pool = pool.buffer_pool.clone();
-        let shutdown = pool.shutdown_rx.clone();
 
         io_loop.spawn(
             format!("session-{id}"),
             io_uring_shared::PacketProcessorCtx::SessionPool { pool, port },
-            io_uring_shared::PacketReceiver::SessionPool(downstream_receiver),
+            pending_sends,
             buffer_pool,
-            shutdown,
         )
     }
 }

--- a/src/components/proxy/sessions/reference.rs
+++ b/src/components/proxy/sessions/reference.rs
@@ -14,20 +14,21 @@
  *  limitations under the License.
  */
 
+use crate::components::proxy;
+
 impl super::SessionPool {
     pub(super) fn spawn_session(
         self: std::sync::Arc<Self>,
         raw_socket: socket2::Socket,
         port: u16,
-        mut downstream_receiver: tokio::sync::mpsc::Receiver<crate::components::proxy::SendPacket>,
-    ) -> Result<std::sync::mpsc::Receiver<()>, crate::components::proxy::PipelineError> {
+        pending_sends: (proxy::PendingSends, proxy::PacketSendReceiver),
+    ) -> Result<(), proxy::PipelineError> {
         let pool = self;
 
-        let rx = uring_spawn!(
+        uring_spawn!(
             uring_span!(tracing::debug_span!("session pool")),
             async move {
                 let mut last_received_at = None;
-                let mut shutdown_rx = pool.shutdown_rx.clone();
 
                 let socket =
                     std::sync::Arc::new(crate::net::DualStackLocalSocket::from_raw(raw_socket));
@@ -35,54 +36,48 @@ impl super::SessionPool {
                 let (tx, mut rx) = tokio::sync::oneshot::channel();
 
                 uring_inner_spawn!(async move {
-                    loop {
-                        match downstream_receiver.recv().await {
-                            None => {
-                                crate::metrics::errors_total(
-                                    crate::metrics::WRITE,
-                                    "downstream channel closed",
-                                    &crate::metrics::EMPTY,
-                                )
-                                .inc();
-                                break;
-                            }
-                            Some(crate::components::proxy::SendPacket {
-                                destination,
-                                data,
-                                asn_info,
-                            }) => {
-                                tracing::trace!(%destination, length = data.len(), "sending packet upstream");
-                                let (result, _) = socket2.send_to(data, destination).await;
-                                let asn_info = asn_info.as_ref().into();
-                                match result {
-                                    Ok(size) => {
-                                        crate::metrics::packets_total(
-                                            crate::metrics::READ,
-                                            &asn_info,
-                                        )
+                    let (pending_sends, mut sends_rx) = pending_sends;
+                    let mut sends_double_buffer = Vec::with_capacity(pending_sends.capacity());
+
+                    while sends_rx.changed().await.is_ok() {
+                        if !*sends_rx.borrow() {
+                            tracing::trace!("io loop shutdown requested");
+                            break;
+                        }
+
+                        sends_double_buffer = pending_sends.swap(sends_double_buffer);
+
+                        for packet in sends_double_buffer.drain(..sends_double_buffer.len()) {
+                            let destination = packet.destination.as_socket().unwrap();
+                            tracing::trace!(
+                                %destination,
+                                length = packet.data.len(),
+                                "sending packet upstream"
+                            );
+                            let (result, _) = socket2.send_to(packet.data, destination).await;
+                            let asn_info = packet.asn_info.as_ref().into();
+                            match result {
+                                Ok(size) => {
+                                    crate::metrics::packets_total(crate::metrics::READ, &asn_info)
                                         .inc();
-                                        crate::metrics::bytes_total(
-                                            crate::metrics::READ,
-                                            &asn_info,
-                                        )
+                                    crate::metrics::bytes_total(crate::metrics::READ, &asn_info)
                                         .inc_by(size as u64);
-                                    }
-                                    Err(error) => {
-                                        tracing::trace!(%error, "sending packet upstream failed");
-                                        let source = error.to_string();
-                                        crate::metrics::errors_total(
-                                            crate::metrics::READ,
-                                            &source,
-                                            &asn_info,
-                                        )
-                                        .inc();
-                                        crate::metrics::packets_dropped_total(
-                                            crate::metrics::READ,
-                                            &source,
-                                            &asn_info,
-                                        )
-                                        .inc();
-                                    }
+                                }
+                                Err(error) => {
+                                    tracing::trace!(%error, "sending packet upstream failed");
+                                    let source = error.to_string();
+                                    crate::metrics::errors_total(
+                                        crate::metrics::READ,
+                                        &source,
+                                        &asn_info,
+                                    )
+                                    .inc();
+                                    crate::metrics::packets_dropped_total(
+                                        crate::metrics::READ,
+                                        &source,
+                                        &asn_info,
+                                    )
+                                    .inc();
                                 }
                             }
                         }
@@ -104,10 +99,6 @@ impl super::SessionPool {
                                 Ok((_size, recv_addr)) => pool.process_received_upstream_packet(buf, recv_addr, port, &mut last_received_at),
                             }
                         }
-                        _ = shutdown_rx.changed() => {
-                            tracing::debug!("Closing upstream socket loop");
-                            return;
-                        }
                         _ = &mut rx => {
                             tracing::debug!("Closing upstream socket loop, downstream closed");
                             return;
@@ -117,6 +108,6 @@ impl super::SessionPool {
             }
         );
 
-        Ok(rx)
+        Ok(())
     }
 }


### PR DESCRIPTION
This makes it so that enqueuing buffers to be sent is now done with `PendingSends` for both io-uring and tokio implementations. This means io-uring no longer needs its own tokio runtime just to drive the channel futures to transition back to sync code. Instead of a single downstream channel that can be picked up by any receiver, the sessionpool now just has a vector of pending sends that it round robins between to spread out downstream sends.

Since I wanted to remove the tokio runtime from the io-uring thread, this also meant I needed to figure out a way to get rid of the shutdown receiver that was also async, so since all loops have a `PendingSends` now, I just made it so that you can signal the thread that is the receiver for the pending sends to shutdown, consolidating things a bit.