### PR TITLE
More logging in xDS client

### DIFF
--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -476,7 +476,7 @@ impl DeltaServerStream {
 }
 
 pub struct DeltaSubscription {
-    handle: tokio::task::JoinHandle<Result<()>>,
+    pub handle: tokio::task::JoinHandle<Result<()>>,
 }
 
 impl Drop for DeltaSubscription {

--- a/crates/xds/src/metrics.rs
+++ b/crates/xds/src/metrics.rs
@@ -128,6 +128,7 @@ pub struct StreamConnectionMetrics {
 
 impl StreamConnectionMetrics {
     pub fn new(control_plane: String) -> Self {
+        tracing::info!("StreamConnectionMetrics created");
         self::active_control_planes(&control_plane).inc();
 
         Self { control_plane }
@@ -136,6 +137,7 @@ impl StreamConnectionMetrics {
 
 impl Drop for StreamConnectionMetrics {
     fn drop(&mut self) {
+        tracing::info!("StreamConnectionMetrics dropped");
         self::active_control_planes(&self.control_plane).dec();
     }
 }


### PR DESCRIPTION
It seemed weird to me that we never awaited the `JoinHandle` in the `DeltaSubscription`, I assume there's no "magic" in tokio that would catch the errors? ~Not sure if just making the handle `pub` is the most elegant but want to try it out~ EDIT: ok this turned super hacky, very much not mergable in the current state but just want an image built so I can test it out.