### PR TITLE
Remove Listener resource

### DIFF
--- a/benches/misc.rs
+++ b/benches/misc.rs
@@ -219,9 +219,6 @@ impl GenResource for Cluster {
 // From Config::apply
 fn deserialize(a: prost_types::Any) {
     match Resource::try_decode(a).unwrap() {
-        Resource::Listener(_) => {
-            unreachable!()
-        }
         Resource::FilterChain(fc) => {
             let chain: quilkin::filters::FilterChain = if fc.filters.is_empty() {
                 Default::default()
@@ -253,9 +250,6 @@ fn deserialize(a: prost_types::Any) {
 
 fn deserialize_faster(a: prost_types::Any) {
     match Resource::try_decode(a).unwrap() {
-        Resource::Listener(_) => {
-            unreachable!()
-        }
         Resource::FilterChain(fc) => {
             quilkin::filters::FilterChain::try_create_fallible(fc.filters).unwrap();
         }

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -224,7 +224,6 @@ impl Proxy {
                 &[
                     (crate::xds::CLUSTER_TYPE, Vec::new()),
                     (crate::xds::DATACENTER_TYPE, Vec::new()),
-                    (crate::xds::LISTENER_TYPE, Vec::new()),
                 ],
             ),
         ];

--- a/src/config/providers.rs
+++ b/src/config/providers.rs
@@ -190,7 +190,6 @@ impl Providers {
             &[
                 (crate::xds::CLUSTER_TYPE, Vec::new()),
                 (crate::xds::DATACENTER_TYPE, Vec::new()),
-                (crate::xds::LISTENER_TYPE, Vec::new()),
             ],
         ),
     ];

--- a/src/xds.rs
+++ b/src/xds.rs
@@ -21,25 +21,19 @@ use prost_types::Any;
 pub const CLUSTER_TYPE: &str = "type.googleapis.com/quilkin.config.v1alpha1.Cluster";
 pub const DATACENTER_TYPE: &str = "type.googleapis.com/quilkin.config.v1alpha1.Datacenter";
 pub const FILTER_CHAIN_TYPE: &str = "type.googleapis.com/quilkin.config.v1alpha1.FilterChain";
-pub const LISTENER_TYPE: &str = "type.googleapis.com/envoy.config.listener.v3.Listener";
 const PREFIX: &str = "type.googleapis.com/quilkin.config.v1alpha1.";
 
 pub enum Resource {
     Cluster(proto::Cluster),
     Datacenter(proto::Datacenter),
     FilterChain(proto::FilterChain),
-    Listener(proto::FilterChain),
 }
 
 impl Resource {
     #[inline]
     pub fn try_decode(any: Any) -> Result<Self, eyre::Error> {
         let Some(suffix) = any.type_url.strip_prefix(PREFIX) else {
-            if any.type_url == LISTENER_TYPE {
-                return Self::decode_listener(&any.value);
-            } else {
-                eyre::bail!("unknown resource type '{}'", any.type_url);
-            }
+            eyre::bail!("unknown resource type '{}'", any.type_url);
         };
 
         Ok(match suffix {
@@ -48,62 +42,6 @@ impl Resource {
             "FilterChain" => Self::FilterChain(proto::FilterChain::decode(&*any.value)?),
             _ => eyre::bail!("unknown resource type '{}'", any.type_url),
         })
-    }
-
-    #[inline]
-    fn decode_listener(buf: &[u8]) -> eyre::Result<Self> {
-        let mut listener =
-            quilkin_xds::generated::envoy::config::listener::v3::Listener::decode(buf)?;
-        eyre::ensure!(
-            !listener.filter_chains.is_empty(),
-            "{LISTENER_TYPE} resource had no filter chains"
-        );
-        eyre::ensure!(
-            listener.filter_chains.len() == 1,
-            "{LISTENER_TYPE} resource had more than one filter chain"
-        );
-        let filter_chain = listener.filter_chains.swap_remove(0);
-
-        let filters = filter_chain
-            .filters
-            .into_iter()
-            .map(|filter| {
-                use quilkin_xds::generated::envoy::config::listener::v3::filter::ConfigType;
-
-                let config = if let Some(config_type) = filter.config_type {
-                    let config = match config_type {
-                        ConfigType::TypedConfig(any) => any,
-                        ConfigType::ConfigDiscovery(_) => {
-                            eyre::bail!("ConfigDiscovery is not supported")
-                        }
-                    };
-
-                    let json_value = match crate::filters::FilterRegistry::get_factory(&filter.name)
-                        .ok_or_else(|| {
-                            crate::filters::CreationError::NotFound(filter.name.clone())
-                        })?
-                        .encode_config_to_json(config)
-                    {
-                        Ok(jv) => jv,
-                        Err(err) => {
-                            return Err(err.into());
-                        }
-                    };
-
-                    Some(serde_json::to_string(&json_value)?)
-                } else {
-                    None
-                };
-
-                Ok(proto::Filter {
-                    name: filter.name,
-                    label: None,
-                    config,
-                })
-            })
-            .collect::<eyre::Result<Vec<_>>>()?;
-
-        Ok(Self::Listener(proto::FilterChain { filters }))
     }
 
     #[inline]
@@ -124,28 +62,6 @@ impl Resource {
                 f.encode(&mut value)?;
                 (value, FILTER_CHAIN_TYPE)
             }
-            Self::Listener(f) => {
-                let l = quilkin_xds::generated::envoy::config::listener::v3::Listener {
-                    filter_chains: vec![quilkin_xds::generated::envoy::config::listener::v3::FilterChain {
-                        filters: f.filters.iter().map(|f| {
-                            quilkin_xds::generated::envoy::config::listener::v3::Filter {
-                                name: f.name.clone(),
-                                config_type: if let Some(cfg) = &f.config {
-                                    let jval: serde_json::Value = serde_json::from_str(cfg).unwrap();
-                                    Some(quilkin_xds::generated::envoy::config::listener::v3::filter::ConfigType::TypedConfig(crate::filters::FilterRegistry::get_factory(&f.name).unwrap().encode_config_to_protobuf(jval).unwrap()))
-                                } else {
-                                    None
-                                },
-                            }
-                        }).collect(),
-                        ..Default::default()
-                    }],
-                    ..Default::default()
-                };
-                let mut value = Vec::with_capacity(l.encoded_len());
-                l.encode(&mut value)?;
-                (value, LISTENER_TYPE)
-            }
         };
 
         Ok(Any {
@@ -160,7 +76,6 @@ impl Resource {
             Self::Cluster(_) => CLUSTER_TYPE,
             Self::Datacenter(_) => DATACENTER_TYPE,
             Self::FilterChain(_) => FILTER_CHAIN_TYPE,
-            Self::Listener(_) => LISTENER_TYPE,
         }
     }
 }
@@ -170,24 +85,15 @@ pub enum ResourceType {
     Cluster,
     Datacenter,
     FilterChain,
-    Listener,
 }
 
 impl std::str::FromStr for ResourceType {
     type Err = eyre::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let Some(suffix) = s.strip_prefix(PREFIX) else {
-            if s == LISTENER_TYPE {
-                return Ok(Self::Listener);
-            } else {
-                eyre::bail!("unknown resource type '{s}'");
-            }
-        };
-
-        Ok(match suffix {
-            "Cluster" => Self::Cluster,
-            "Datacenter" => Self::Datacenter,
-            "FilterChain" => Self::FilterChain,
+        Ok(match s.strip_prefix(PREFIX) {
+            Some("Cluster") => Self::Cluster,
+            Some("Datacenter") => Self::Datacenter,
+            Some("FilterChain") => Self::FilterChain,
             _ => eyre::bail!("unknown resource type '{s}'"),
         })
     }


### PR DESCRIPTION
The `Listener` resource was supplanted by `FilterChain` a while back, this just removes the last vestiges.