### PR TITLE
refactor: Make DownstreamPacket sans-io

### DIFF
--- a/src/components/proxy/io_uring_shared.rs
+++ b/src/components/proxy/io_uring_shared.rs
@@ -249,14 +249,7 @@ fn process_packet(
                 source: packet.source,
             };
 
-            crate::components::proxy::packet_router::DownstreamReceiveWorkerConfig::process_task(
-                ds_packet,
-                *worker_id,
-                config,
-                sessions,
-                error_acc,
-                destinations,
-            );
+            ds_packet.process(*worker_id, config, sessions, error_acc, destinations);
         }
         PacketProcessorCtx::SessionPool { pool, port, .. } => {
             let mut last_received_at = None;

--- a/src/components/proxy/packet_router.rs
+++ b/src/components/proxy/packet_router.rs
@@ -14,12 +14,13 @@
  *  limitations under the License.
  */
 
-use super::{sessions::SessionKey, PipelineError, SessionPool};
+use super::{
+    sessions::{SessionKey, SessionManager},
+    PipelineError, SessionPool,
+};
 use crate::{
     filters::{Filter as _, ReadContext},
-    metrics,
-    pool::PoolBuffer,
-    Config,
+    metrics, Config,
 };
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::mpsc;
@@ -29,44 +30,64 @@ mod io_uring;
 #[cfg(not(target_os = "linux"))]
 mod reference;
 
+/// Representation of an immutable set of bytes pulled from the network, this trait
+/// provides an abstraction over however the packet was received (epoll, io-uring, xdp)
+///
+/// Use [PacketMut] if you need a mutable representation.
+pub trait Packet: Sized {
+    /// Returns the underlying slice of bytes representing the packet.
+    fn as_slice(&self) -> &[u8];
+
+    /// Returns the size of the packet.
+    fn len(&self) -> usize;
+
+    /// Returns whether the given packet is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Representation of an mutable set of bytes pulled from the network, this trait
+/// provides an abstraction over however the packet was received (epoll, io-uring, xdp)
+pub trait PacketMut: Sized + Packet {
+    type FrozenPacket: Packet;
+    fn alloc_sized(&self, size: usize) -> Option<Self>;
+    fn as_mut_slice(&mut self) -> &mut [u8];
+    fn set_len(&mut self, len: usize);
+    fn remove_head(&mut self, length: usize);
+    fn remove_tail(&mut self, length: usize);
+    fn extend_head(&mut self, bytes: &[u8]);
+    fn extend_tail(&mut self, bytes: &[u8]);
+    /// Returns an immutable version of the packet, this allows certain types
+    /// return a type that can be more cheaply cloned and shared.
+    fn freeze(self) -> Self::FrozenPacket;
+}
+
 /// Packet received from local port
-pub(crate) struct DownstreamPacket {
-    pub(crate) contents: PoolBuffer,
-    //received_at: UtcTimestamp,
+pub(crate) struct DownstreamPacket<P> {
+    pub(crate) contents: P,
     pub(crate) source: SocketAddr,
 }
 
-/// Represents the required arguments to run a worker task that
-/// processes packets received downstream.
-pub struct DownstreamReceiveWorkerConfig {
-    /// ID of the worker.
-    pub worker_id: usize,
-    pub port: u16,
-    pub config: Arc<Config>,
-    pub sessions: Arc<SessionPool>,
-    pub error_sender: super::error::ErrorSender,
-    pub buffer_pool: Arc<crate::pool::BufferPool>,
-}
-
-impl DownstreamReceiveWorkerConfig {
+impl<P: PacketMut> DownstreamPacket<P> {
     #[inline]
-    pub(crate) fn process_task(
-        packet: DownstreamPacket,
+    pub(crate) fn process<S: SessionManager<Packet = P::FrozenPacket>>(
+        self,
         worker_id: usize,
         config: &Arc<Config>,
-        sessions: &Arc<SessionPool>,
+        sessions: &S,
         error_acc: &mut super::error::ErrorAccumulator,
         destinations: &mut Vec<crate::net::EndpointAddress>,
     ) {
         tracing::trace!(
             id = worker_id,
-            size = packet.contents.len(),
-            source = %packet.source,
+            size = self.contents.len(),
+            source = %self.source,
             "received packet from downstream"
         );
 
         let timer = metrics::processing_time(metrics::READ).start_timer();
-        match Self::process_downstream_received_packet(packet, config, sessions, destinations) {
+        match self.process_inner(config, sessions, destinations) {
             Ok(()) => {
                 error_acc.maybe_send();
             }
@@ -84,10 +105,10 @@ impl DownstreamReceiveWorkerConfig {
 
     /// Processes a packet by running it through the filter chain.
     #[inline]
-    fn process_downstream_received_packet(
-        packet: DownstreamPacket,
+    fn process_inner<S: SessionManager<Packet = P::FrozenPacket>>(
+        self,
         config: &Arc<Config>,
-        sessions: &Arc<SessionPool>,
+        sessions: &S,
         destinations: &mut Vec<crate::net::EndpointAddress>,
     ) -> Result<(), PipelineError> {
         if !config.clusters.read().has_endpoints() {
@@ -97,8 +118,7 @@ impl DownstreamReceiveWorkerConfig {
 
         let cm = config.clusters.clone_value();
         let filters = config.filters.load();
-        let mut context =
-            ReadContext::new(&cm, packet.source.into(), packet.contents, destinations);
+        let mut context = ReadContext::new(&cm, self.source.into(), self.contents, destinations);
         filters.read(&mut context).map_err(PipelineError::Filter)?;
 
         let ReadContext { contents, .. } = context;
@@ -110,15 +130,27 @@ impl DownstreamReceiveWorkerConfig {
 
         for epa in destinations.drain(0..) {
             let session_key = SessionKey {
-                source: packet.source,
+                source: self.source,
                 dest: epa.to_socket_addr()?,
             };
 
-            sessions.send(session_key, contents.clone())?;
+            sessions.send(session_key, &contents)?;
         }
 
         Ok(())
     }
+}
+
+/// Represents the required arguments to run a worker task that
+/// processes packets received downstream.
+pub struct DownstreamReceiveWorkerConfig {
+    /// ID of the worker.
+    pub worker_id: usize,
+    pub port: u16,
+    pub config: Arc<Config>,
+    pub sessions: Arc<SessionPool>,
+    pub error_sender: super::error::ErrorSender,
+    pub buffer_pool: Arc<crate::pool::BufferPool>,
 }
 
 /// Spawns a background task that sits in a loop, receiving packets from the passed in socket.

--- a/src/components/proxy/packet_router/reference.rs
+++ b/src/components/proxy/packet_router/reference.rs
@@ -128,8 +128,7 @@ impl super::DownstreamReceiveWorkerConfig {
                                 }
                                 last_received_at = Some(received_at);
 
-                                Self::process_task(
-                                    packet,
+                                packet.process(
                                     worker_id,
                                     &config,
                                     &sessions,

--- a/src/config/slot.rs
+++ b/src/config/slot.rs
@@ -194,14 +194,14 @@ impl<T: JsonSchema + Default> JsonSchema for Slot<T> {
 }
 
 impl<T: crate::filters::Filter + Default> crate::filters::Filter for Slot<T> {
-    fn read<P: crate::filters::Packet>(
+    fn read<P: crate::filters::PacketMut>(
         &self,
         ctx: &mut ReadContext<'_, P>,
     ) -> Result<(), FilterError> {
         self.load().read(ctx)
     }
 
-    fn write<P: crate::filters::Packet>(
+    fn write<P: crate::filters::PacketMut>(
         &self,
         ctx: &mut WriteContext<P>,
     ) -> Result<(), FilterError> {

--- a/src/filters/capture.rs
+++ b/src/filters/capture.rs
@@ -58,7 +58,7 @@ impl Capture {
 
 impl Filter for Capture {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         let capture = self.capture.capture(ctx.contents.as_slice());
         ctx.metadata.insert(
             self.is_present_key,

--- a/src/filters/chain.rs
+++ b/src/filters/chain.rs
@@ -273,7 +273,7 @@ impl schemars::JsonSchema for FilterChain {
 }
 
 impl Filter for FilterChain {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         for ((id, instance), histogram) in self
             .filters
             .iter()
@@ -303,7 +303,7 @@ impl Filter for FilterChain {
         Ok(())
     }
 
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         for ((id, instance), histogram) in self
             .filters
             .iter()

--- a/src/filters/compress.rs
+++ b/src/filters/compress.rs
@@ -53,7 +53,7 @@ impl Compress {
 
 impl Filter for Compress {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         let original_size = ctx.contents.as_slice().len();
 
         match self.on_read {
@@ -96,7 +96,7 @@ impl Filter for Compress {
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         let original_size = ctx.contents.as_slice().len();
         match self.on_write {
             Action::Compress => match self.compressor.encode(&ctx.contents) {

--- a/src/filters/compress/compressor.rs
+++ b/src/filters/compress/compressor.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::filters::Packet;
+use crate::filters::PacketMut;
 use parking_lot::Mutex;
 use std::io;
 
@@ -30,7 +30,7 @@ pub enum Compressor {
 }
 
 impl Compressor {
-    pub fn encode<P: Packet>(&self, contents: &P) -> io::Result<P> {
+    pub fn encode<P: PacketMut>(&self, contents: &P) -> io::Result<P> {
         let input = contents.as_slice();
         let encoded = match self {
             Self::Snappy(imp) => {
@@ -80,7 +80,7 @@ impl Compressor {
         Ok(encoded)
     }
 
-    pub fn decode<P: Packet>(&self, contents: &P) -> io::Result<P> {
+    pub fn decode<P: PacketMut>(&self, contents: &P) -> io::Result<P> {
         let input = contents.as_slice();
         let decoded = match self {
             Self::Snappy(_imp) => {

--- a/src/filters/concatenate.rs
+++ b/src/filters/concatenate.rs
@@ -43,7 +43,7 @@ impl Concatenate {
 }
 
 impl Filter for Concatenate {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         match self.on_read {
             Strategy::Append => {
                 ctx.contents.extend_tail(&self.bytes);
@@ -57,7 +57,7 @@ impl Filter for Concatenate {
         Ok(())
     }
 
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         match self.on_write {
             Strategy::Append => {
                 ctx.contents.extend_tail(&self.bytes);

--- a/src/filters/debug.rs
+++ b/src/filters/debug.rs
@@ -38,13 +38,13 @@ impl Debug {
 
 impl Filter for Debug {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         info!(id = ?self.config.id, source = ?&ctx.source, contents = ?String::from_utf8_lossy(ctx.contents.as_slice()), "Read filter event");
         Ok(())
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         info!(
             id = ?self.config.id,
             source = ?&ctx.source,

--- a/src/filters/drop.rs
+++ b/src/filters/drop.rs
@@ -32,12 +32,12 @@ impl Drop {
 
 impl Filter for Drop {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    fn read<P: Packet>(&self, _: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, _: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         Err(FilterError::Dropped)
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    fn write<P: Packet>(&self, _: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, _: &mut WriteContext<P>) -> Result<(), FilterError> {
         Err(FilterError::Dropped)
     }
 }

--- a/src/filters/firewall.rs
+++ b/src/filters/firewall.rs
@@ -50,7 +50,7 @@ impl StaticFilter for Firewall {
 
 impl Filter for Firewall {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         for rule in &self.on_read {
             if rule.contains(ctx.source.to_socket_addr()?) {
                 return match rule.action {
@@ -78,7 +78,7 @@ impl Filter for Firewall {
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         for rule in &self.on_write {
             if rule.contains(ctx.source.to_socket_addr()?) {
                 return match rule.action {

--- a/src/filters/load_balancer.rs
+++ b/src/filters/load_balancer.rs
@@ -38,7 +38,7 @@ impl LoadBalancer {
 }
 
 impl Filter for LoadBalancer {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         self.endpoint_chooser
             .choose_endpoints(ctx.destinations, ctx.endpoints, &ctx.source);
         Ok(())

--- a/src/filters/local_rate_limit.rs
+++ b/src/filters/local_rate_limit.rs
@@ -55,9 +55,9 @@ struct Bucket {
 }
 
 /// A filter that implements rate limiting on packets based on the token-bucket
-/// algorithm.  Packets that violate the rate limit are dropped.  It only
+/// algorithm.  PacketMuts that violate the rate limit are dropped.  It only
 /// applies rate limiting on packets received from a downstream connection (processed
-/// through [`LocalRateLimit::read`]). Packets coming from upstream endpoints
+/// through [`LocalRateLimit::read`]). PacketMuts coming from upstream endpoints
 /// flow through the filter untouched.
 pub struct LocalRateLimit {
     /// Tracks rate limiting state per source address.
@@ -148,7 +148,7 @@ impl LocalRateLimit {
 }
 
 impl Filter for LocalRateLimit {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         if self.acquire_token(&ctx.source) {
             Ok(())
         } else {

--- a/src/filters/match.rs
+++ b/src/filters/match.rs
@@ -119,7 +119,7 @@ fn match_filter<'config, 'ctx, Ctx>(
 
 impl Filter for Match {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         tracing::trace!(metadata=?ctx.metadata);
         match_filter(
             &self.on_read_filters,
@@ -131,7 +131,7 @@ impl Filter for Match {
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, ctx)))]
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         match_filter(
             &self.on_write_filters,
             &self.metrics,

--- a/src/filters/pass.rs
+++ b/src/filters/pass.rs
@@ -31,12 +31,12 @@ impl Pass {
 
 impl Filter for Pass {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    fn read<P: Packet>(&self, _: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, _: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         Ok(())
     }
 
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    fn write<P: Packet>(&self, _: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, _: &mut WriteContext<P>) -> Result<(), FilterError> {
         Ok(())
     }
 }

--- a/src/filters/read.rs
+++ b/src/filters/read.rs
@@ -35,7 +35,7 @@ pub struct ReadContext<'ctx, P> {
     pub metadata: DynamicMetadata,
 }
 
-impl<'ctx, P: super::Packet> ReadContext<'ctx, P> {
+impl<'ctx, P: super::PacketMut> ReadContext<'ctx, P> {
     /// Creates a new [`ReadContext`].
     #[inline]
     pub fn new(

--- a/src/filters/registry.rs
+++ b/src/filters/registry.rs
@@ -67,18 +67,20 @@ mod tests {
     use crate::test::{alloc_buffer, load_test_filters};
 
     use super::*;
-    use crate::filters::{Filter, FilterError, FilterRegistry, Packet, ReadContext, WriteContext};
+    use crate::filters::{
+        Filter, FilterError, FilterRegistry, PacketMut, ReadContext, WriteContext,
+    };
     use crate::net::endpoint::{Endpoint, EndpointAddress};
 
     #[allow(dead_code)]
     struct TestFilter {}
 
     impl Filter for TestFilter {
-        fn read<P: Packet>(&self, _: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+        fn read<P: PacketMut>(&self, _: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
             Err(FilterError::Custom("test error"))
         }
 
-        fn write<P: Packet>(&self, _: &mut WriteContext<P>) -> Result<(), FilterError> {
+        fn write<P: PacketMut>(&self, _: &mut WriteContext<P>) -> Result<(), FilterError> {
             Err(FilterError::Custom("test error"))
         }
     }

--- a/src/filters/timestamp.rs
+++ b/src/filters/timestamp.rs
@@ -87,12 +87,12 @@ impl TryFrom<Config> for Timestamp {
 }
 
 impl Filter for Timestamp {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         self.observe(&ctx.metadata, Direction::Read);
         Ok(())
     }
 
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         self.observe(&ctx.metadata, Direction::Write);
         Ok(())
     }

--- a/src/filters/token_router.rs
+++ b/src/filters/token_router.rs
@@ -43,7 +43,7 @@ impl StaticFilter for TokenRouter {
 }
 
 impl Filter for TokenRouter {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         match ctx.metadata.get(&self.config.metadata_key) {
             Some(metadata::Value::Bytes(token)) => {
                 let tok = crate::net::cluster::Token::new(token);
@@ -81,7 +81,7 @@ impl StaticFilter for HashedTokenRouter {
 }
 
 impl Filter for HashedTokenRouter {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         self.0.read(ctx)
     }
 }
@@ -339,7 +339,7 @@ mod tests {
     fn assert_read<F, P>(filter: &F, mut ctx: ReadContext<'_, P>)
     where
         F: Filter + ?Sized,
-        P: Packet,
+        P: PacketMut,
     {
         filter.read(&mut ctx).unwrap();
         assert_eq!(b"hello", ctx.contents.as_slice());

--- a/src/filters/write.rs
+++ b/src/filters/write.rs
@@ -32,7 +32,7 @@ pub struct WriteContext<P> {
     pub metadata: DynamicMetadata,
 }
 
-impl<P: super::Packet> WriteContext<P> {
+impl<P: super::PacketMut> WriteContext<P> {
     /// Creates a new [`WriteContext`]
     #[inline]
     pub fn new(source: EndpointAddress, dest: EndpointAddress, contents: P) -> Self {

--- a/src/test.rs
+++ b/src/test.rs
@@ -99,7 +99,7 @@ fn get_address(address_type: AddressType, socket: &DualStackLocalSocket) -> Sock
 pub struct TestFilter;
 
 impl Filter for TestFilter {
-    fn read<P: Packet>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
+    fn read<P: PacketMut>(&self, ctx: &mut ReadContext<'_, P>) -> Result<(), FilterError> {
         // append values on each run
         ctx.metadata
             .entry("downstream".into())
@@ -111,7 +111,7 @@ impl Filter for TestFilter {
         Ok(())
     }
 
-    fn write<P: Packet>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
+    fn write<P: PacketMut>(&self, ctx: &mut WriteContext<P>) -> Result<(), FilterError> {
         // append values on each run
         ctx.metadata
             .entry("upstream".into())


### PR DESCRIPTION
This moves the DownstreamPacket struct to be completely sans-IO, meaning it is now generic over any input container and output container. This is just a basic shell right now to enable building and testing more stuff without IO, and to enable alternatives like XDP to integrate easily.