### PR TITLE
Use MissedTickBehavior::Delay for propagation_interval

### DIFF
--- a/crates/xds/src/server.rs
+++ b/crates/xds/src/server.rs
@@ -418,6 +418,7 @@ impl<C: crate::config::Configuration> ControlPlane<C> {
             let buffer = ResponseBroadcastPropagationBuffer::default();
             let mut lag_amount: u64 = 0;
             let mut propagation_interval = tokio::time::interval(RESPONSE_PROPAGATION_INTERVAL);
+            propagation_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
             loop {
                 tokio::select! {
@@ -850,6 +851,7 @@ impl<C: crate::config::Configuration> AggregatedControlPlaneDiscoveryService for
             let buffer = ResponseBroadcastPropagationBuffer::default();
             let mut lag_amount: u64 = 0;
             let mut propagation_interval = tokio::time::interval(RESPONSE_PROPAGATION_INTERVAL);
+            propagation_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
             loop {
                 tokio::select! {


### PR DESCRIPTION
The default behavior is Burst which doesn't fit this use-case since we are buffering changes, so it doesn't make sense to burst away 2 responses if we happen to miss one tick

https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html#variant.Delay