### PR TITLE
Begin config migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,6 +2725,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "tryhard",
+ "typemap_rev",
  "url",
  "uuid",
  "xxhash-rust",
@@ -3915,6 +3916,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "typemap_rev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,15 +2167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nmap-service-probes"
-version = "0.1.0"
-dependencies = [
- "pretty_assertions",
- "thiserror 2.0.11",
- "winnow",
-]
-
-[[package]]
 name = "notify"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4389,15 +4380,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ members = [
     ".",
     "crates/agones",
     "crates/macros",
-    "crates/nmap-service-probes",
+    #"crates/nmap-service-probes",
     "crates/proto-gen",
     "crates/quilkin-proto",
     "crates/test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber = { workspace = true, features = ["json", "env-filter"] }
 tryhard.workspace = true
+typemap_rev = "0.3.0"
 url.workspace = true
 uuid.workspace = true
 lasso = { version = "0.7.3", features = ["multi-threaded"] }

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -322,7 +322,7 @@ impl Pail {
                     quilkin::signal::channel(quilkin::signal::ShutdownKind::Testing);
 
                 let config = Arc::new(Config::default_non_agent());
-                config.id.store(Arc::new(spc.name.into()));
+                config.dyn_cfg.id.store(Arc::new(spc.name.into()));
 
                 let task = tokio::spawn(
                     relay::Relay {
@@ -397,7 +397,7 @@ impl Pail {
 
                 let config_path = path.clone();
                 let config = Arc::new(Config::default_agent());
-                config.id.store(Arc::new(spc.name.into()));
+                config.dyn_cfg.id.store(Arc::new(spc.name.into()));
                 let acfg = config.clone();
 
                 let task = tokio::spawn(async move {
@@ -490,7 +490,7 @@ impl Pail {
                         .modify(|clusters| clusters.insert_default(endpoints));
                 }
 
-                config.id.store(Arc::new(spc.name.into()));
+                config.dyn_cfg.id.store(Arc::new(spc.name.into()));
                 let pconfig = config.clone();
 
                 let (rttx, rtrx) = tokio::sync::mpsc::unbounded_channel();

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -16,7 +16,7 @@
 
 use std::sync::Arc;
 
-use crate::{components::agent, config::Config};
+use crate::components::agent;
 pub use agent::Ready;
 
 define_port!(7600);
@@ -81,7 +81,7 @@ impl Agent {
     pub async fn run(
         self,
         locality: Option<crate::net::endpoint::Locality>,
-        config: Arc<Config>,
+        config: Arc<crate::Config>,
         ready: Ready,
         shutdown_rx: crate::signal::ShutdownRx,
     ) -> crate::Result<()> {

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -94,11 +94,7 @@ impl Proxy {
         initialized: Option<tokio::sync::oneshot::Sender<()>>,
         shutdown_rx: ShutdownRx,
     ) -> crate::Result<()> {
-        tracing::info!(
-            port = self.port,
-            proxy_id = &*config.id.load(),
-            "Starting proxy"
-        );
+        tracing::info!(port = self.port, proxy_id = config.id(), "Starting proxy");
 
         // The number of worker tasks to spawn. Each task gets a dedicated queue to
         // consume packets off.

--- a/src/components/agent.rs
+++ b/src/components/agent.rs
@@ -89,10 +89,7 @@ impl Agent {
             }
             .spawn_providers(&config, ready.provider_is_healthy.clone(), self.locality);
 
-            let task = crate::net::xds::client::MdsClient::connect(
-                String::clone(&config.id.load()),
-                self.relay_servers,
-            );
+            let task = crate::net::xds::client::MdsClient::connect(config.id(), self.relay_servers);
 
             tokio::select! {
                 result = task => {

--- a/src/components/manage.rs
+++ b/src/components/manage.rs
@@ -62,11 +62,9 @@ impl Manage {
 
         let _relay_stream = if !self.relay_servers.is_empty() {
             tracing::info!("connecting to relay server");
-            let client = crate::net::xds::client::MdsClient::connect(
-                String::clone(&config.id.load()),
-                self.relay_servers,
-            )
-            .await?;
+            let client =
+                crate::net::xds::client::MdsClient::connect(config.id(), self.relay_servers)
+                    .await?;
 
             // Attempt to connect to a delta stream if the relay has one
             // available, otherwise fallback to the regular aggregated stream

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -226,7 +226,7 @@ impl Proxy {
                 *lock = Some(check.clone());
             }
 
-            let id = config.id.load();
+            let id = config.id();
 
             std::thread::Builder::new()
                 .name("proxy-subscription".into())

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,8 +79,6 @@ pub struct Config {
     pub filters: Slot<crate::filters::FilterChain>,
     #[serde(default = "default_proxy_id")]
     pub id: Slot<String>,
-    #[serde(default)]
-    pub version: Slot<Version>,
     #[serde(flatten)]
     pub datacenter: DatacenterConfig,
 }
@@ -562,7 +560,6 @@ impl Config {
             clusters: Default::default(),
             filters: Default::default(),
             id: default_proxy_id(),
-            version: Slot::with_default(),
             datacenter: DatacenterConfig::Agent {
                 icao_code: Default::default(),
                 qcmp_port: Default::default(),
@@ -575,7 +572,6 @@ impl Config {
             clusters: Default::default(),
             filters: Default::default(),
             id: default_proxy_id(),
-            version: Slot::with_default(),
             datacenter: DatacenterConfig::NonAgent {
                 datacenters: Default::default(),
             },
@@ -985,10 +981,6 @@ mod tests {
 
     use super::*;
 
-    fn parse_config(yaml: &str) -> Config {
-        Config::from_reader(yaml.as_bytes()).unwrap()
-    }
-
     #[test]
     fn deserialise_client() {
         let config = Config::default_non_agent();
@@ -1024,18 +1016,6 @@ mod tests {
         .unwrap();
 
         assert!(config.id.load().len() > 1);
-    }
-
-    #[test]
-    fn parse_proxy() {
-        let yaml = "
-version: v1alpha1
-id: server-proxy
-  ";
-        let config = parse_config(yaml);
-
-        assert_eq!(config.id.load().as_str(), "server-proxy");
-        assert_eq!(*config.version.load(), Version::V1Alpha1);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,16 +168,14 @@ impl<'de> Deserialize<'de> for Config {
 
                 let datacenter = if let Some(datacenters) = datacenters {
                     DatacenterConfig::NonAgent { datacenters }
+                } else if icao_code.is_none() && qcmp_port.is_none() {
+                    DatacenterConfig::NonAgent {
+                        datacenters: Default::default(),
+                    }
                 } else {
-                    if icao_code.is_none() && qcmp_port.is_none() {
-                        DatacenterConfig::NonAgent {
-                            datacenters: Default::default(),
-                        }
-                    } else {
-                        DatacenterConfig::Agent {
-                            icao_code: Slot::new(icao_code),
-                            qcmp_port: Slot::new(qcmp_port),
-                        }
+                    DatacenterConfig::Agent {
+                        icao_code: Slot::new(icao_code),
+                        qcmp_port: Slot::new(qcmp_port),
                     }
                 };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,9 +31,10 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{
-    filters::prelude::*,
+    filters::{prelude::*, FilterChain},
     generated::envoy::service::discovery::v3::Resource as XdsResource,
     net::cluster::{self, ClusterMap},
+    xds::{self, ResourceType},
 };
 
 pub use self::{
@@ -44,10 +45,13 @@ mod config_type;
 mod error;
 pub mod providers;
 pub mod providersv2;
+mod serialization;
 mod slot;
 pub mod watch;
 
 pub(crate) const BACKOFF_INITIAL_DELAY: Duration = Duration::from_millis(500);
+
+pub type ConfigMap = typemap_rev::TypeMap<dyn typemap_rev::CloneDebuggableStorage>;
 
 base64_serde_type!(pub Base64Standard, base64::engine::general_purpose::STANDARD);
 
@@ -67,29 +71,246 @@ pub enum DatacenterConfig {
     },
 }
 
-/// Configuration for a component
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq))]
-#[serde(deny_unknown_fields)]
-#[non_exhaustive]
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug))]
 pub struct Config {
-    #[serde(default)]
     pub clusters: Watch<ClusterMap>,
-    #[serde(default)]
     pub filters: Slot<crate::filters::FilterChain>,
-    #[serde(default = "default_proxy_id")]
-    pub id: Slot<String>,
-    #[serde(flatten)]
     pub datacenter: DatacenterConfig,
+    pub dyn_cfg: DynamicConfig,
+}
+
+#[cfg(test)]
+impl<'de> Deserialize<'de> for Config {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Config;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Quilkin config")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                use serde::de::Error;
+
+                let mut id = Option::<String>::None;
+                let mut filters = None;
+                let mut clusters = None;
+                let mut icao_code = None;
+                let mut qcmp_port = None;
+                let mut datacenters = None;
+
+                while let Some(key) = map.next_key::<std::borrow::Cow<'de, str>>()? {
+                    match key.as_ref() {
+                        "id" => id = Some(map.next_value()?),
+                        "filters" => filters = Some(map.next_value()?),
+                        "clusters" => clusters = Some(map.next_value()?),
+                        "datacenters" => {
+                            if icao_code.is_some() || qcmp_port.is_some() {
+                                return Err(Error::custom(
+                                    "agent specific fields have already been deserialized",
+                                ));
+                            } else if datacenters.is_some() {
+                                return Err(Error::duplicate_field("datacenters"));
+                            }
+
+                            datacenters = Some(map.next_value()?);
+                        }
+                        "icao_code" => {
+                            if datacenters.is_some() {
+                                return Err(Error::custom(
+                                    "non-agent `datacenters` field has already been deserialized",
+                                ));
+                            } else if icao_code.is_some() {
+                                return Err(Error::duplicate_field("icao_code"));
+                            }
+
+                            icao_code = Some(map.next_value()?);
+                        }
+                        "qcmp_port" => {
+                            if datacenters.is_some() {
+                                return Err(Error::custom(
+                                    "non-agent `datacenters` field has already been deserialized",
+                                ));
+                            } else if qcmp_port.is_some() {
+                                return Err(Error::duplicate_field("qcmp_port"));
+                            }
+
+                            qcmp_port = Some(map.next_value()?);
+                        }
+                        "version" => {
+                            map.next_value::<String>()?;
+                        }
+                        unknown => {
+                            return Err(Error::unknown_field(
+                                unknown,
+                                &[
+                                    "id",
+                                    "filters",
+                                    "clusters",
+                                    "datacenters",
+                                    "icao_code",
+                                    "qcmp_port",
+                                ],
+                            ));
+                        }
+                    }
+                }
+
+                let datacenter = if let Some(datacenters) = datacenters {
+                    DatacenterConfig::NonAgent { datacenters }
+                } else {
+                    if icao_code.is_none() && qcmp_port.is_none() {
+                        DatacenterConfig::NonAgent {
+                            datacenters: Default::default(),
+                        }
+                    } else {
+                        DatacenterConfig::Agent {
+                            icao_code: Slot::new(icao_code),
+                            qcmp_port: Slot::new(qcmp_port),
+                        }
+                    }
+                };
+
+                Ok(Config {
+                    filters: filters.unwrap_or_default(),
+                    clusters: clusters.unwrap_or_default(),
+                    datacenter,
+                    dyn_cfg: DynamicConfig {
+                        id: id.map_or_else(default_id, Slot::new),
+                        typemap: default_typemap(),
+                    },
+                })
+            }
+        }
+
+        deserializer.deserialize_map(Visitor)
+    }
+}
+
+#[cfg(test)]
+impl PartialEq for Config {
+    fn eq(&self, other: &Self) -> bool {
+        if self.clusters != other.clusters
+            || self.filters != other.filters
+            || self.datacenter != other.datacenter
+        {
+            return false;
+        }
+
+        // TODO: compare typemaps
+        true
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Agent {
+    pub icao_code: Slot<IcaoCode>,
+    pub qcmp_port: Slot<u16>,
+}
+
+/// Configuration for a component
+#[derive(Clone)]
+#[cfg_attr(test, derive(Debug))]
+pub struct DynamicConfig {
+    pub id: Slot<String>,
+    typemap: ConfigMap,
+}
+
+#[cfg(test)]
+impl<'de> Deserialize<'de> for DynamicConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct DynVisitor {
+            id: Option<String>,
+            map: ConfigMap,
+        }
+
+        impl<'de> serde::de::Visitor<'de> for DynVisitor {
+            type Value = DynamicConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("Quilkin dynamic config")
+            }
+
+            fn visit_map<A>(mut self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                while let Some(key) = map.next_key::<std::borrow::Cow<'de, str>>()? {
+                    match key.as_ref() {
+                        "id" => self.id = Some(map.next_value()?),
+                        other => {
+                            return Err(serde::de::Error::unknown_field(other, &["id"]));
+                        }
+                    }
+                }
+
+                Ok(DynamicConfig {
+                    id: self.id.map_or_else(default_id, |id| Slot::new(id)),
+                    typemap: self.map,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(DynVisitor {
+            id: None,
+            map: default_typemap(),
+        })
+    }
+}
+
+impl typemap_rev::TypeMapKey for FilterChain {
+    type Value = Slot<FilterChain>;
+}
+
+impl typemap_rev::TypeMapKey for ClusterMap {
+    type Value = Watch<ClusterMap>;
+}
+
+impl typemap_rev::TypeMapKey for DatacenterMap {
+    type Value = Watch<DatacenterMap>;
+}
+
+impl typemap_rev::TypeMapKey for Agent {
+    type Value = Agent;
+}
+
+impl DynamicConfig {
+    pub fn filters(&self) -> Option<Slot<FilterChain>> {
+        self.typemap.get::<FilterChain>().cloned()
+    }
+
+    pub fn clusters(&self) -> Option<Watch<ClusterMap>> {
+        self.typemap.get::<ClusterMap>().cloned()
+    }
+
+    pub fn datacenters(&self) -> Option<Watch<DatacenterMap>> {
+        self.typemap.get::<DatacenterMap>().cloned()
+    }
+
+    pub fn agent(&self) -> Option<Agent> {
+        self.typemap.get::<Agent>().cloned()
+    }
 }
 
 impl quilkin_xds::config::Configuration for Config {
     fn identifier(&self) -> String {
-        (*self.id.load()).clone()
+        String::clone(&self.id())
     }
 
     fn allow_request_processing(&self, resource_type: &str) -> bool {
-        resource_type.parse::<crate::xds::ResourceType>().is_ok()
+        resource_type.parse::<ResourceType>().is_ok()
     }
 
     fn apply_delta(
@@ -114,8 +335,8 @@ impl quilkin_xds::config::Configuration for Config {
         _server_version: &str,
     ) -> impl Iterator<Item = (&'static str, Vec<String>)> {
         [
-            (crate::xds::CLUSTER_TYPE, Vec::new()),
-            (crate::xds::DATACENTER_TYPE, Vec::new()),
+            (xds::CLUSTER_TYPE, Vec::new()),
+            (xds::DATACENTER_TYPE, Vec::new()),
         ]
         .into_iter()
     }
@@ -124,13 +345,11 @@ impl quilkin_xds::config::Configuration for Config {
         &self,
         control_plane: quilkin_xds::server::ControlPlane<Self>,
     ) -> impl std::future::Future<Output = ()> + Send + 'static {
-        let mut cluster_watcher = self.clusters.watch();
-
         if !control_plane.is_relay {
             self.filters.watch({
                 let this = control_plane.clone();
                 move |_| {
-                    this.push_update(crate::xds::FILTER_CHAIN_TYPE);
+                    this.push_update(xds::FILTER_CHAIN_TYPE);
                 }
             });
         }
@@ -138,6 +357,7 @@ impl quilkin_xds::config::Configuration for Config {
         tracing::trace!("waiting for changes");
 
         async move {
+            let mut cluster_watcher = control_plane.config.clusters.watch();
             match &control_plane.config.datacenter {
                 crate::config::DatacenterConfig::Agent { .. } => loop {
                     match cluster_watcher.changed().await {
@@ -172,48 +392,6 @@ impl quilkin_xds::config::Configuration for Config {
 use crate::net::xds::config::DeltaDiscoveryRes;
 
 impl Config {
-    /// Attempts to deserialize `input` as a YAML object representing `Self`.
-    pub fn from_reader<R: std::io::Read>(input: R) -> Result<Self, serde_yaml::Error> {
-        serde_yaml::from_reader(input)
-    }
-
-    fn update_from_json(
-        &self,
-        mut map: serde_json::Map<String, serde_json::Value>,
-        locality: Option<crate::net::endpoint::Locality>,
-    ) -> Result<(), eyre::Error> {
-        macro_rules! replace_if_present {
-            ($($field:ident),+) => {
-                $(
-                    if let Some(value) = map.remove(stringify!($field)) {
-                        tracing::trace!(%value, "replacing {}", stringify!($field));
-                        self.$field.try_replace(serde_json::from_value(value)?);
-                    }
-                )+
-            }
-        }
-
-        replace_if_present!(filters, id);
-
-        if let Some(value) = map.remove("clusters") {
-            let cmd: cluster::ClusterMapDeser = serde_json::from_value(value)?;
-            tracing::trace!(len = cmd.endpoints.len(), "replacing clusters");
-            self.clusters.modify(|clusters| {
-                for cluster in cmd.endpoints {
-                    clusters.insert(cluster.locality, cluster.endpoints);
-                }
-
-                if let Some(locality) = locality {
-                    clusters.update_unlocated_endpoints(locality);
-                }
-            });
-        }
-
-        self.apply_metrics();
-
-        Ok(())
-    }
-
     /// Given a list of subscriptions and the current state of the calling client,
     /// construct a response with the current state of our resources that differ
     /// from those of the client
@@ -550,16 +728,20 @@ impl Config {
 
     #[inline]
     pub fn apply_metrics(&self) {
-        let clusters = self.clusters.read();
-        crate::net::cluster::active_clusters().set(clusters.len() as i64);
-        crate::net::cluster::active_endpoints().set(clusters.num_of_endpoints() as i64);
+        // let Some(clusters) = self.clusters() else {
+        //     return;
+        // };
+        crate::metrics::apply_clusters(&self.clusters);
     }
 
     pub fn default_agent() -> Self {
         Self {
             clusters: Default::default(),
             filters: Default::default(),
-            id: default_proxy_id(),
+            dyn_cfg: DynamicConfig {
+                id: default_id(),
+                typemap: default_typemap(),
+            },
             datacenter: DatacenterConfig::Agent {
                 icao_code: Default::default(),
                 qcmp_port: Default::default(),
@@ -571,7 +753,10 @@ impl Config {
         Self {
             clusters: Default::default(),
             filters: Default::default(),
-            id: default_proxy_id(),
+            dyn_cfg: DynamicConfig {
+                id: default_id(),
+                typemap: default_typemap(),
+            },
             datacenter: DatacenterConfig::NonAgent {
                 datacenters: Default::default(),
             },
@@ -587,6 +772,11 @@ impl Config {
                 unreachable!("this should not be called on an agent");
             }
         }
+    }
+
+    #[inline]
+    pub fn id(&self) -> String {
+        String::clone(&self.dyn_cfg.id.load())
     }
 }
 
@@ -843,7 +1033,7 @@ impl Default for Version {
     }
 }
 
-fn default_proxy_id() -> Slot<String> {
+pub(crate) fn default_id() -> Slot<String> {
     Slot::from(
         std::env::var("QUILKIN_SERVICE_ID")
             .or_else(|_| {
@@ -857,6 +1047,10 @@ fn default_proxy_id() -> Slot<String> {
             })
             .unwrap_or_else(|_| Uuid::new_v4().as_hyphenated().to_string()),
     )
+}
+
+pub(crate) fn default_typemap() -> ConfigMap {
+    typemap_rev::TypeMap::custom()
 }
 
 /// Filter is the configuration for a single filter
@@ -969,219 +1163,4 @@ pub enum AddrKind {
     Ipv4,
     Ipv6,
     Any,
-}
-
-#[cfg(test)]
-mod tests {
-    use std::net::Ipv6Addr;
-
-    use serde_json::json;
-
-    use crate::net::endpoint::{Endpoint, Metadata};
-
-    use super::*;
-
-    #[test]
-    fn deserialise_client() {
-        let config = Config::default_non_agent();
-        config.clusters.modify(|clusters| {
-            clusters.insert_default([Endpoint::new("127.0.0.1:25999".parse().unwrap())].into())
-        });
-
-        let _ = serde_yaml::to_string(&config).unwrap();
-    }
-
-    #[test]
-    fn deserialise_server() {
-        let config = Config::default_non_agent();
-        config.clusters.modify(|clusters| {
-            clusters.insert_default(
-                [
-                    Endpoint::new("127.0.0.1:26000".parse().unwrap()),
-                    Endpoint::new("127.0.0.1:26001".parse().unwrap()),
-                ]
-                .into(),
-            )
-        });
-
-        let _ = serde_yaml::to_string(&config).unwrap();
-    }
-
-    #[test]
-    fn parse_default_values() {
-        let config: Config = serde_json::from_value(json!({
-            "version": "v1alpha1",
-             "clusters":[]
-        }))
-        .unwrap();
-
-        assert!(config.id.load().len() > 1);
-    }
-
-    #[test]
-    fn parse_client() {
-        let config: Config = serde_json::from_value(json!({
-            "version": "v1alpha1",
-            "clusters": [{
-                "endpoints": [{
-                    "address": "127.0.0.1:25999"
-                }],
-            }]
-        }))
-        .unwrap();
-
-        let value = config.clusters.read();
-        assert_eq!(
-            &*value,
-            &ClusterMap::new_default(
-                [Endpoint::new((std::net::Ipv4Addr::LOCALHOST, 25999).into(),)].into()
-            )
-        )
-    }
-
-    #[test]
-    fn parse_ipv6_endpoint() {
-        let config: Config = serde_json::from_value(json!({
-            "version": "v1alpha1",
-            "clusters":[{
-                "endpoints": [{
-                    "address": "[2345:0425:2CA1:0000:0000:0567:5673:24b5]:25999"
-                }],
-            }]
-        }))
-        .unwrap();
-
-        let value = config.clusters.read();
-        assert_eq!(
-            &*value,
-            &ClusterMap::new_default(
-                [Endpoint::new(
-                    (
-                        "2345:0425:2CA1:0000:0000:0567:5673:24b5"
-                            .parse::<Ipv6Addr>()
-                            .unwrap(),
-                        25999
-                    )
-                        .into()
-                )]
-                .into()
-            )
-        )
-    }
-
-    #[test]
-    fn parse_server() {
-        let config: Config = serde_json::from_value(json!({
-            "version": "v1alpha1",
-            "clusters": [{
-                "endpoints": [
-                    {
-                        "address" : "127.0.0.1:26000",
-                        "metadata": {
-                            "quilkin.dev": {
-                                "tokens": ["MXg3aWp5Ng==", "OGdqM3YyaQ=="],
-                            }
-                        }
-                    },
-                    {
-                        "address" : "[2345:0425:2CA1:0000:0000:0567:5673:24b5]:25999",
-                        "metadata": {
-                            "quilkin.dev": {
-                                "tokens": ["bmt1eTcweA=="],
-                            }
-                        }
-                    }
-                ],
-            }]
-        }))
-        .unwrap_or_else(|_| Config::default_agent());
-
-        let value = config.clusters.read();
-        assert_eq!(
-            &*value,
-            &ClusterMap::new_default(
-                [
-                    Endpoint::with_metadata(
-                        "127.0.0.1:26000".parse().unwrap(),
-                        Metadata {
-                            tokens: vec!["1x7ijy6", "8gj3v2i"]
-                                .into_iter()
-                                .map(From::from)
-                                .collect(),
-                        },
-                    ),
-                    Endpoint::with_metadata(
-                        "[2345:0425:2CA1:0000:0000:0567:5673:24b5]:25999"
-                            .parse()
-                            .unwrap(),
-                        Metadata {
-                            tokens: vec!["nkuy70x"].into_iter().map(From::from).collect(),
-                        },
-                    ),
-                ]
-                .into()
-            )
-        );
-    }
-
-    #[test]
-    fn deny_unused_fields() {
-        let configs = vec![
-            "
-version: v1alpha1
-foo: bar
-clusters:
-    - endpoints:
-        - address: 127.0.0.1:7001
-",
-            "
-# proxy
-version: v1alpha1
-foo: bar
-id: client-proxy
-port: 7000
-clusters:
-    - endpoints:
-        - address: 127.0.0.1:7001
-",
-            "
-# admin
-version: v1alpha1
-admin:
-    foo: bar
-    address: 127.0.0.1:7001
-",
-            "
-# static.endpoints
-version: v1alpha1
-clusters:
-    - endpoints:
-        - address: 127.0.0.1:7001
-          connection_ids:
-            - Mxg3aWp5Ng==
-",
-            "
-# static.filters
-version: v1alpha1
-filters:
-  - name: quilkin.core.v1.rate-limiter
-    foo: bar
-",
-            "
-# dynamic.management_servers
-version: v1alpha1
-dynamic:
-  management_servers:
-    - address: 127.0.0.1:25999
-      foo: bar
-",
-        ];
-
-        for config in configs {
-            let result = Config::from_reader(config.as_bytes());
-            let error = result.unwrap_err();
-            println!("here: {}", error);
-            assert!(format!("{error:?}").contains("unknown field"));
-        }
-    }
 }

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -1,0 +1,331 @@
+use serde::ser::SerializeMap;
+
+use super::*;
+
+impl Config {
+    /// Attempts to deserialize `input` as a YAML object representing `Self`.
+    pub fn from_reader<R: std::io::Read>(input: R, is_agent: bool) -> Result<Self, eyre::Error> {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct AllConfig {
+            id: Option<String>,
+            filters: Option<crate::filters::FilterChain>,
+            clusters: Option<ClusterMap>,
+            #[serde(flatten)]
+            datacenter: DatacenterConfig,
+        }
+
+        let mut cfg: AllConfig = serde_yaml::from_reader(input)?;
+
+        // Workaround deficiency in serde flatten + untagged
+        if is_agent {
+            cfg.datacenter = match cfg.datacenter {
+                DatacenterConfig::Agent {
+                    icao_code,
+                    qcmp_port,
+                } => DatacenterConfig::Agent {
+                    icao_code,
+                    qcmp_port,
+                },
+                DatacenterConfig::NonAgent { datacenters } => {
+                    eyre::ensure!(
+                        datacenters.read().is_empty(),
+                        "starting an agent, but the configuration file has `datacenters` set"
+                    );
+                    crate::config::DatacenterConfig::Agent {
+                        icao_code: crate::config::Slot::new(crate::config::IcaoCode::default()),
+                        qcmp_port: crate::config::Slot::new(0),
+                    }
+                }
+            };
+        }
+
+        Ok(Self {
+            clusters: Watch::new(cfg.clusters.unwrap_or_default()),
+            filters: Slot::new(cfg.filters.unwrap_or_default()),
+            datacenter: cfg.datacenter,
+            dyn_cfg: DynamicConfig {
+                id: cfg.id.map_or_else(default_id, Slot::from),
+                typemap: default_typemap(),
+            },
+        })
+    }
+
+    pub fn update_from_json(
+        &self,
+        map: serde_json::Map<String, serde_json::Value>,
+        mut locality: Option<crate::net::endpoint::Locality>,
+    ) -> Result<(), eyre::Error> {
+        for (k, v) in map {
+            match k.as_str() {
+                "filters" => {
+                    self.filters.try_replace(serde_json::from_value(v)?);
+                }
+                "id" => {
+                    self.dyn_cfg.id.try_replace(serde_json::from_value(v)?);
+                }
+                "clusters" => {
+                    let cmd: cluster::ClusterMapDeser = serde_json::from_value(v)?;
+                    tracing::trace!(len = cmd.endpoints.len(), "replacing clusters");
+                    self.clusters.modify(|clusters| {
+                        for cluster in cmd.endpoints {
+                            clusters.insert(cluster.locality, cluster.endpoints);
+                        }
+
+                        if let Some(locality) = locality.take() {
+                            clusters.update_unlocated_endpoints(locality);
+                        }
+                    });
+                    self.apply_metrics();
+                }
+                field => {
+                    tracing::debug!(field, "unable to replace invalid field");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl serde::Serialize for Config {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let len = self.dyn_cfg.typemap.len() + 1 /* id */ + 1 /* filters */ + 1 /* clusters */ + if matches!(self.datacenter, DatacenterConfig::Agent { .. }) { 2 } else { 1};
+        let mut map = serializer.serialize_map(Some(len))?;
+
+        map.serialize_entry("id", &self.dyn_cfg.id)?;
+        map.serialize_entry("filters", &self.filters)?;
+        map.serialize_entry("clusters", &self.clusters)?;
+
+        match &self.datacenter {
+            DatacenterConfig::Agent {
+                icao_code,
+                qcmp_port,
+            } => {
+                map.serialize_entry("icao_code", icao_code)?;
+                map.serialize_entry("qcmp_port", qcmp_port)?;
+            }
+            DatacenterConfig::NonAgent { datacenters } => {
+                map.serialize_entry("datacenters", datacenters)?;
+            }
+        }
+
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::net::endpoint::{Endpoint, Metadata};
+    use serde_json::json;
+    use std::net::Ipv6Addr;
+
+    use super::*;
+
+    #[test]
+    fn deserialise_client() {
+        let config = Config::default_non_agent();
+        config.clusters.modify(|clusters| {
+            clusters.insert_default([Endpoint::new("127.0.0.1:25999".parse().unwrap())].into())
+        });
+
+        let _ = serde_yaml::to_string(&config).unwrap();
+    }
+
+    #[test]
+    fn deserialise_server() {
+        let config = Config::default_non_agent();
+        config.clusters.modify(|clusters| {
+            clusters.insert_default(
+                [
+                    Endpoint::new("127.0.0.1:26000".parse().unwrap()),
+                    Endpoint::new("127.0.0.1:26001".parse().unwrap()),
+                ]
+                .into(),
+            )
+        });
+
+        let _ = serde_yaml::to_string(&config).unwrap();
+    }
+
+    #[test]
+    fn parse_default_values() {
+        let config: Config = serde_json::from_value(json!({
+            "version": "v1alpha1",
+             "clusters":[]
+        }))
+        .unwrap();
+
+        assert!(!config.id().is_empty());
+    }
+
+    #[test]
+    fn parse_client() {
+        let config: Config = serde_json::from_value(json!({
+            "version": "v1alpha1",
+            "clusters": [{
+                "endpoints": [{
+                    "address": "127.0.0.1:25999"
+                }],
+            }]
+        }))
+        .unwrap();
+
+        let value = config.clusters.read();
+        assert_eq!(
+            &*value,
+            &ClusterMap::new_default(
+                [Endpoint::new((std::net::Ipv4Addr::LOCALHOST, 25999).into(),)].into()
+            )
+        )
+    }
+
+    #[test]
+    fn parse_ipv6_endpoint() {
+        let config: Config = serde_json::from_value(json!({
+            "version": "v1alpha1",
+            "clusters":[{
+                "endpoints": [{
+                    "address": "[2345:0425:2CA1:0000:0000:0567:5673:24b5]:25999"
+                }],
+            }]
+        }))
+        .unwrap();
+
+        let value = config.clusters.read();
+        assert_eq!(
+            &*value,
+            &ClusterMap::new_default(
+                [Endpoint::new(
+                    (
+                        "2345:0425:2CA1:0000:0000:0567:5673:24b5"
+                            .parse::<Ipv6Addr>()
+                            .unwrap(),
+                        25999
+                    )
+                        .into()
+                )]
+                .into()
+            )
+        )
+    }
+
+    #[test]
+    fn parse_server() {
+        let config: Config = serde_json::from_value(json!({
+            "version": "v1alpha1",
+            "clusters": [{
+                "endpoints": [
+                    {
+                        "address" : "127.0.0.1:26000",
+                        "metadata": {
+                            "quilkin.dev": {
+                                "tokens": ["MXg3aWp5Ng==", "OGdqM3YyaQ=="],
+                            }
+                        }
+                    },
+                    {
+                        "address" : "[2345:0425:2CA1:0000:0000:0567:5673:24b5]:25999",
+                        "metadata": {
+                            "quilkin.dev": {
+                                "tokens": ["bmt1eTcweA=="],
+                            }
+                        }
+                    }
+                ],
+            }]
+        }))
+        .unwrap_or_else(|_| Config::default_agent());
+
+        let value = config.clusters.read();
+        assert_eq!(
+            &*value,
+            &ClusterMap::new_default(
+                [
+                    Endpoint::with_metadata(
+                        "127.0.0.1:26000".parse().unwrap(),
+                        Metadata {
+                            tokens: vec!["1x7ijy6", "8gj3v2i"]
+                                .into_iter()
+                                .map(From::from)
+                                .collect(),
+                        },
+                    ),
+                    Endpoint::with_metadata(
+                        "[2345:0425:2CA1:0000:0000:0567:5673:24b5]:25999"
+                            .parse()
+                            .unwrap(),
+                        Metadata {
+                            tokens: vec!["nkuy70x"].into_iter().map(From::from).collect(),
+                        },
+                    ),
+                ]
+                .into()
+            )
+        );
+    }
+
+    #[test]
+    fn deny_unused_fields() {
+        let configs = vec![
+            "
+version: v1alpha1
+foo: bar
+clusters:
+    - endpoints:
+        - address: 127.0.0.1:7001
+",
+            "
+# proxy
+version: v1alpha1
+foo: bar
+id: client-proxy
+port: 7000
+clusters:
+    - endpoints:
+        - address: 127.0.0.1:7001
+",
+            "
+# admin
+version: v1alpha1
+admin:
+    foo: bar
+    address: 127.0.0.1:7001
+",
+            "
+# static.endpoints
+version: v1alpha1
+clusters:
+    - endpoints:
+        - address: 127.0.0.1:7001
+          connection_ids:
+            - Mxg3aWp5Ng==
+",
+            "
+# static.filters
+version: v1alpha1
+filters:
+  - name: quilkin.core.v1.rate-limiter
+    foo: bar
+",
+            "
+# dynamic.management_servers
+version: v1alpha1
+dynamic:
+  management_servers:
+    - address: 127.0.0.1:25999
+      foo: bar
+",
+        ];
+
+        for config in configs {
+            let result = Config::from_reader(config.as_bytes(), false);
+            let error = result.unwrap_err();
+            println!("here: {}", error);
+            assert!(format!("{error:?}").contains("unknown field"));
+        }
+    }
+}

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -9,6 +9,7 @@ impl Config {
         #[serde(deny_unknown_fields)]
         struct AllConfig {
             id: Option<String>,
+            version: Option<Version>,
             filters: Option<crate::filters::FilterChain>,
             clusters: Option<ClusterMap>,
             #[serde(flatten)]
@@ -46,6 +47,7 @@ impl Config {
             datacenter: cfg.datacenter,
             dyn_cfg: DynamicConfig {
                 id: cfg.id.map_or_else(default_id, Slot::from),
+                version: cfg.version.unwrap_or_default(),
                 typemap: default_typemap(),
             },
         })
@@ -96,6 +98,7 @@ impl serde::Serialize for Config {
         let len = self.dyn_cfg.typemap.len() + 1 /* id */ + 1 /* filters */ + 1 /* clusters */ + if matches!(self.datacenter, DatacenterConfig::Agent { .. }) { 2 } else { 1};
         let mut map = serializer.serialize_map(Some(len))?;
 
+        map.serialize_entry("version", &self.dyn_cfg.version)?;
         map.serialize_entry("id", &self.dyn_cfg.id)?;
         map.serialize_entry("filters", &self.filters)?;
         map.serialize_entry("clusters", &self.clusters)?;

--- a/src/config/watch/agones.rs
+++ b/src/config/watch/agones.rs
@@ -42,12 +42,12 @@ pub async fn watch(
         let configmap_reflector = crate::config::providers::k8s::update_filters_from_configmap(
             client.clone(),
             cns,
-            config.clone(),
+            config.filters.clone(),
         );
         let gameserver_reflector = crate::config::providers::k8s::update_endpoints_from_gameservers(
             client,
             gameservers_namespace,
-            config.clone(),
+            config.clusters.clone(),
             locality,
             address_selector,
         );
@@ -70,7 +70,7 @@ pub async fn watch(
         let gameserver_reflector = crate::config::providers::k8s::update_endpoints_from_gameservers(
             client,
             gameservers_namespace,
-            config.clone(),
+            config.clusters.clone(),
             locality,
             address_selector,
         );

--- a/src/config/watch/fs.rs
+++ b/src/config/watch/fs.rs
@@ -31,8 +31,7 @@ pub async fn watch(
     locality: Option<crate::net::endpoint::Locality>,
 ) -> crate::Result<()> {
     let path = path.into();
-    let span =
-        tracing::info_span!("config_provider", path = %path.display(), id = %config.id.load());
+    let span = tracing::info_span!("config_provider", path = %path.display(), id = %config.id());
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
     async fn watch_inner(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -353,3 +353,10 @@ pub trait CollectorExt: Collector + Clone + Sized + 'static {
 }
 
 impl<C: Collector + Clone + 'static> CollectorExt for C {}
+
+#[inline]
+pub(crate) fn apply_clusters(clusters: &crate::config::Watch<crate::net::ClusterMap>) {
+    let clusters = clusters.read();
+    crate::net::cluster::active_clusters().set(clusters.len() as i64);
+    crate::net::cluster::active_endpoints().set(clusters.num_of_endpoints() as i64);
+}


### PR DESCRIPTION
- Adds `DynamicConfig` as a field of `Config`
- Moves `id` and `version` to `DynamicConfig`
- Change phoenix and k8s to only take the fields they actually need instead of an entire config
- Change admin to only take in a `<C: Serialize>` as it only cares about dumping the config as JSON

Part of #1117 