### PR TITLE
Phoenix metric improvements

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -375,7 +375,10 @@ pub(crate) fn phoenix_requests() -> &'static IntCounter {
     &PHOENIX_REQUESTS
 }
 
-pub(crate) fn phoenix_measurement_seconds(icao: crate::config::IcaoCode, direction: &str) -> Histogram {
+pub(crate) fn phoenix_measurement_seconds(
+    icao: crate::config::IcaoCode,
+    direction: &str,
+) -> Histogram {
     static PHOENIX_MEASUREMENT: Lazy<HistogramVec> = Lazy::new(|| {
         prometheus::register_histogram_vec_with_registry! {
             prometheus::histogram_opts! {
@@ -406,6 +409,22 @@ pub(crate) fn phoenix_distance(icao: crate::config::IcaoCode) -> Gauge {
     });
 
     PHOENIX_DISTANCE.with_label_values(&[icao.as_ref()])
+}
+
+pub(crate) fn phoenix_coordinates(icao: crate::config::IcaoCode, axis: &str) -> Gauge {
+    static PHOENIX_COORDINATES: Lazy<GaugeVec> = Lazy::new(|| {
+        prometheus::register_gauge_vec_with_registry! {
+            prometheus::opts! {
+                "phoenix_coordinates",
+                "The phoenix coordinates relative to this node",
+            },
+            &["icao", "axis"],
+            registry(),
+        }
+        .unwrap()
+    });
+
+    PHOENIX_COORDINATES.with_label_values(&[icao.as_ref(), axis])
 }
 
 pub(crate) fn phoenix_distance_error_estimate(icao: crate::config::IcaoCode) -> Gauge {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -202,70 +202,70 @@ pub(crate) mod qcmp {
         METRIC.set(active as _);
     }
 
-    fn bytes_total(kind: &'static str, asn: &AsnInfo<'_>) -> IntCounter {
+    fn bytes_total(kind: &'static str) -> IntCounter {
         static METRIC: Lazy<IntCounterVec> = Lazy::new(|| {
             prometheus::register_int_counter_vec_with_registry! {
                 prometheus::opts! {
                     "service_qcmp_bytes_total",
                     "Total number of bytes processed through QCMP",
                 },
-                &["kind", ASN_LABEL],
+                &["kind"],
                 registry(),
             }
             .unwrap()
         });
 
-        METRIC.with_label_values(&[kind, asn.asn])
+        METRIC.with_label_values(&[kind])
     }
 
-    pub(crate) fn errors_total(reason: &str, asn: &AsnInfo<'_>) -> IntCounter {
+    pub(crate) fn errors_total(reason: &str) -> IntCounter {
         static METRIC: Lazy<IntCounterVec> = Lazy::new(|| {
             prometheus::register_int_counter_vec_with_registry! {
                 prometheus::opts! {
                     "service_qcmp_errors_total",
                     "total number of errors QCMP has encountered",
                 },
-                &["reason", ASN_LABEL],
+                &["reason"],
                 registry(),
             }
             .unwrap()
         });
 
-        METRIC.with_label_values(&[reason, asn.asn])
+        METRIC.with_label_values(&[reason])
     }
 
-    fn packets_total(kind: &'static str, asn: &AsnInfo<'_>) -> IntCounter {
+    fn packets_total(kind: &'static str) -> IntCounter {
         static METRIC: Lazy<IntCounterVec> = Lazy::new(|| {
             prometheus::register_int_counter_vec_with_registry! {
                 prometheus::opts! {
                     "service_qcmp_packets_total",
                     "Total number of packets processed through QCMP",
                 },
-                &["kind", ASN_LABEL],
+                &["kind"],
                 registry(),
             }
             .unwrap()
         });
 
-        METRIC.with_label_values(&[kind, asn.asn])
+        METRIC.with_label_values(&[kind])
     }
 
-    pub(crate) fn packets_total_invalid(size: usize, asn_info: &AsnInfo<'_>) {
+    pub(crate) fn packets_total_invalid(size: usize) {
         const KIND: &str = "invalid";
-        bytes_total(KIND, asn_info).inc_by(size as u64);
-        packets_total(KIND, asn_info).inc();
+        bytes_total(KIND).inc_by(size as u64);
+        packets_total(KIND).inc();
     }
 
-    pub(crate) fn packets_total_unsupported(size: usize, asn_info: &AsnInfo<'_>) {
+    pub(crate) fn packets_total_unsupported(size: usize) {
         const KIND: &str = "unsupported";
-        bytes_total(KIND, asn_info).inc_by(size as u64);
-        packets_total(KIND, asn_info).inc();
+        bytes_total(KIND).inc_by(size as u64);
+        packets_total(KIND).inc();
     }
 
-    pub(crate) fn packets_total_valid(size: usize, asn_info: &AsnInfo<'_>) {
+    pub(crate) fn packets_total_valid(size: usize) {
         const KIND: &str = "valid";
-        bytes_total(KIND, asn_info).inc_by(size as u64);
-        packets_total(KIND, asn_info).inc();
+        bytes_total(KIND).inc_by(size as u64);
+        packets_total(KIND).inc();
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -375,20 +375,53 @@ pub(crate) fn phoenix_requests() -> &'static IntCounter {
     &PHOENIX_REQUESTS
 }
 
-pub(crate) fn phoenix_distance(icao: crate::config::IcaoCode, error_estimate: f64) -> Gauge {
-    static PHOENIX_DISTANCE: Lazy<GaugeVec> = Lazy::new(|| {
-        prometheus::register_gauge_vec_with_registry! {
-            prometheus::opts! {
-                "service_phoenix_distance",
-                "The distance from this instance to another node in the network",
+pub(crate) fn phoenix_measurement_seconds(icao: crate::config::IcaoCode, direction: &str) -> Histogram {
+    static PHOENIX_MEASUREMENT: Lazy<HistogramVec> = Lazy::new(|| {
+        prometheus::register_histogram_vec_with_registry! {
+            prometheus::histogram_opts! {
+                "phoenix_measurement_seconds",
+                "Histogram of phoenix measurements for a given node",
+                prometheus::DEFAULT_BUCKETS.to_vec()
             },
-            &["icao", "error_estimate"],
+            &["icao", "direction"],
             registry(),
         }
         .unwrap()
     });
 
-    PHOENIX_DISTANCE.with_label_values(&[icao.as_ref(), &error_estimate.to_string()])
+    PHOENIX_MEASUREMENT.with_label_values(&[icao.as_ref(), direction])
+}
+
+pub(crate) fn phoenix_distance(icao: crate::config::IcaoCode) -> Gauge {
+    static PHOENIX_DISTANCE: Lazy<GaugeVec> = Lazy::new(|| {
+        prometheus::register_gauge_vec_with_registry! {
+            prometheus::opts! {
+                "phoenix_distance",
+                "The distance from this instance to another node in the network",
+            },
+            &["icao"],
+            registry(),
+        }
+        .unwrap()
+    });
+
+    PHOENIX_DISTANCE.with_label_values(&[icao.as_ref()])
+}
+
+pub(crate) fn phoenix_distance_error_estimate(icao: crate::config::IcaoCode) -> Gauge {
+    static PHOENIX_DISTANCE_ERROR_ESTIMATE: Lazy<GaugeVec> = Lazy::new(|| {
+        prometheus::register_gauge_vec_with_registry! {
+            prometheus::opts! {
+                "phoenix_distance_error_estimate",
+                "The distance from this instance to another node in the network",
+            },
+            &["icao"],
+            registry(),
+        }
+        .unwrap()
+    });
+
+    PHOENIX_DISTANCE_ERROR_ESTIMATE.with_label_values(&[icao.as_ref()])
 }
 
 pub(crate) fn phoenix_task_closed() -> &'static IntGauge {

--- a/src/net/phoenix.rs
+++ b/src/net/phoenix.rs
@@ -613,6 +613,8 @@ impl Node {
                 x: incoming,
                 y: outgoing,
             };
+            crate::metrics::phoenix_coordinates(self.icao_code, "x").set(coordinates.x);
+            crate::metrics::phoenix_coordinates(self.icao_code, "y").set(coordinates.y);
             crate::metrics::phoenix_distance(self.icao_code)
                 .set(Coordinates::ORIGIN.distance_to(&coordinates));
             self.coordinates = Some(coordinates);
@@ -624,6 +626,8 @@ impl Node {
         coordinates.x = (coordinates.x + (incoming * weight)) / 2.0;
         coordinates.y = (coordinates.y + (outgoing * weight)) / 2.0;
 
+        crate::metrics::phoenix_coordinates(self.icao_code, "x").set(coordinates.x);
+        crate::metrics::phoenix_coordinates(self.icao_code, "y").set(coordinates.y);
         crate::metrics::phoenix_distance(self.icao_code)
             .set(Coordinates::ORIGIN.distance_to(coordinates));
     }

--- a/src/net/phoenix.rs
+++ b/src/net/phoenix.rs
@@ -228,7 +228,9 @@ use crate::time::DurationNanos;
 #[derive(Copy, Clone)]
 #[cfg_attr(test, derive(Debug))]
 pub struct DistanceMeasure {
+    /// Latency for a packet travelling to a given target (incoming for the target)
     pub incoming: DurationNanos,
+    /// Latency for a packet arriving from a given target (outgoing for the target)
     pub outgoing: DurationNanos,
 }
 
@@ -584,6 +586,7 @@ struct Node {
 
 impl Node {
     fn new(icao_code: IcaoCode) -> Self {
+        crate::metrics::phoenix_distance_error_estimate(icao_code).set(1.0);
         Node {
             coordinates: None,
             icao_code,
@@ -593,18 +596,24 @@ impl Node {
 
     fn increase_error_estimate(&mut self) {
         self.error_estimate += 0.1;
+        crate::metrics::phoenix_distance_error_estimate(self.icao_code).set(self.error_estimate);
     }
 
     fn adjust_coordinates(&mut self, distance: DistanceMeasure) {
         let incoming = distance.incoming.nanos() as f64;
         let outgoing = distance.outgoing.nanos() as f64;
 
+        crate::metrics::phoenix_measurement_seconds(self.icao_code, "incoming")
+            .observe(distance.incoming.duration().as_secs_f64());
+        crate::metrics::phoenix_measurement_seconds(self.icao_code, "outgoing")
+            .observe(distance.outgoing.duration().as_secs_f64());
+
         let Some(coordinates) = &mut self.coordinates else {
             let coordinates = Coordinates {
                 x: incoming,
                 y: outgoing,
             };
-            crate::metrics::phoenix_distance(self.icao_code, self.error_estimate)
+            crate::metrics::phoenix_distance(self.icao_code)
                 .set(Coordinates::ORIGIN.distance_to(&coordinates));
             self.coordinates = Some(coordinates);
             return;
@@ -615,7 +624,7 @@ impl Node {
         coordinates.x = (coordinates.x + (incoming * weight)) / 2.0;
         coordinates.y = (coordinates.y + (outgoing * weight)) / 2.0;
 
-        crate::metrics::phoenix_distance(self.icao_code, self.error_estimate)
+        crate::metrics::phoenix_distance(self.icao_code)
             .set(Coordinates::ORIGIN.distance_to(coordinates));
     }
 }


### PR DESCRIPTION
* Remove the `error_estimate` label from the `phoenix_distance` metric and create a new gauge `phoenix_error_estimate` for it
* Add `phoenix_measurement_seconds` histogram to get visibility of the raw input samples into the phoenix system
* Remove the `asn` label from all `qcmp_*` metrics. Currently of little use but contributes a lot to cardinality.