### PR TITLE
Fix various XDP bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,7 +4292,7 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 [[package]]
 name = "xdp"
 version = "0.0.1"
-source = "git+https://github.com/Jake-Shadle/xdp?branch=impl#c375726411235a9d05c9e12c638cf6148c2fdec7"
+source = "git+https://github.com/Jake-Shadle/xdp?branch=impl#4ec459e29fd1fdf38f85a7d48b64d3ae2f6098de"
 dependencies = [
  "libc",
  "memmap2",

--- a/crates/xdp/src/lib.rs
+++ b/crates/xdp/src/lib.rs
@@ -249,10 +249,13 @@ pub fn get_default_nic() -> std::io::Result<Option<NicIndex>> {
         };
 
         if let Some(def) = def_iface {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Unsupported,
-                format!("unable to determine default interface, found {def:?} and {iface:?}"),
-            ));
+            // A NIC can have multiple routes, so don't error when it comes up again
+            if def != iface {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    format!("unable to determine default interface, found {def:?} and {iface:?}"),
+                ));
+            }
         }
 
         def_iface = Some(iface);

--- a/src/net/xdp.rs
+++ b/src/net/xdp.rs
@@ -321,6 +321,12 @@ pub fn spawn(workers: XdpWorkers, config: Arc<crate::Config>) -> Result<XdpLoop,
     // Now that all the io loops are running, attach the eBPF program to route
     // packets to the bound sockets
     let mut ebpf_prog = workers.ebpf_prog;
+
+    // We use the default flags here, which means that the program will be attached
+    // in driver mode if the NIC + driver is capable of it, otherwise it will fallback
+    // to SKB mode. This allows maximum compatibility, and we already provide
+    // flags to force zerocopy, which relies on driver mode, so the user can use
+    // that if they don't want the fallback behavior
     let xdp_link =
         ebpf_prog.attach(workers.nic, quilkin_xdp::aya::programs::XdpFlags::default())?;
 


### PR DESCRIPTION
This fixes a couple of bugs in the XDP implementation.

- When enumerating NICs to find the default one, I wasn't taking into account the same NIC can appear multiple times with different routes since my home/work machine doesn't have those, this just makes it so that an error doesn't occur when that happens https://github.com/Jake-Shadle/xdp/commit/6efad6c10fbe84404dd7186881957a9a5875f308
- Removes a panic that would occur if the generic "netdev" family could not be retrieved, though an error there indicates something really wrong and means we can't query device capabilities. https://github.com/Jake-Shadle/xdp/commit/2a1b21b1bd7781c196fea57c088fcc2ff35f81a5
- I had accidentally mixed up that the IPv4 checksum is always required, and the UDP checksum is not required in IPv4, which would cause packets to be dropped by the receiver due to an invalid checksum, so we always calculate it now. https://github.com/Jake-Shadle/xdp/commit/4ec459e29fd1fdf38f85a7d48b64d3ae2f6098de