### PR TITLE
chore: Remove parts of GCB that are covered by GHA

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -77,7 +77,7 @@ version:
 	@echo $(package_version)
 
 # Run all tests
-test: ensure-build-image test-quilkin test-docs
+test: ensure-build-image
 
 # In CI with split jobs that both fetch they will fail if run in parallel since
 # cargo will be fighting with itself for some the same host directory that is
@@ -86,39 +86,6 @@ fetch-quilkin: ensure-build-image
 	docker run --rm $(common_rust_args)  \
 			--network=host \
 			-e RUST_BACKTRACE=1 --entrypoint=cargo $(BUILD_IMAGE_TAG) fetch
-
-check-quilkin: ensure-build-image
-	docker run --rm $(common_rust_args) \
-			--entrypoint=cargo $(BUILD_IMAGE_TAG) deny check
-	docker run --rm $(common_rust_args) \
-		--entrypoint=cargo $(BUILD_IMAGE_TAG) clippy --tests -- -D warnings
-	docker run --rm $(common_rust_args) \
-		--entrypoint=cargo $(BUILD_IMAGE_TAG) fmt -- --check
-
-# test only the quilkin crate, if you want to see test output regardless of test
-# failure or success, set RUST_TEST_NOCAPTURE to something other than "0"
-test-quilkin: ensure-build-image
-	# --network=host because docker containers are not great at ipv6.
-	docker run --rm $(common_rust_args)  \
-			--network=host \
-			-e RUST_BACKTRACE=1 --entrypoint=cargo $(BUILD_IMAGE_TAG) test -p quilkin -p qt
-
-# Run tests against documentation
-test-docs: ensure-build-image
-test-docs: GITHUB_REF_NAME ?= main
-test-docs: QUILKIN_VERSION ?= $(shell $(MAKE) version)
-test-docs:
-	docker run --rm $(common_rust_args) \
-		-e GITHUB_REF_NAME=$(GITHUB_REF_NAME) -e QUILKIN_VERSION=$(QUILKIN_VERSION) \
-		--entrypoint=bash $(BUILD_IMAGE_TAG) -c \
-			'if ! [git diff --quiet --exit-code origin/main -- docs]; then echo "docs unchanged, skipping docs test" && exit 0; fi; \
-			export RUSTDOCFLAGS="-Dwarnings" && mkdir /tmp/docs && \
-			mkdir -p "$(CARGO_TARGET_DIR)/doc"; \
-			cargo doc --workspace --no-deps && cd docs && mdbook build --dest-dir /tmp/docs/book && \
-			cp -r "$(CARGO_TARGET_DIR)/doc" /tmp/docs/api && \
-			rm /tmp/docs/book/print.html && \
-			echo "<!doctype html>" > /tmp/docs/book/print.html && \
-			htmltest -c /workspace/docs/htmltest.yaml /tmp/docs'
 
 # Build all binaries, images and related artifacts
 build: binary-archive build-image
@@ -242,22 +209,6 @@ minikube-push: build-image
 # to set those options.
 minikube-test-agones: minikube-push
 	$(MAKE) DOCKER_RUN_ARGS="$(minikube_args)" run-test-agones
-
-# Runs mdbook and cargo doc in the same directory structure as what is hosted on Github pages.
-# Open http://localhost:3000/ after running and browse to the docs you are editing. Pages will live reload on change.
-# Use `GITHUB_REF_NAME` (default: `main`) to specify the branch or tag to point Github links to and `QUILKIN_VERSION`
-# (default `$(make version)) to specify which Quilkin version the documentation uses for examples.
-docs: ensure-build-image
-docs: GITHUB_REF_NAME ?= main
-docs: QUILKIN_VERSION ?= $(shell $(MAKE) version)
-docs:
-	@echo "📭 Open browser to http://localhost:3000/ and browse as needed"
-	docker run -it --rm $(common_rust_args) -p 3000:3000 \
-		-e GITHUB_REF_NAME=$(GITHUB_REF_NAME) -e QUILKIN_VERSION=$(QUILKIN_VERSION) \
-		--entrypoint=bash $(BUILD_IMAGE_TAG) -c \
-			'mkdir /tmp/docs && (browser-sync start --server "/tmp/docs" --directory --index index.html --port 3000 --no-open --files "/tmp/docs" &) && \
-			mkdir -p "$(CARGO_TARGET_DIR)/doc"; ln -s "$(CARGO_TARGET_DIR)/doc" /tmp/docs/api && \
-			cargo watch -s "cargo doc --workspace --no-deps && cd docs && mdbook build --dest-dir /tmp/docs/book"'
 
 # Start an interactive shell inside the build image
 # Useful for testing, or adhoc cargo, gcloud, kubectl or other commands

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -27,8 +27,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN set -eux && \
     apt-get update && \
     apt-get install -y lsb-release jq curl wget zip git build-essential software-properties-common protobuf-compiler \
-        libssl-dev pkg-config nodejs npm bash-completion g++-x86-64-linux-gnu g++-mingw-w64-x86-64 && \
-    npm install -g browser-sync && \
+        libssl-dev pkg-config bash-completion g++-x86-64-linux-gnu g++-mingw-w64-x86-64 && \
     echo "source /etc/bash_completion" >> /root/.bashrc
 
 # install protoc-gen-doc
@@ -54,11 +53,6 @@ RUN wget --quiet -O terraform.zip "https://releases.hashicorp.com/terraform/1.5.
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && \
     echo "source <(helm completion bash)" >> /root/.bashrc
 
-# Install htmltest
-WORKDIR /tmp
-RUN wget --quiet -O htmltest.tar.gz "https://github.com/wjdp/htmltest/releases/download/v0.16.0/htmltest_0.16.0_linux_$(dpkg --print-architecture).tar.gz" && \
-     tar -xf htmltest.tar.gz && mv ./htmltest /usr/local/bin/ && rm htmltest.tar.gz
-
 # Add /workspace as a git safe directory
 RUN git config --global --add safe.directory /workspace
 
@@ -79,11 +73,7 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME && \
     rustup component add rustfmt clippy && \
     rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-pc-windows-gnu && \
-    cargo install mdbook && \
-    cargo install --locked cargo-about && \
-    cargo install --locked mdbook-variables && \
-    cargo install --locked cargo-deny && \
-    cargo install --locked proto-gen && \
+    cargo install --locked cargo-about proto-gen && \
     rustup --version && \
     cargo --version && \
     rustc --version

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -34,18 +34,6 @@ steps:
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:
-      - test-quilkin
-    id: test-quilkin
-    waitFor:
-      - fetch-quilkin
-  - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
-    dir: ./build
-    args:
-      - test-docs
-    id: test-docs
-  - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
-    dir: ./build
-    args:
       - build-image
     id: build
 
@@ -80,8 +68,6 @@ steps:
     args:
       - ci-gcloud-auth-cluster
     id: gcloud-auth-cluster
-    waitFor:
-      - test-quilkin
   - name: us-docker.pkg.dev/$PROJECT_ID/ci/make-docker
     dir: ./build
     args:


### PR DESCRIPTION
I'm pretty sure all of this functionality is already tested in GHA, so just remove it for now for faster release image builds.