### PR TITLE
Fully refresh local state on new connection

### DIFF
--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -550,6 +550,10 @@ impl AdsClient {
 
                     resource_subscriptions = handle_first_response(&mut stream, resources).await?;
 
+                    // Assume the new server we've connected to has completely different
+                    // state from the previous one, so get rid of our current state
+                    // and get a full refresh from the new relay
+                    local.reset();
                     ds.refresh(&identifier, resource_subscriptions.to_vec(), &local)
                         .await?;
                 }

--- a/crates/xds/src/config.rs
+++ b/crates/xds/src/config.rs
@@ -44,6 +44,13 @@ impl LocalVersions {
             .unwrap()
             .lock()
     }
+
+    #[inline]
+    pub fn reset(&self) {
+        for (_, map) in &self.versions {
+            map.lock().clear();
+        }
+    }
 }
 
 pub type VersionMap = HashMap<String, String>;


### PR DESCRIPTION
This is purely a guess about one thing that could go wrong if a proxy needs to connect to a new relay.