### PR TITLE
chore(refactor): move service to the top level directory

### DIFF
--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -331,7 +331,7 @@ impl QuilkinLoop {
                 );
             });
 
-            let proxy = quilkin::cli::Service::builder()
+            let proxy = quilkin::Service::builder()
                 .udp()
                 .udp_port(port)
                 .qcmp()

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -330,7 +330,7 @@ impl Pail {
                     .fs()
                     .fs_path(path)
                     .spawn_providers(&config, <_>::default(), None);
-                let task = quilkin::cli::Service::default()
+                let task = quilkin::Service::default()
                     .xds()
                     .xds_port(xds_port)
                     .mds()
@@ -405,7 +405,7 @@ impl Pail {
                     .fs_path(path)
                     .grpc_push_endpoints(relay_servers)
                     .spawn_providers(&config, <_>::default(), None);
-                let task = quilkin::cli::Service::default()
+                let task = quilkin::Service::default()
                     .qcmp()
                     .qcmp_port(port)
                     .spawn_services(&config, &shutdown_rx, apc.icao_code)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -21,17 +21,10 @@ use clap::crate_version;
 
 use strum_macros::{Display, EnumString};
 
-pub use self::{
-    generate_config_schema::GenerateConfigSchema,
-    qcmp::Qcmp,
-    service::{Finalizer, Service},
-};
+pub use self::{generate_config_schema::GenerateConfigSchema, qcmp::Qcmp};
 
 pub mod generate_config_schema;
 pub mod qcmp;
-mod service;
-
-pub use service::XdpOptions;
 
 const ETC_CONFIG_PATH: &str = "/etc/quilkin/quilkin.yaml";
 
@@ -128,7 +121,7 @@ pub struct Cli {
     #[command(flatten)]
     pub providers: crate::config::providers::Providers,
     #[command(flatten)]
-    pub service: Service,
+    pub service: crate::service::Service,
 }
 
 /// The various log format options
@@ -315,5 +308,13 @@ impl std::str::FromStr for Timeout {
         };
 
         Ok(Self(std::time::Duration::from_secs(seconds)))
+    }
+}
+
+impl std::ops::Deref for Timeout {
+    type Target = std::time::Duration;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/components/proxy.rs
+++ b/src/components/proxy.rs
@@ -71,7 +71,7 @@ pub struct Proxy {
     pub qcmp: socket2::Socket,
     pub phoenix: crate::net::TcpListener,
     pub notifier: Option<tokio::sync::mpsc::UnboundedSender<String>>,
-    pub xdp: crate::cli::XdpOptions,
+    pub xdp: crate::service::XdpOptions,
     pub termination_timeout: Option<crate::cli::Timeout>,
 }
 
@@ -293,7 +293,7 @@ impl Proxy {
         )
         .port();
 
-        let svc_task = crate::cli::Service::default()
+        let svc_task = crate::Service::default()
             .udp()
             .udp_port(udp_port)
             .xdp(self.xdp)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,12 +31,13 @@ pub mod codec;
 pub mod components;
 pub mod config;
 pub mod filters;
+pub mod service;
 pub mod xds;
 
 #[doc(hidden)]
 pub mod test;
 
-pub use quilkin_proto as generated;
+pub use {quilkin_proto as generated, service::Service};
 
 pub type Result<T, E = eyre::Error> = std::result::Result<T, E>;
 

--- a/src/net/phoenix.rs
+++ b/src/net/phoenix.rs
@@ -45,7 +45,7 @@ pub fn spawn<M: Clone + Measurement + Sync + Send + 'static>(
     listener: crate::net::TcpListener,
     datacenters: config::Watch<config::DatacenterMap>,
     phoenix: Phoenix<M>,
-) -> crate::Result<crate::cli::Finalizer> {
+) -> crate::Result<crate::service::Finalizer> {
     use eyre::WrapErr as _;
     use hyper::{Response, StatusCode};
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -117,7 +117,7 @@ pub struct Service {
     )]
     tls_key_path: Option<std::path::PathBuf>,
     #[clap(long = "termination-timeout")]
-    termination_timeout: Option<super::Timeout>,
+    termination_timeout: Option<crate::cli::Timeout>,
 }
 
 pub type Finalizer = Box<dyn FnOnce(&crate::signal::ShutdownRx) + Send>;
@@ -226,7 +226,7 @@ impl Service {
             || self.mds_enabled
     }
 
-    pub fn termination_timeout(mut self, timeout: Option<super::Timeout>) -> Self {
+    pub fn termination_timeout(mut self, timeout: Option<crate::cli::Timeout>) -> Self {
         self.termination_timeout = timeout;
         self
     }
@@ -302,7 +302,7 @@ impl Service {
                         sessions_check.tick().await;
                         let elapsed = start.elapsed();
                         if let Some(tt) = &self.termination_timeout {
-                            if elapsed > tt.0 {
+                            if elapsed > **tt {
                                 tracing::info!(
                                     ?elapsed,
                                     "termination timeout was reached before all sessions expired"


### PR DESCRIPTION
This is just to separate service from being part of CLI, as the service configuration can come from many places. No actual API changes aside from that.