### PR TITLE
feat: parse origin IP through proxy headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,6 +976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "fsevent-sys"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
 name = "notify"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2787,7 @@ dependencies = [
  "enum-map",
  "eyre",
  "fixedstr",
+ "forwarded-header-value",
  "futures",
  "once_cell",
  "parking_lot",

--- a/crates/xds/Cargo.toml
+++ b/crates/xds/Cargo.toml
@@ -38,3 +38,4 @@ tracing.workspace = true
 tryhard.workspace = true
 uuid.workspace = true
 url.workspace = true
+forwarded-header-value = "0.1.1"

--- a/crates/xds/src/config.rs
+++ b/crates/xds/src/config.rs
@@ -187,7 +187,7 @@ pub trait Configuration: Send + Sync + Sized + 'static {
         resource_type: &str,
         resources: Vec<Resource>,
         removed_resources: &[String],
-        remote_addr: Option<std::net::SocketAddr>,
+        remote_addr: Option<std::net::IpAddr>,
     ) -> crate::Result<()>;
 
     fn allow_request_processing(&self, resource_type: &str) -> bool;
@@ -220,7 +220,7 @@ pub fn handle_delta_discovery_responses<C: Configuration>(
     stream: impl futures::Stream<Item = tonic::Result<DeltaDiscoveryResponse>> + 'static + Send,
     config: Arc<C>,
     local: Arc<LocalVersions>,
-    remote_addr: Option<std::net::SocketAddr>,
+    remote_addr: Option<std::net::IpAddr>,
     mut notifier: Option<tokio::sync::mpsc::UnboundedSender<String>>,
 ) -> std::pin::Pin<Box<dyn futures::Stream<Item = crate::Result<DeltaDiscoveryRequest>> + Send>> {
     Box::pin(async_stream::try_stream! {

--- a/src/config.rs
+++ b/src/config.rs
@@ -392,7 +392,7 @@ impl quilkin_xds::config::Configuration for Config {
         type_url: &str,
         resources: Vec<XdsResource>,
         removed_resources: &[String],
-        remote_addr: Option<std::net::SocketAddr>,
+        remote_addr: Option<std::net::IpAddr>,
     ) -> quilkin_xds::Result<()> {
         self.apply_delta(type_url, resources, removed_resources, remote_addr)
     }
@@ -688,7 +688,7 @@ impl Config {
         type_url: &str,
         mut resources: Vec<XdsResource>,
         removed_resources: &[String],
-        remote_addr: Option<std::net::SocketAddr>,
+        remote_addr: Option<std::net::IpAddr>,
     ) -> crate::Result<()> {
         let resource_type = type_url.parse::<ResourceType>()?;
 
@@ -733,8 +733,6 @@ impl Config {
                 };
 
                 datacenters.modify(|wg| {
-                    let remote_addr = remote_addr.map(|ra| ra.ip().to_canonical());
-
                     wg.remove(removed_resources);
 
                     for res in resources {


### PR DESCRIPTION
Currently we take the host value, but that might not match if the service is behind a HTTP proxy, so we parse the standard (and common non-standard) headers to get this information.