### PR TITLE
Remove unused is_relay field from ControlPlane

### DIFF
--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -288,9 +288,7 @@ impl MdsClient {
                         );
 
                         let change_watcher = tokio::spawn({
-                            let mut this = control_plane.clone();
-                            this.is_relay = true; // This is a lie, but means we don't unneccessarily watch for filter changes on the agent, which doesn't perform them
-                            control_plane.config.on_changed(this, shutdown.clone())
+                            control_plane.config.on_changed(control_plane.clone(), shutdown.clone())
                         });
 
                         tokio::select! {


### PR DESCRIPTION
Looks like the usage of this was removed with https://github.com/EmbarkStudios/quilkin/pull/1215