### PR TITLE
Remove unused version field of EndpointSet, hash is used for version()

### DIFF
--- a/src/net/cluster.rs
+++ b/src/net/cluster.rs
@@ -114,9 +114,6 @@ pub struct EndpointSet {
     pub token_map: TokenAddressMap,
     /// The hash of all of the endpoints in this set
     hash: u64,
-    /// Version of this set of endpoints. Any mutatation of the endpoints
-    /// set monotonically increases this number
-    version: u64,
 }
 
 impl EndpointSet {
@@ -127,7 +124,6 @@ impl EndpointSet {
             endpoints,
             token_map: <_>::default(),
             hash: 0,
-            version: 0,
         };
 
         this.update();
@@ -145,7 +141,6 @@ impl EndpointSet {
             endpoints,
             token_map: <_>::default(),
             hash: hash.number(),
-            version: 1,
         };
 
         this.build_token_map();
@@ -195,7 +190,6 @@ impl EndpointSet {
         }
 
         self.hash = hasher.finish();
-        self.version += 1;
         std::mem::replace(&mut self.token_map, token_map)
     }
 
@@ -232,7 +226,6 @@ impl EndpointSet {
             self.update()
         } else {
             self.hash = replacement.hash;
-            self.version += 1;
             self.build_token_map()
         };
 


### PR DESCRIPTION
This field was confusing and probably just a leftover. This is good though because this means that an EndpointSet is deterministically versioned and if e.g. two agents are connected to the relay from the same cluster they will report the same version. I will need to confirm things but this should mean that we don't need to track "who is responsible" for a specific locality and lock it to only one agent at a time.