### PR TITLE
Add more logging to xDS client to investigate issue

### DIFF
--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -568,7 +568,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
             let mut resource_subscriptions = resource_subscriptions;
 
             loop {
-                tracing::trace!("creating discovery response handler");
+                tracing::info!("creating discovery response handler");
                 let mut response_stream = crate::config::handle_delta_discovery_responses(
                     identifier.clone(),
                     stream,
@@ -578,6 +578,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                     notifier.clone(),
                 );
 
+                tracing::info!("entering xDS stream loop");
                 loop {
                     let next_response =
                         tokio::time::timeout(IDLE_REQUEST_INTERVAL, response_stream.next());
@@ -626,9 +627,11 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                     DeltaClientStream::connect(&endpoints, identifier.clone()).await?;
 
                 resource_subscriptions = handle_first_response(&mut stream, resources).await?;
+                tracing::info!("received first response");
 
                 ds.refresh(&identifier, resource_subscriptions.to_vec(), &local)
                     .await?;
+                tracing::info!("xDS connection refreshed");
             }
         }
         .instrument(tracing::trace_span!("xds_client_stream", id)),


### PR DESCRIPTION
Working with the hypothesis that we for some reason fail to flip back the readiness check I want to see how far we get and ensure we successfully re-enter the stream loop

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/quilkin/blob/main/CONTRIBUTING.md 
   and developer guide https://github.com/googleforgames/quilkin/blob/main/build/README.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/googleforgames/quilkin/blob/main/build/README.md#run-tests
-->

**What type of PR is this?**

/kind other


**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Related to: #1227 

**Special notes for your reviewer**:

