### PR TITLE
Fix ClusterMap deadlock

### DIFF
--- a/crates/test/tests/xdp.rs
+++ b/crates/test/tests/xdp.rs
@@ -434,7 +434,7 @@ async fn multiple_servers() {
         endpoints(
             servers
                 .iter()
-                .map(|a| (a.clone(), &tok[..]))
+                .map(|a| (*a, &tok[..]))
                 .collect::<Vec<_>>()
                 .as_slice(),
         ),

--- a/src/net/cluster.rs
+++ b/src/net/cluster.rs
@@ -271,7 +271,6 @@ pub struct ClusterMap<S = gxhash::GxBuildHasher> {
 }
 
 type DashMapRef<'inner> = dashmap::mapref::one::Ref<'inner, Option<Locality>, EndpointSet>;
-type DashMapRefMut<'inner> = dashmap::mapref::one::RefMut<'inner, Option<Locality>, EndpointSet>;
 
 impl ClusterMap {
     pub fn new() -> Self {
@@ -374,20 +373,9 @@ where
         self.map.is_empty()
     }
 
+    #[inline]
     pub fn get(&self, key: &Option<Locality>) -> Option<DashMapRef<'_>> {
         self.map.get(key)
-    }
-
-    pub fn get_mut(&self, key: &Option<Locality>) -> Option<DashMapRefMut<'_>> {
-        self.map.get_mut(key)
-    }
-
-    pub fn get_default(&self) -> Option<DashMapRef<'_>> {
-        self.get(&None)
-    }
-
-    pub fn get_default_mut(&self) -> Option<DashMapRefMut<'_>> {
-        self.get_mut(&None)
     }
 
     #[inline]


### PR DESCRIPTION
The `ClusterMap::remove_endpoint` and `ClusterMap::remove_endpoint_if` would 100% cause a deadlock if the last gameserver was removed from the locality as a reference was held via the clustermap iterator, while map.remove() was called. This just moves the locality removal outside of the iteration to avoid it.