### PR TITLE
Add XDP CLI options and initialization code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,7 +258,7 @@ dependencies = [
  "bytes",
  "libc",
  "log",
- "object 0.36.5",
+ "object 0.36.7",
  "once_cell",
  "thiserror 1.0.69",
  "tokio",
@@ -297,7 +297,7 @@ dependencies = [
  "core-error",
  "hashbrown 0.15.1",
  "log",
- "object 0.36.5",
+ "object 0.36.7",
  "thiserror 1.0.69",
 ]
 
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.1",

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -499,14 +499,12 @@ impl Pail {
                 let task = tokio::spawn(async move {
                     components::proxy::Proxy {
                         num_workers: NonZeroUsize::new(1).unwrap(),
-                        mmdb: None,
-                        to: Vec::new(),
-                        to_tokens: None,
                         management_servers,
                         socket: Some(socket),
                         qcmp,
                         phoenix,
                         notifier: Some(rttx),
+                        ..Default::default()
                     }
                     .run(
                         RunArgs {

--- a/crates/xdp/src/lib.rs
+++ b/crates/xdp/src/lib.rs
@@ -90,6 +90,7 @@ impl EbpfProgram {
         let port_range = std::fs::read_to_string("/proc/sys/net/ipv4/ip_local_port_range")?;
         let (start, end) =
             port_range
+                .trim()
                 .split_once(char::is_whitespace)
                 .ok_or(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,

--- a/crates/xdp/src/lib.rs
+++ b/crates/xdp/src/lib.rs
@@ -164,8 +164,10 @@ impl EbpfProgram {
         nic: NicIndex,
         flags: aya::programs::XdpFlags,
     ) -> Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError> {
-        if let Err(error) = aya_log::EbpfLogger::init(&mut self.bpf) {
-            tracing::warn!(%error, "failed to initialize eBPF logging");
+        // Would be good to enable this if we do end up adding log messages to
+        // the eBPF program
+        if let Err(_error) = aya_log::EbpfLogger::init(&mut self.bpf) {
+            //tracing::warn!(%error, "failed to initialize eBPF logging");
         }
 
         // We use this entrypoint for now, but in the future we could also use

--- a/crates/xdp/src/lib.rs
+++ b/crates/xdp/src/lib.rs
@@ -29,7 +29,7 @@ struct AlignedTo<Align, Bytes: ?Sized> {
 }
 
 // dummy static used to create aligned data
-static ALIGNED: &'static AlignedTo<u64, [u8]> = &AlignedTo {
+static ALIGNED: &AlignedTo<u64, [u8]> = &AlignedTo {
     _align: [],
     bytes: *include_bytes!("../bin/packet-router.bin"),
 };

--- a/crates/xdp/src/lib.rs
+++ b/crates/xdp/src/lib.rs
@@ -34,7 +34,7 @@ static ALIGNED: &'static AlignedTo<u64, [u8]> = &AlignedTo {
     bytes: *include_bytes!("../bin/packet-router.bin"),
 };
 
-static PROGRAM: &'static [u8] = &ALIGNED.bytes;
+static PROGRAM: &[u8] = &ALIGNED.bytes;
 
 #[derive(thiserror::Error, Debug)]
 pub enum BindError {

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -55,10 +55,62 @@ pub struct Proxy {
     /// to an management server after receiving no updates.
     #[clap(long, env = "QUILKIN_IDLE_REQUEST_INTERVAL_SECS")]
     pub idle_request_interval_secs: Option<u64>,
-    /// Number of worker threads used to process packets. If not specified defaults
-    /// to number of cpus.
+    /// Number of worker threads used to process packets.
+    ///
+    /// If not specified defaults to number of cpus. Has no effect if XDP is used,
+    /// as the number of workers is always the same as the NIC queue size.
     #[clap(short, long, env = "QUILKIN_WORKERS")]
     pub workers: Option<std::num::NonZeroUsize>,
+    #[clap(flatten)]
+    pub xdp_opts: XdpOptions,
+}
+
+/// XDP (eXpress Data Path) options
+#[derive(clap::Args, Clone, Debug)]
+pub struct XdpOptions {
+    /// The name of the network interface to bind the XDP socket(s) to.
+    ///
+    /// If not specified quilkin will attempt to determine the most appropriate
+    /// network interface to use. Quilkin will exit with an error if the network
+    /// interface does not exist, or a suitable default cannot be determined.
+    #[clap(long)]
+    pub network_interface: Option<String>,
+    /// Forces the use of XDP.
+    ///
+    /// If XDP is not available on the chosen NIC, Quilkin exits with an error.
+    /// If false, io-uring will be used as the fallback implementation.
+    #[clap(long)]
+    pub force_xdp: bool,
+    /// Forces the use of [`XDP_ZEROCOPY`](https://www.kernel.org/doc/html/latest/networking/af_xdp.html#xdp-copy-and-xdp-zerocopy-bind-flags)
+    ///
+    /// If zero copy is not available on the chosen NIC, Quilkin exits with an error
+    #[clap(long)]
+    pub force_zerocopy: bool,
+    /// Forces the use of [TX checksum offload](https://docs.kernel.org/6.8/networking/xsk-tx-metadata.html)
+    ///
+    /// TX checksum offload is an optional feature allowing the data portion of
+    /// a packet to have its internet checksum calculation offloaded to the NIC,
+    /// as otherwise this is done in software
+    #[clap(long)]
+    pub force_tx_checksum_offload: bool,
+    /// The maximum amount of memory mapped for packet buffers, in bytes
+    ///
+    /// If not specified, this defaults to 4MiB (2k allocated packets of 2k each at a time)
+    /// per NIC queue, ie 128MiB on a 32 queue NIC
+    pub maximum_memory: Option<u64>,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for XdpOptions {
+    fn default() -> Self {
+        Self {
+            network_interface: None,
+            force_xdp: false,
+            force_zerocopy: false,
+            force_tx_checksum_offload: false,
+            maximum_memory: None,
+        }
+    }
 }
 
 impl Default for Proxy {
@@ -72,6 +124,7 @@ impl Default for Proxy {
             to_tokens: None,
             idle_request_interval_secs: None,
             workers: None,
+            xdp_opts: Default::default(),
         }
     }
 }
@@ -127,6 +180,7 @@ impl Proxy {
             qcmp,
             phoenix,
             notifier: None,
+            xdp: self.xdp_opts,
         }
         .run(
             crate::components::RunArgs {

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -73,30 +73,31 @@ pub struct XdpOptions {
     /// If not specified quilkin will attempt to determine the most appropriate
     /// network interface to use. Quilkin will exit with an error if the network
     /// interface does not exist, or a suitable default cannot be determined.
-    #[clap(long)]
+    #[clap(long = "publish.udp.xdp.network-interface")]
     pub network_interface: Option<String>,
     /// Forces the use of XDP.
     ///
     /// If XDP is not available on the chosen NIC, Quilkin exits with an error.
     /// If false, io-uring will be used as the fallback implementation.
-    #[clap(long)]
+    #[clap(long = "publish.udp.xdp")]
     pub force_xdp: bool,
     /// Forces the use of [`XDP_ZEROCOPY`](https://www.kernel.org/doc/html/latest/networking/af_xdp.html#xdp-copy-and-xdp-zerocopy-bind-flags)
     ///
     /// If zero copy is not available on the chosen NIC, Quilkin exits with an error
-    #[clap(long)]
+    #[clap(long= "publish.udp.xdp.zerocopy")]
     pub force_zerocopy: bool,
     /// Forces the use of [TX checksum offload](https://docs.kernel.org/6.8/networking/xsk-tx-metadata.html)
     ///
     /// TX checksum offload is an optional feature allowing the data portion of
     /// a packet to have its internet checksum calculation offloaded to the NIC,
     /// as otherwise this is done in software
-    #[clap(long)]
+    #[clap(long= "publish.udp.xdp.tco")]
     pub force_tx_checksum_offload: bool,
     /// The maximum amount of memory mapped for packet buffers, in bytes
     ///
     /// If not specified, this defaults to 4MiB (2k allocated packets of 2k each at a time)
     /// per NIC queue, ie 128MiB on a 32 queue NIC
+    #[clap(long= "publish.udp.xdp.memory-limit")]
     pub maximum_memory: Option<u64>,
 }
 

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -84,20 +84,20 @@ pub struct XdpOptions {
     /// Forces the use of [`XDP_ZEROCOPY`](https://www.kernel.org/doc/html/latest/networking/af_xdp.html#xdp-copy-and-xdp-zerocopy-bind-flags)
     ///
     /// If zero copy is not available on the chosen NIC, Quilkin exits with an error
-    #[clap(long= "publish.udp.xdp.zerocopy")]
+    #[clap(long = "publish.udp.xdp.zerocopy")]
     pub force_zerocopy: bool,
     /// Forces the use of [TX checksum offload](https://docs.kernel.org/6.8/networking/xsk-tx-metadata.html)
     ///
     /// TX checksum offload is an optional feature allowing the data portion of
     /// a packet to have its internet checksum calculation offloaded to the NIC,
     /// as otherwise this is done in software
-    #[clap(long= "publish.udp.xdp.tco")]
+    #[clap(long = "publish.udp.xdp.tco")]
     pub force_tx_checksum_offload: bool,
     /// The maximum amount of memory mapped for packet buffers, in bytes
     ///
     /// If not specified, this defaults to 4MiB (2k allocated packets of 2k each at a time)
     /// per NIC queue, ie 128MiB on a 32 queue NIC
-    #[clap(long= "publish.udp.xdp.memory-limit")]
+    #[clap(long = "publish.udp.xdp.memory-limit")]
     pub maximum_memory: Option<u64>,
 }
 

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -309,7 +309,10 @@ impl Proxy {
                         return Err(err);
                     }
 
-                    tracing::warn!(?err, "failed to spawn XDP I/O loop, falling back to io-uring");
+                    tracing::warn!(
+                        ?err,
+                        "failed to spawn XDP I/O loop, falling back to io-uring"
+                    );
                 }
             }
         }
@@ -353,7 +356,10 @@ impl Proxy {
     }
 
     #[cfg(target_os = "linux")]
-    fn spawn_xdp(&mut self, config: Arc<crate::config::Config>) -> eyre::Result<Box<dyn FnOnce(crate::ShutdownRx) + Send>> {
+    fn spawn_xdp(
+        &mut self,
+        config: Arc<crate::config::Config>,
+    ) -> eyre::Result<Box<dyn FnOnce(crate::ShutdownRx) + Send>> {
         use crate::net::xdp;
         use eyre::Context as _;
 
@@ -380,7 +386,8 @@ impl Proxy {
             maximum_packet_memory: self.xdp.maximum_memory,
             require_zero_copy: self.xdp.force_zerocopy,
             require_tx_checksum: self.xdp.force_tx_checksum_offload,
-        }).context("failed to setup XDP")?;
+        })
+        .context("failed to setup XDP")?;
 
         let io_loop = xdp::spawn(workers, config).context("failed to spawn XDP I/O loop")?;
         Ok(Box::new(move |srx: crate::ShutdownRx| {

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -299,60 +299,17 @@ impl Proxy {
         config: Arc<crate::config::Config>,
     ) -> eyre::Result<Box<dyn FnOnce(crate::ShutdownRx) + Send>> {
         #[cfg(target_os = "linux")]
-        'xdp: {
-            use crate::net::xdp;
-            use eyre::Context as _;
-
-            // TODO: remove this once it's been more stabilized
-            if true {
-                break 'xdp;
-            }
-
-            let Some(external_port) = self.socket.as_ref().and_then(|s| {
-                s.local_addr()
-                    .ok()
-                    .and_then(|la| la.as_socket().map(|sa| sa.port()))
-            }) else {
-                break 'xdp;
-            };
-
-            match xdp::setup_xdp_io(xdp::XdpConfig {
-                nic: self
-                    .xdp
-                    .network_interface
-                    .as_deref()
-                    .map_or(xdp::NicConfig::Default, xdp::NicConfig::Name),
-                external_port,
-                maximum_packet_memory: self.xdp.maximum_memory,
-                require_zero_copy: self.xdp.force_zerocopy,
-                require_tx_checksum: self.xdp.force_tx_checksum_offload,
-            }) {
-                Ok(workers) => match xdp::spawn(workers, config.clone()) {
-                    Ok(xdp_loop) => {
-                        return Ok(Box::new(move |srx: crate::ShutdownRx| {
-                            xdp_loop.shutdown(*srx.borrow() == crate::ShutdownKind::Normal);
-                        }));
-                    }
-                    Err(err) => {
-                        if self.xdp.force_xdp {
-                            return Err(err)
-                                .context("failed to spawn XDP I/O loop, and XDP mode is forced");
-                        }
-
-                        tracing::warn!(
-                            ?err,
-                            "failed to spawn XDP I/O loop, falling back to io-uring"
-                        );
-                        break 'xdp;
-                    }
-                },
+        {
+            match self.spawn_xdp(config.clone()) {
+                Ok(xdp) => {
+                    return Ok(xdp);
+                }
                 Err(err) => {
                     if self.xdp.force_xdp {
-                        return Err(err).context("unable to setup XDP, and XDP mode is forced");
+                        return Err(err);
                     }
 
-                    tracing::warn!(?err, "failed to setup XDP, falling back to io-uring");
-                    break 'xdp;
+                    tracing::warn!(?err, "failed to spawn XDP I/O loop, falling back to io-uring");
                 }
             }
         }
@@ -392,6 +349,42 @@ impl Proxy {
 
         Ok(Box::new(move |shutdown_rx: crate::ShutdownRx| {
             sessions.shutdown(*shutdown_rx.borrow() == crate::ShutdownKind::Normal);
+        }))
+    }
+
+    #[cfg(target_os = "linux")]
+    fn spawn_xdp(&mut self, config: Arc<crate::config::Config>) -> eyre::Result<Box<dyn FnOnce(crate::ShutdownRx) + Send>> {
+        use crate::net::xdp;
+        use eyre::Context as _;
+
+        // TODO: remove this once it's been more stabilized
+        if true {
+            eyre::bail!("temporarily disabled");
+        }
+
+        let Some(external_port) = self.socket.as_ref().and_then(|s| {
+            s.local_addr()
+                .ok()
+                .and_then(|la| la.as_socket().map(|sa| sa.port()))
+        }) else {
+            eyre::bail!("unable to determine port");
+        };
+
+        let workers = xdp::setup_xdp_io(xdp::XdpConfig {
+            nic: self
+                .xdp
+                .network_interface
+                .as_deref()
+                .map_or(xdp::NicConfig::Default, xdp::NicConfig::Name),
+            external_port,
+            maximum_packet_memory: self.xdp.maximum_memory,
+            require_zero_copy: self.xdp.force_zerocopy,
+            require_tx_checksum: self.xdp.force_tx_checksum_offload,
+        }).context("failed to setup XDP")?;
+
+        let io_loop = xdp::spawn(workers, config).context("failed to spawn XDP I/O loop")?;
+        Ok(Box::new(move |srx: crate::ShutdownRx| {
+            io_loop.shutdown(*srx.borrow() == crate::ShutdownKind::Normal);
         }))
     }
 }

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -303,6 +303,11 @@ impl Proxy {
             use crate::net::xdp;
             use eyre::Context as _;
 
+            // TODO: remove this once it's been more stabilized
+            if true {
+                break 'xdp;
+            }
+
             let Some(external_port) = self.socket.as_ref().and_then(|s| {
                 s.local_addr()
                     .ok()

--- a/src/net/xdp.rs
+++ b/src/net/xdp.rs
@@ -245,14 +245,11 @@ pub fn setup_xdp_io(config: XdpConfig<'_>) -> Result<XdpWorkers, XdpSetupError> 
     })
 }
 
-/// We need the u64 for the call to [`pthread_cancel`](https://www.man7.org/linux/man-pages/man3/pthread_cancel.3.html),
-/// but unfortunately `std::thread::ThreadId` doesn't have that on [stable](https://doc.rust-lang.org/std/thread/struct.ThreadId.html#method.as_u64)
-type ThreadId = u64;
-
 pub struct XdpLoop {
-    threads: Vec<(ThreadId, std::thread::JoinHandle<()>)>,
+    threads: Vec<std::thread::JoinHandle<()>>,
     ebpf_prog: quilkin_xdp::EbpfProgram,
     xdp_link: quilkin_xdp::aya::programs::xdp::XdpLinkId,
+    shutdown: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl XdpLoop {
@@ -263,45 +260,21 @@ impl XdpLoop {
             tracing::error!(%error, "failed to detach eBPF program");
         }
 
-        for (tid, _) in &mut self.threads {
-            // This will only fail if the thread doesn't exist, so we just
-            // make it so that we skip joining if that happens
-            // SAFETY: this should be safe to call even if the thread doesn't
-            // exist
-            let err = unsafe { libc::pthread_cancel(*tid) };
-            match err {
-                0 => {}
-                libc::ESRCH => {
-                    tracing::warn!(tid, "thread does not exist");
-                    *tid = 0;
-                }
-                _ => {
-                    tracing::warn!(
-                        tid,
-                        err,
-                        "thread could not be cancelled, but the error seems to be incorrect"
-                    );
-                    *tid = 0;
-                }
-            }
-        }
+        self.shutdown
+            .store(true, std::sync::atomic::Ordering::Relaxed);
 
         if !wait {
             return;
         }
 
-        for (tid, jh) in self.threads {
-            if tid == 0 {
-                continue;
-            }
-
+        for jh in self.threads {
             if let Err(error) = jh.join() {
                 if let Some(error) = error.downcast_ref::<&'static str>() {
-                    tracing::error!(tid, error, "XDP I/O thread enountered error");
+                    tracing::error!(error, "XDP I/O thread enountered error");
                 } else if let Some(error) = error.downcast_ref::<String>() {
-                    tracing::error!(tid, error, "XDP I/O thread enountered error");
+                    tracing::error!(error, "XDP I/O thread enountered error");
                 } else {
-                    tracing::error!(tid, ?error, "XDP I/O thread enountered error");
+                    tracing::error!(?error, "XDP I/O thread enountered error");
                 };
             }
         }
@@ -319,18 +292,17 @@ impl XdpLoop {
 /// This can fail if threads can not be spawned for some reason (unlikely), the
 /// more likely reason for failure is the inability to attach the eBPF program
 pub fn spawn(workers: XdpWorkers, config: Arc<crate::Config>) -> Result<XdpLoop, XdpSpawnError> {
-    let (tx, rx) = std::sync::mpsc::sync_channel(1);
-
     let external_port = workers.external_port;
     let ipv4 = workers.ipv4;
     let ipv6 = workers.ipv6;
     let session_state = Arc::new(process::SessionState::default());
+    let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     let mut threads = Vec::with_capacity(workers.workers.len());
     for (i, mut worker) in workers.workers.into_iter().enumerate() {
-        let tx = tx.clone();
         let cfg = config.clone();
         let ss = session_state.clone();
+        let shutdown = shutdown.clone();
 
         let jh = std::thread::Builder::new()
             .name(format!("xdp-io-{i}"))
@@ -339,14 +311,11 @@ pub fn spawn(workers: XdpWorkers, config: Arc<crate::Config>) -> Result<XdpLoop,
                 // SAFETY: we keep the umem alive for as long as the socket is alive
                 unsafe { worker.fill.enqueue(&mut worker.umem, BATCH_SIZE * 2) };
 
-                // SAFETY: there are no invariants to uphold
-                tx.send(unsafe { libc::pthread_self() }).unwrap();
-                io_loop(worker, external_port, cfg, ss, ipv4, ipv6)
+                io_loop(worker, external_port, cfg, ss, ipv4, ipv6, shutdown.clone())
             })
             .map_err(XdpSpawnError::Thread)?;
 
-        let tid = rx.recv().unwrap();
-        threads.push((tid, jh));
+        threads.push(jh);
     }
 
     // Now that all the io loops are running, attach the eBPF program to route
@@ -359,6 +328,7 @@ pub fn spawn(workers: XdpWorkers, config: Arc<crate::Config>) -> Result<XdpLoop,
         threads,
         ebpf_prog,
         xdp_link,
+        shutdown,
     })
 }
 
@@ -377,6 +347,7 @@ fn io_loop(
     sessions: Arc<process::SessionState>,
     local_ipv4: std::net::Ipv4Addr,
     local_ipv6: std::net::Ipv6Addr,
+    shutdown: Arc<std::sync::atomic::AtomicBool>,
 ) {
     let quilkin_xdp::XdpWorker {
         mut umem,
@@ -407,7 +378,7 @@ fn io_loop(
     // between frames and the Umem, the frames cannot outlive the Umem which is
     // the owner of the actual memory map
     unsafe {
-        loop {
+        while !shutdown.load(std::sync::atomic::Ordering::Relaxed) {
             // Wait for packets to be received/sent, note that
             // [poll](https://www.man7.org/linux/man-pages/man2/poll.2.html) also acts
             // as a [cancellation point](https://www.man7.org/linux/man-pages/man7/pthreads.7.html),

--- a/src/test.rs
+++ b/src/test.rs
@@ -302,14 +302,10 @@ impl TestHelper {
 
             crate::components::proxy::Proxy {
                 num_workers: std::num::NonZeroUsize::new(1).unwrap(),
-                mmdb: None,
-                management_servers: Vec::new(),
-                to: Vec::new(),
-                to_tokens: None,
                 socket: Some(crate::net::raw_socket_with_reuse(0).unwrap()),
                 qcmp,
                 phoenix,
-                notifier: None,
+                ..Default::default()
             }
         });
 


### PR DESCRIPTION
This adds the support for several XDP specific options, and the initialization code to bring up the XDP I/O loop, falling back to io-uring if setup fails for some reason. This PR _always_ falls back to io-uring at the moment, this is just to get the code in so that it can be iterated on in further PRs, as I only tested that we can spinup quilkin proxy using XDP and shut it down cleanly, not the actual I/O which I'm leaving for tomorrow.

Fixed several bugs:

- Fix bug in ephemeral port range parsing
- Remove warning about eBPF logging, the current eBPF program has no log messages, which makes log initialization fail, but we would want to enable it in the future if we did add logging to the program
- `pthread_cancel` is apparently super not good and was causing a crash at shutdown due to signal shenanigans, so I just replaced it with an atomic bool for now
- We include the eBPF program inlined in the quilkin binary, but it could be aligned however rustc/LLVM decided, and object parsing requires it be aligned correctly, which for 64-bit ELF files is 8 bytes