### PR TITLE
Explicitly fail if io_uring can't be setup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() {
             match <quilkin::Cli as clap::Parser>::parse().drive().await {
                 Ok(()) => std::process::exit(0),
                 Err(error) => {
-                    tracing::error!(%error, error_debug=?error, "fatal error");
+                    tracing::error!(?error, "fatal error");
 
                     std::process::exit(-1)
                 }


### PR DESCRIPTION
This adds a block of code on linux to invoke `io_uring_setup` to detect if it fails, the most likely reason of which inside containers would be seccomp profiles not allowing the syscall. Failing here means we can give a better error message and fail more gracefully, unlike in #1183 where a panic occurs inside tokio that almost completely hides the true error.

Related: #1183 