### PR TITLE
refactor: Remove Config::default(), init typemap depending on enabled services/providers

### DIFF
--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -328,7 +328,7 @@ impl QuilkinLoop {
             let providers = quilkin::Providers::default();
             let service = quilkin::Service::default();
             let config = Arc::new(quilkin::Config::new(
-                "".into(),
+                None,
                 Default::default(),
                 &providers,
                 &service,

--- a/benches/shared.rs
+++ b/benches/shared.rs
@@ -325,7 +325,14 @@ impl QuilkinLoop {
 
         let thread = spawn("quilkin", move || {
             let runtime = tokio::runtime::Runtime::new().unwrap();
-            let config = Arc::new(quilkin::Config::default());
+            let providers = quilkin::Providers::default();
+            let service = quilkin::Service::default();
+            let config = Arc::new(quilkin::Config::new(
+                "".into(),
+                Default::default(),
+                &providers,
+                &service,
+            ));
             config.dyn_cfg.clusters().unwrap().modify(|clusters| {
                 clusters.insert_default(
                     [quilkin::net::endpoint::Endpoint::new(endpoint.into())].into(),

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -370,7 +370,7 @@ impl Pail {
                     .mds_port(mds_port);
 
                 let config = Arc::new(crate::Config::new(
-                    "test-relay".into(),
+                    Some("test-relay".into()),
                     Default::default(),
                     &providers,
                     &svc,
@@ -451,7 +451,7 @@ impl Pail {
                     .grpc_push_endpoints(relay_servers);
 
                 let config = Arc::new(crate::Config::new(
-                    "test-agent".into(),
+                    Some("test-agent".into()),
                     apc.icao_code,
                     &providers,
                     &svc,
@@ -517,7 +517,7 @@ impl Pail {
                     .termination_timeout(None);
 
                 let config = Arc::new(crate::Config::new(
-                    "test-proxy".into(),
+                    Some("test-proxy".into()),
                     Default::default(),
                     &Default::default(),
                     &svc,

--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -94,7 +94,7 @@ trace_test!(uring_receiver, {
 
     let service = quilkin::Service::builder().udp();
     let config = std::sync::Arc::new(quilkin::Config::new(
-        "".into(),
+        None,
         Default::default(),
         &Default::default(),
         &service,
@@ -146,7 +146,7 @@ trace_test!(
         let (mut packet_rx, endpoint) = sb.server("server");
 
         let config = std::sync::Arc::new(quilkin::Config::new(
-            "".into(),
+            None,
             Default::default(),
             &Default::default(),
             &Default::default(),

--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -92,7 +92,13 @@ trace_test!(uring_receiver, {
 
     let (mut packet_rx, endpoint) = sb.server("server");
 
-    let config = std::sync::Arc::new(quilkin::Config::default());
+    let service = quilkin::Service::builder().udp();
+    let config = std::sync::Arc::new(quilkin::Config::new(
+        "".into(),
+        Default::default(),
+        &Default::default(),
+        &service,
+    ));
     config
         .dyn_cfg
         .clusters()
@@ -139,7 +145,12 @@ trace_test!(
 
         let (mut packet_rx, endpoint) = sb.server("server");
 
-        let config = std::sync::Arc::new(quilkin::Config::default());
+        let config = std::sync::Arc::new(quilkin::Config::new(
+            "".into(),
+            Default::default(),
+            &Default::default(),
+            &Default::default(),
+        ));
         config
             .dyn_cfg
             .clusters()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -257,9 +257,16 @@ impl Cli {
         tracing::debug!(cli = ?self, "config parameters");
 
         let locality = self.locality.locality();
-        let config =
-            self.service
-                .read_config(&self.config, self.locality.icao_code, locality.clone())?;
+
+        // TODO should use self.service.id instead of default_id() here
+        let mut config = crate::Config::new(
+            crate::config::default_id(),
+            self.locality.icao_code,
+            &self.providers,
+            &self.service,
+        );
+        config.read_config(&self.config, locality.clone())?;
+        let config = Arc::new(config);
 
         let ready = Arc::<std::sync::atomic::AtomicBool>::default();
         let shutdown_handler = crate::signal::spawn_handler();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -258,9 +258,8 @@ impl Cli {
 
         let locality = self.locality.locality();
 
-        // TODO should use self.service.id instead of default_id() here
         let mut config = crate::Config::new(
-            crate::config::default_id(),
+            self.service.id.clone(),
             self.locality.icao_code,
             &self.providers,
             &self.service,

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -106,7 +106,7 @@ mod tests {
         let providers = Default::default();
         let service = Default::default();
         let config = Config::new(
-            "deserialize_client".into(),
+            Some("deserialize_client".into()),
             Default::default(),
             &providers,
             &service,
@@ -123,7 +123,7 @@ mod tests {
         let providers = Default::default();
         let service = Default::default();
         let config = Config::new(
-            "deserialize_server".into(),
+            Some("deserialize_server".into()),
             Default::default(),
             &providers,
             &service,
@@ -146,7 +146,12 @@ mod tests {
         let providers = Default::default();
         let service = Default::default();
         let before = String::from("parse_default_values");
-        let config = Config::new(before.clone(), Default::default(), &providers, &service);
+        let config = Config::new(
+            Some(before.clone()),
+            Default::default(),
+            &providers,
+            &service,
+        );
         assert!(!before.is_empty());
         config
             .update_from_json(
@@ -167,7 +172,7 @@ mod tests {
         let providers = Default::default();
         let service = Default::default();
         let config = Config::new(
-            "parse_client".into(),
+            Some("parse_client".into()),
             Default::default(),
             &providers,
             &service,
@@ -201,7 +206,7 @@ mod tests {
         let providers = Default::default();
         let service = Default::default();
         let config = Config::new(
-            "parse_ipv6_endpoint".into(),
+            Some("parse_ipv6_endpoint".into()),
             Default::default(),
             &providers,
             &service,
@@ -244,7 +249,7 @@ mod tests {
         let providers = Default::default();
         let service = Default::default();
         let config = Config::new(
-            "parse_server".into(),
+            Some("parse_server".into()),
             Default::default(),
             &providers,
             &service,
@@ -363,7 +368,7 @@ dynamic:
         let providers = crate::Providers::default();
         let service = crate::Service::default();
         let mut config = Config::new(
-            "deny_unused_fields".into(),
+            Some("deny_unused_fields".into()),
             Default::default(),
             &providers,
             &service,

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -103,7 +103,14 @@ mod tests {
 
     #[test]
     fn deserialise_client() {
-        let config = Config::default();
+        let providers = Default::default();
+        let service = Default::default();
+        let config = Config::new(
+            "deserialize_client".into(),
+            Default::default(),
+            &providers,
+            &service,
+        );
         config.dyn_cfg.clusters().unwrap().modify(|clusters| {
             clusters.insert_default([Endpoint::new("127.0.0.1:25999".parse().unwrap())].into());
         });
@@ -113,7 +120,14 @@ mod tests {
 
     #[test]
     fn deserialise_server() {
-        let config = Config::default();
+        let providers = Default::default();
+        let service = Default::default();
+        let config = Config::new(
+            "deserialize_server".into(),
+            Default::default(),
+            &providers,
+            &service,
+        );
         config.dyn_cfg.clusters().unwrap().modify(|clusters| {
             clusters.insert_default(
                 [
@@ -129,8 +143,10 @@ mod tests {
 
     #[test]
     fn parse_default_values() {
-        let config = Config::default();
-        let before = config.id();
+        let providers = Default::default();
+        let service = Default::default();
+        let before = String::from("parse_default_values");
+        let config = Config::new(before.clone(), Default::default(), &providers, &service);
         assert!(!before.is_empty());
         config
             .update_from_json(
@@ -148,7 +164,14 @@ mod tests {
 
     #[test]
     fn parse_client() {
-        let config = Config::default();
+        let providers = Default::default();
+        let service = Default::default();
+        let config = Config::new(
+            "parse_client".into(),
+            Default::default(),
+            &providers,
+            &service,
+        );
         config
             .update_from_json(
                 serde_json::from_value(json!({
@@ -175,7 +198,14 @@ mod tests {
 
     #[test]
     fn parse_ipv6_endpoint() {
-        let config = Config::default();
+        let providers = Default::default();
+        let service = Default::default();
+        let config = Config::new(
+            "parse_ipv6_endpoint".into(),
+            Default::default(),
+            &providers,
+            &service,
+        );
         config
             .update_from_json(
                 serde_json::from_value(json!({
@@ -211,7 +241,14 @@ mod tests {
 
     #[test]
     fn parse_server() {
-        let config = Config::default();
+        let providers = Default::default();
+        let service = Default::default();
+        let config = Config::new(
+            "parse_server".into(),
+            Default::default(),
+            &providers,
+            &service,
+        );
         config
             .update_from_json(
                 serde_json::from_value(json!({
@@ -323,7 +360,16 @@ dynamic:
 ",
         ];
 
-        let config = Config::default();
+        let providers = crate::Providers::default();
+        let service = crate::Service::default();
+        let mut config = Config::new(
+            "deny_unused_fields".into(),
+            Default::default(),
+            &providers,
+            &service,
+        );
+        insert_default::<crate::filters::FilterChain>(&mut config.dyn_cfg.typemap);
+
         for cstr in configs {
             let json = serde_yaml::from_str(cstr).unwrap();
             let result = config.update_from_json(json, None);

--- a/src/providers/fs.rs
+++ b/src/providers/fs.rs
@@ -98,13 +98,13 @@ mod tests {
         let providers = Default::default();
         let service = Default::default();
         let source = Arc::new(crate::Config::new(
-            "basic".into(),
+            Some("basic".into()),
             Default::default(),
             &providers,
             &service,
         ));
         let dest = Arc::new(crate::Config::new(
-            "basic".into(),
+            Some("basic".into()),
             Default::default(),
             &providers,
             &service,

--- a/src/providers/fs.rs
+++ b/src/providers/fs.rs
@@ -95,8 +95,20 @@ mod tests {
 
     #[tokio::test]
     async fn basic() {
-        let source = Arc::new(crate::Config::default());
-        let dest = Arc::new(crate::Config::default());
+        let providers = Default::default();
+        let service = Default::default();
+        let source = Arc::new(crate::Config::new(
+            "basic".into(),
+            Default::default(),
+            &providers,
+            &service,
+        ));
+        let dest = Arc::new(crate::Config::new(
+            "basic".into(),
+            Default::default(),
+            &providers,
+            &service,
+        ));
         assert_eq!(source, dest);
 
         let tmp_dir = tempfile::tempdir().unwrap();

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,13 +1,7 @@
 use eyre::ContextCompat;
 use std::sync::Arc;
 
-use crate::{
-    components::proxy::SessionPool,
-    config::{Config, IcaoCode},
-    signal::ShutdownHandler,
-};
-
-const ETC_CONFIG_PATH: &str = "/etc/quilkin/quilkin.yaml";
+use crate::{components::proxy::SessionPool, config::Config, signal::ShutdownHandler};
 
 #[derive(Debug, clap::Parser)]
 #[command(next_help_heading = "Service Options")]
@@ -254,67 +248,23 @@ impl Service {
             || self.grpc_enabled
     }
 
-    pub fn build_config(&self, icao_code: IcaoCode) -> eyre::Result<Config> {
+    /// Adds the required typemap entries to the config depending on what services are enabled
+    pub fn init_config(&self, config: &mut Config) {
         use crate::config::{self, insert_default};
 
-        let mut typemap = crate::config::default_typemap();
-
         if self.udp_enabled || self.xds_enabled || self.mds_enabled {
-            insert_default::<crate::filters::FilterChain>(&mut typemap);
-            insert_default::<config::DatacenterMap>(&mut typemap);
+            insert_default::<crate::filters::FilterChain>(&mut config.dyn_cfg.typemap);
+            insert_default::<config::DatacenterMap>(&mut config.dyn_cfg.typemap);
         }
 
         if self.qcmp_enabled {
-            typemap.insert::<config::qcmp::QcmpPort>(config::qcmp::QcmpPort::new(self.qcmp_port));
+            config
+                .dyn_cfg
+                .typemap
+                .insert::<config::qcmp::QcmpPort>(config::qcmp::QcmpPort::new(self.qcmp_port));
         }
 
-        insert_default::<crate::net::ClusterMap>(&mut typemap);
-
-        Ok(Config {
-            dyn_cfg: config::DynamicConfig {
-                id: Arc::new(parking_lot::Mutex::new(config::default_id())),
-                version: config::Version::default(),
-                icao_code: config::NotifyingIcaoCode::new(icao_code),
-                typemap,
-            },
-        })
-    }
-
-    /// Attempts to find and configure a `Config` from a file
-    ///
-    ///
-    pub fn read_config(
-        &self,
-        config_path: &std::path::Path,
-        icao_code: IcaoCode,
-        locality: Option<crate::net::endpoint::Locality>,
-    ) -> Result<Arc<Config>, eyre::Error> {
-        let paths = [config_path, std::path::Path::new(ETC_CONFIG_PATH)];
-        let mut paths = paths.iter();
-
-        let file = loop {
-            let Some(path) = paths.next() else {
-                return Ok(<_>::default());
-            };
-
-            match std::fs::File::open(path) {
-                Ok(file) => break file,
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    tracing::debug!(path = %path.display(), "config path not found");
-                    continue;
-                }
-                Err(err) => {
-                    tracing::error!(path = %path.display(), error = ?err, "failed to read path");
-                    eyre::bail!(err);
-                }
-            }
-        };
-
-        let config = self.build_config(icao_code)?;
-        let json = serde_yaml::from_reader(file)?;
-        config.update_from_json(json, locality)?;
-
-        Ok(Arc::new(config))
+        insert_default::<crate::net::ClusterMap>(&mut config.dyn_cfg.typemap);
     }
 
     pub fn termination_timeout(mut self, timeout: Option<crate::cli::Duration>) -> Self {

--- a/src/service.rs
+++ b/src/service.rs
@@ -8,7 +8,7 @@ use crate::{components::proxy::SessionPool, config::Config, signal::ShutdownHand
 pub struct Service {
     /// The identifier for an instance.
     #[arg(long = "service.id", env = "QUILKIN_SERVICE_ID")]
-    id: Option<String>,
+    pub id: Option<String>,
     /// Whether to serve mDS requests.
     #[arg(
         long = "service.mds",

--- a/src/test.rs
+++ b/src/test.rs
@@ -292,6 +292,17 @@ impl TestHelper {
         addr.into()
     }
 
+    pub fn new_config() -> Config {
+        let providers = crate::Providers::default();
+        let service = crate::Service::builder().udp().qcmp();
+        crate::Config::new(
+            "test-server".into(),
+            Default::default(),
+            &providers,
+            &service,
+        )
+    }
+
     pub async fn run_server(
         &mut self,
         config: Arc<Config>,

--- a/src/test.rs
+++ b/src/test.rs
@@ -296,7 +296,7 @@ impl TestHelper {
         let providers = crate::Providers::default();
         let service = crate::Service::builder().udp().qcmp();
         crate::Config::new(
-            "test-server".into(),
+            Some("test-server".into()),
             Default::default(),
             &providers,
             &service,

--- a/tests/health.rs
+++ b/tests/health.rs
@@ -26,7 +26,7 @@ async fn health_server() {
     let mut t = TestHelper::default();
 
     // create server configuration
-    let server_config = std::sync::Arc::new(quilkin::Config::default());
+    let server_config = std::sync::Arc::new(TestHelper::new_config());
     server_config
         .dyn_cfg
         .clusters()

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -33,7 +33,7 @@ async fn metrics_server() {
         .port();
 
     // create server configuration
-    let server_config = std::sync::Arc::new(quilkin::Config::default());
+    let server_config = std::sync::Arc::new(TestHelper::new_config());
     server_config
         .dyn_cfg
         .clusters()
@@ -48,7 +48,7 @@ async fn metrics_server() {
         .await;
 
     // create a local client
-    let client_config = std::sync::Arc::new(quilkin::Config::default());
+    let client_config = std::sync::Arc::new(TestHelper::new_config());
     client_config
         .dyn_cfg
         .clusters()

--- a/tests/qcmp.rs
+++ b/tests/qcmp.rs
@@ -31,7 +31,7 @@ async fn proxy_ping() {
         to: vec![(Ipv4Addr::UNSPECIFIED, 0).into()],
         ..<_>::default()
     };
-    let server_config = std::sync::Arc::new(quilkin::Config::default());
+    let server_config = std::sync::Arc::new(TestHelper::new_config());
     t.run_server(server_config, Some(server_proxy), None).await;
     ping(qcmp_port).await;
 }


### PR DESCRIPTION
Part four of breaking up https://github.com/googleforgames/quilkin/pull/1245

Removes the `Default` implementation for Config and adds a constructor instead. Now the typemap will be initialized only with the types which are required by the providers/services that are enabled.

Also consolidates service id configuration so it is fetched from the cli struct and can be set with `--service.id` and not only `QUILKIN_SERVICE_ID`