### PR TITLE
Always send control_plane in DeltaDiscoveryResponse to ensure metrics always have label values

### DIFF
--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -538,7 +538,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
     async fn handle_first_response(
         stream: &mut tonic::Streaming<DeltaDiscoveryResponse>,
         resources: &'static [(&'static str, &'static [(&'static str, Vec<String>)])],
-    ) -> eyre::Result<&'static [(&'static str, Vec<String>)]> {
+    ) -> eyre::Result<(String, &'static [(&'static str, Vec<String>)])> {
         const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
         match tokio::time::timeout(TIMEOUT, stream.message()).await {
@@ -550,6 +550,12 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                     eyre::bail!("expected at least one response from the management server");
                 };
 
+                let control_plane_identifier = first
+                    .control_plane
+                    .as_ref()
+                    .map(|cp| cp.identifier.clone())
+                    .unwrap_or_default();
+
                 if first.type_url != "ignore-me" {
                     tracing::warn!("expected `ignore-me` response from management server");
                 }
@@ -557,6 +563,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                 resources
                     .iter()
                     .find_map(|(vers, subs)| (*vers == first.system_version_info).then_some(*subs))
+                    .map(|rs| (control_plane_identifier, rs))
                     .with_context(|| {
                         format!(
                             "failed to find resources with version `{}` to subscribe to",
@@ -567,8 +574,13 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
         }
     }
 
-    let resource_subscriptions = match handle_first_response(&mut stream, resources).await {
-        Ok(rs) => rs,
+    let (mut control_plane, resource_subscriptions) = match handle_first_response(
+        &mut stream,
+        resources,
+    )
+    .await
+    {
+        Ok((id, rs)) => (id, rs),
         Err(error) => {
             tracing::error!(%error, "failed to acquire matching resource subscriptions based on response from management sever");
             return Err(error);
@@ -591,7 +603,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
         return Err(err);
     }
 
-    let id = identifier.clone();
+    let client_id = identifier.clone();
     let handle = tokio::task::spawn(
         async move {
             tracing::trace!("starting xDS delta stream task");
@@ -599,9 +611,9 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
             let mut resource_subscriptions = resource_subscriptions;
 
             loop {
-                tracing::info!("creating discovery response handler");
+                tracing::info!(%control_plane, "creating discovery response handler");
                 let mut response_stream = crate::config::handle_delta_discovery_responses(
-                    identifier.clone(),
+                    control_plane.clone(),
                     stream,
                     config.clone(),
                     local.clone(),
@@ -609,7 +621,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                     notifier.clone(),
                 );
 
-                tracing::info!("entering xDS stream loop");
+                tracing::info!(%control_plane, "entering xDS stream loop");
                 loop {
                     let next_response =
                         tokio::time::timeout(IDLE_REQUEST_INTERVAL, response_stream.next());
@@ -632,6 +644,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                         Ok(Some(Err(error))) => {
                             if crate::is_broken_pipe(&error) {
                                 tracing::info!(
+                                    %control_plane,
                                     endpoint = %connected_endpoint.uri(),
                                     "remoteterminated the connection",
                                 );
@@ -641,7 +654,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                             break;
                         }
                         Ok(None) => {
-                            tracing::warn!("xDS stream terminated");
+                            tracing::warn!(%control_plane, "xDS stream terminated");
                             break;
                         }
                         Err(_) => {
@@ -662,7 +675,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                 local.clear(&config, None);
 
                 loop {
-                    tracing::info!("Lost connection to xDS, retrying");
+                    tracing::info!(%control_plane, "Lost connection to xDS, retrying");
                     match DeltaClientStream::connect(&endpoints, identifier.clone()).await {
                         Ok(res) => {
                             (ds, stream, connected_endpoint) = res;
@@ -674,9 +687,10 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                     }
 
                     match handle_first_response(&mut stream, resources).await {
-                        Ok(rs) => {
+                        Ok((id, rs)) => {
+                            control_plane = id;
                             resource_subscriptions = rs;
-                            tracing::info!("received first response");
+                            tracing::info!(%control_plane, "received first response");
                             break;
                         }
                         Err(error) => {
@@ -688,10 +702,10 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                 ds.refresh(&identifier, resource_subscriptions.to_vec(), &local)
                     .await
                     .wrap_err("refresh failed")?;
-                tracing::info!("xDS connection refreshed");
+                tracing::info!(%control_plane, "xDS connection refreshed");
             }
         }
-        .instrument(tracing::trace_span!("xds_client_stream", id)),
+        .instrument(tracing::trace_span!("xds_client_stream", client_id)),
     );
 
     Ok(handle)

--- a/crates/xds/src/server.rs
+++ b/crates/xds/src/server.rs
@@ -258,13 +258,14 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
             "subscribed to config updates"
         );
 
-        let control_plane_id = crate::core::ControlPlane {
+        let control_plane = Some(crate::core::ControlPlane {
             identifier: id.clone(),
-        };
+        });
 
         use crate::config::ClientTracker;
         let mut client_tracker = ClientTracker::track_client(node_id.clone());
 
+        let responder_control_plane = control_plane.clone();
         let client = node_id.clone();
         let cfg = self.config.clone();
         let mut shutdown = self.shutdown.clone();
@@ -322,7 +323,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                     let response = DeltaDiscoveryResponse {
                         resources: req.resources,
                         nonce: nonce.to_string(),
-                        control_plane: Some(control_plane_id.clone()),
+                        control_plane: responder_control_plane.clone(),
                         type_url: type_url.into(),
                         removed_resources,
                         system_version_info: VERSION_INFO.into(),
@@ -351,7 +352,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                 DeltaDiscoveryResponse {
                     resources: Vec::new(),
                     nonce: String::new(),
-                    control_plane: None,
+                    control_plane: control_plane.clone(),
                     type_url: message.type_url,
                     removed_resources: Vec::new(),
                     system_version_info: VERSION_INFO.into(),
@@ -364,7 +365,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
                     DeltaDiscoveryResponse {
                         resources: Vec::new(),
                         nonce: String::new(),
-                        control_plane: None,
+                        control_plane: control_plane.clone(),
                         type_url,
                         removed_resources: Vec::new(),
                         system_version_info: VERSION_INFO.into(),
@@ -685,13 +686,14 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
             "subscribed to config updates"
         );
 
-        let control_plane_id = crate::core::ControlPlane {
+        let control_plane = Some(crate::core::ControlPlane {
             identifier: id.clone(),
-        };
+        });
 
         use crate::config::ClientTracker;
         let mut client_tracker = ClientTracker::track_client(node_id.clone());
 
+        let responder_control_plane = control_plane.clone();
         let client = node_id.clone();
         let cfg = self.config.clone();
         let responder = move |req: Option<DeltaDiscoveryRequest>,
@@ -747,7 +749,7 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
                     let response = DeltaDiscoveryResponse {
                         resources: req.resources,
                         nonce: nonce.to_string(),
-                        control_plane: Some(control_plane_id.clone()),
+                        control_plane: responder_control_plane.clone(),
                         type_url: type_url.into(),
                         removed_resources,
                         system_version_info: VERSION_INFO.into(),
@@ -776,7 +778,7 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
                 DeltaDiscoveryResponse {
                     resources: Vec::new(),
                     nonce: String::new(),
-                    control_plane: None,
+                    control_plane: control_plane.clone(),
                     type_url: message.type_url,
                     removed_resources: Vec::new(),
                     system_version_info: VERSION_INFO.into(),
@@ -789,7 +791,7 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
                     DeltaDiscoveryResponse {
                         resources: Vec::new(),
                         nonce: String::new(),
-                        control_plane: None,
+                        control_plane: control_plane.clone(),
                         type_url,
                         removed_resources: Vec::new(),
                         system_version_info: VERSION_INFO.into(),


### PR DESCRIPTION
Part five of breaking up https://github.com/googleforgames/quilkin/pull/1245