### PR TITLE
fix(mmdb): do not terminate task on completion

### DIFF
--- a/src/providers.rs
+++ b/src/providers.rs
@@ -482,8 +482,9 @@ impl Providers {
                         tracing::warn!(%error, "error updating maxmind database");
                     }
 
-                    tracing::error!("terminating mmdb task");
-                    Ok(())
+                    // TODO: Keep task running for now, should be replaced with
+                    // checking for updates to the mmdb source.
+                    std::future::pending().await
                 })
             },
         )


### PR DESCRIPTION
The providers JoinSet was terminating early because of the mmdb provider completing. Updated so it now goes into pending.