### PR TITLE
Don't fail xDS task on failed send_response

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -523,6 +523,22 @@ pub(crate) fn packets_dropped_total(
     PACKETS_DROPPED.with_label_values(&[direction.label(), source, asn.asn])
 }
 
+pub(crate) fn provider_task_failures_total(provider_task: &str) -> IntCounter {
+    static PROVIDER_TASK_FAILURES_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+        prometheus::register_int_counter_vec_with_registry! {
+            prometheus::opts! {
+                "provider_task_failures_total",
+                "The number of times a provider task has failed and had to be restarted",
+            },
+            &["task"],
+            registry(),
+        }
+        .unwrap()
+    });
+
+    PROVIDER_TASK_FAILURES_TOTAL.with_label_values(&[provider_task])
+}
+
 /// Create a generic metrics options.
 /// Use `filter_opts` instead if the intended target is a filter.
 pub fn opts(name: &str, subsystem: &str, description: &str) -> Opts {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -30,7 +30,6 @@ pub const DIRECTION_LABEL: &str = "event";
 pub(crate) const READ: Direction = Direction::Read;
 pub(crate) const WRITE: Direction = Direction::Write;
 pub(crate) const ASN_LABEL: &str = "asn";
-pub(crate) const PREFIX_LABEL: &str = "ip_prefix";
 
 /// Label value for [`DIRECTION_LABEL`] for `read` events
 pub const READ_DIRECTION_LABEL: &str = "read";
@@ -210,13 +209,13 @@ pub(crate) mod qcmp {
                     "service_qcmp_bytes_total",
                     "Total number of bytes processed through QCMP",
                 },
-                &["kind", ASN_LABEL, PREFIX_LABEL],
+                &["kind", ASN_LABEL],
                 registry(),
             }
             .unwrap()
         });
 
-        METRIC.with_label_values(&[kind, asn.asn, asn.prefix])
+        METRIC.with_label_values(&[kind, asn.asn])
     }
 
     pub(crate) fn errors_total(reason: &str, asn: &AsnInfo<'_>) -> IntCounter {
@@ -226,13 +225,13 @@ pub(crate) mod qcmp {
                     "service_qcmp_errors_total",
                     "total number of errors QCMP has encountered",
                 },
-                &["reason", ASN_LABEL, PREFIX_LABEL],
+                &["reason", ASN_LABEL],
                 registry(),
             }
             .unwrap()
         });
 
-        METRIC.with_label_values(&[reason, asn.asn, asn.prefix])
+        METRIC.with_label_values(&[reason, asn.asn])
     }
 
     fn packets_total(kind: &'static str, asn: &AsnInfo<'_>) -> IntCounter {
@@ -242,13 +241,13 @@ pub(crate) mod qcmp {
                     "service_qcmp_packets_total",
                     "Total number of packets processed through QCMP",
                 },
-                &["kind", ASN_LABEL, PREFIX_LABEL],
+                &["kind", ASN_LABEL],
                 registry(),
             }
             .unwrap()
         });
 
-        METRIC.with_label_values(&[kind, asn.asn, asn.prefix])
+        METRIC.with_label_values(&[kind, asn.asn])
     }
 
     pub(crate) fn packets_total_invalid(size: usize, asn_info: &AsnInfo<'_>) {
@@ -447,13 +446,13 @@ pub(crate) fn bytes_total(direction: Direction, asn: &AsnInfo<'_>) -> IntCounter
                 "bytes_total",
                 "total number of bytes",
             },
-            &[Direction::LABEL, ASN_LABEL, PREFIX_LABEL],
+            &[Direction::LABEL, ASN_LABEL],
             registry(),
         }
         .unwrap()
     });
 
-    BYTES_TOTAL.with_label_values(&[direction.label(), asn.asn, asn.prefix])
+    BYTES_TOTAL.with_label_values(&[direction.label(), asn.asn])
 }
 
 pub(crate) fn errors_total(direction: Direction, display: &str, asn: &AsnInfo<'_>) -> IntCounter {
@@ -463,13 +462,13 @@ pub(crate) fn errors_total(direction: Direction, display: &str, asn: &AsnInfo<'_
                 "errors_total",
                 "total number of errors sending packets",
             },
-            &[Direction::LABEL, "display", ASN_LABEL, PREFIX_LABEL],
+            &[Direction::LABEL, "display", ASN_LABEL],
             registry(),
         }
         .unwrap()
     });
 
-    ERRORS_TOTAL.with_label_values(&[direction.label(), display, asn.asn, asn.prefix])
+    ERRORS_TOTAL.with_label_values(&[direction.label(), display, asn.asn])
 }
 
 pub(crate) fn packet_jitter(direction: Direction, asn: &AsnInfo<'_>) -> IntGauge {
@@ -479,13 +478,13 @@ pub(crate) fn packet_jitter(direction: Direction, asn: &AsnInfo<'_>) -> IntGauge
                 "packet_jitter",
                 "The time between new packets",
             },
-            &[Direction::LABEL, ASN_LABEL, PREFIX_LABEL],
+            &[Direction::LABEL, ASN_LABEL],
             registry(),
         }
         .unwrap()
     });
 
-    PACKET_JITTER.with_label_values(&[direction.label(), asn.asn, asn.prefix])
+    PACKET_JITTER.with_label_values(&[direction.label(), asn.asn])
 }
 
 pub(crate) fn packets_total(direction: Direction, asn: &AsnInfo<'_>) -> IntCounter {
@@ -495,13 +494,13 @@ pub(crate) fn packets_total(direction: Direction, asn: &AsnInfo<'_>) -> IntCount
                 "packets_total",
                 "Total number of packets",
             },
-            &[Direction::LABEL, ASN_LABEL, PREFIX_LABEL],
+            &[Direction::LABEL, ASN_LABEL],
             registry(),
         }
         .unwrap()
     });
 
-    PACKETS_TOTAL.with_label_values(&[direction.label(), asn.asn, asn.prefix])
+    PACKETS_TOTAL.with_label_values(&[direction.label(), asn.asn])
 }
 
 pub(crate) fn packets_dropped_total(
@@ -515,13 +514,13 @@ pub(crate) fn packets_dropped_total(
                 "packets_dropped_total",
                 "Total number of dropped packets",
             },
-            &[Direction::LABEL, "source", ASN_LABEL, PREFIX_LABEL],
+            &[Direction::LABEL, "source", ASN_LABEL],
             registry(),
         }
         .unwrap()
     });
 
-    PACKETS_DROPPED.with_label_values(&[direction.label(), source, asn.asn, asn.prefix])
+    PACKETS_DROPPED.with_label_values(&[direction.label(), source, asn.asn])
 }
 
 /// Create a generic metrics options.

--- a/src/net/sessions/inner_metrics.rs
+++ b/src/net/sessions/inner_metrics.rs
@@ -24,13 +24,13 @@ const AS_NAME_LABEL: &str = "organization";
 const COUNTRY_CODE_LABEL: &str = "country_code";
 const PREFIX_ENTITY_LABEL: &str = "prefix_entity";
 const PREFIX_NAME_LABEL: &str = "prefix_name";
-use crate::metrics::{ASN_LABEL, PREFIX_LABEL};
+use crate::metrics::ASN_LABEL;
 
 pub(crate) fn active_sessions(asn: Option<&crate::net::maxmind_db::IpNetEntry>) -> IntGauge {
     static ACTIVE_SESSIONS: Lazy<IntGaugeVec> = Lazy::new(|| {
         prometheus::register_int_gauge_vec_with_registry! {
             Opts::new("active", "number of sessions currently active").subsystem(SUBSYSTEM),
-            &[ASN_LABEL, AS_NAME_LABEL, COUNTRY_CODE_LABEL, PREFIX_LABEL, PREFIX_ENTITY_LABEL, PREFIX_NAME_LABEL],
+            &[ASN_LABEL, AS_NAME_LABEL, COUNTRY_CODE_LABEL, PREFIX_ENTITY_LABEL, PREFIX_NAME_LABEL],
             crate::metrics::registry(),
         }
         .unwrap()
@@ -45,12 +45,11 @@ pub(crate) fn active_sessions(asn: Option<&crate::net::maxmind_db::IpNetEntry>) 
             unsafe { std::str::from_utf8_unchecked(&asn[..len as _]) },
             &asnfo.as_name,
             &asnfo.as_cc,
-            &asnfo.prefix,
             &asnfo.prefix_entity,
             &asnfo.prefix_name,
         ])
     } else {
-        ACTIVE_SESSIONS.with_label_values(&["", "", "", "", "", ""])
+        ACTIVE_SESSIONS.with_label_values(&["", "", "", "", ""])
     }
 }
 


### PR DESCRIPTION
Also remove `ip_prefix` label from metrics for now due to high cardinality, we can come back to that later when needed. And add a `provider_task_failures_total` metric to track how often tasks fail.