### PR TITLE
feat: add http provider + provider benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,7 +136,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -141,7 +147,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -504,7 +510,7 @@ name = "backoff"
 version = "0.1.0"
 source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#b15842c20500b85f186a3531e36a88c784203539"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -689,6 +695,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +761,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -982,7 +1021,7 @@ dependencies = [
  "quinn-plaintext",
  "quinn-proto",
  "quoted-string",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rangemap",
  "rusqlite",
  "rustls",
@@ -1068,7 +1107,7 @@ dependencies = [
  "pgwire",
  "pin-project-lite",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rusqlite",
  "rustls",
  "socket2 0.6.1",
@@ -1113,7 +1152,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rangemap",
  "rcgen",
  "rusqlite",
@@ -1251,6 +1290,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1339,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -1279,6 +1366,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1664,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1762,7 +1855,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -1820,7 +1913,7 @@ checksum = "298571ae7aab7a82f664d8c8817b12c58480fcf7c5900400fe48e0144cb691c3"
 dependencies = [
  "bincode",
  "bytes",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "tracing",
 ]
@@ -2059,7 +2152,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -2091,6 +2184,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2204,7 +2308,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustls",
  "thiserror 2.0.17",
@@ -2228,7 +2332,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -2684,7 +2788,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2692,6 +2796,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2959,7 +3072,7 @@ checksum = "159a11dbcf655bb619f6479081e565ea889bb860c5d7d830f3ad90adc74fb90a"
 dependencies = [
  "k8s-openapi",
  "kube",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3430,7 +3543,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3590,6 +3703,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,7 +3777,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.17",
 ]
 
@@ -3786,7 +3905,7 @@ dependencies = [
  "lazy-regex",
  "md5",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rust_decimal",
  "rustls-pki-types",
@@ -3874,6 +3993,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3901,7 +4048,7 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha2",
  "stringprep",
 ]
@@ -4177,7 +4324,7 @@ dependencies = [
  "once_cell",
  "quilkin",
  "quilkin-xds",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde_json",
  "socket2 0.6.1",
  "tempfile",
@@ -4219,6 +4366,7 @@ dependencies = [
  "chacha20",
  "clap",
  "corrosion",
+ "criterion",
  "crossbeam-utils",
  "dashmap",
  "either",
@@ -4264,7 +4412,7 @@ dependencies = [
  "quilkin-types",
  "quilkin-xdp",
  "quilkin-xds",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "rustls",
  "schemars",
@@ -4372,7 +4520,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types",
  "quilkin-proto",
- "rand 0.9.2",
+ "rand 0.9.4",
  "schemars",
  "serde",
  "serde_json",
@@ -4430,7 +4578,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4497,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4566,6 +4714,26 @@ name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rcgen"
@@ -4828,7 +4996,7 @@ dependencies = [
  "futures-util",
  "http",
  "mime",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.17",
 ]
 
@@ -4889,7 +5057,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4948,7 +5116,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5650,7 +5818,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5784,6 +5952,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6187,7 +6365,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",
@@ -6551,7 +6729,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,6 +165,12 @@ regex.workspace = true
 tracing-test = "0.2.5"
 tempfile.workspace = true
 axum-test = "18.6.0"
+criterion = { version = "0.5", features = ["async_tokio"] }
+quilkin-xds.workspace = true
+
+[[bench]]
+name = "provider"
+harness = false
 
 # We want debug information when doing benchmarks for debugging purposes as well
 # as better (correct) callstacks in perf

--- a/benches/provider.rs
+++ b/benches/provider.rs
@@ -1,0 +1,431 @@
+//! Provider benchmark — stresses endpoint add/remove across provider backends.
+//!
+//! Three harnesses run by default:
+//!
+//! * **HTTP** — drives the HTTP provider REST API via `axum_test` (no sockets).
+//! * **Corrosion** — calls `ServerMutator` directly against in-memory
+//!   `LocalState` (no external database required).
+//! * **MDS+HTTP** — spins up a real Corrosion MDS service (`SQLite` in a temp
+//!   directory, random UDP + gRPC ports) alongside the HTTP provider.  Both
+//!   share the same in-memory `Config`.  This is the most realistic scenario:
+//!   endpoint mutations are made through the HTTP provider while the Corrosion
+//!   service is active in the background, exercising the full integrated stack.
+//!
+//! Run all scenarios:
+//!   cargo bench --bench provider
+//!
+//! Run only the cycle scenario across all harnesses:
+//!   cargo bench --bench provider -- `add_remove_cycle`
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use quilkin::{
+    net::endpoint::{Endpoint, Metadata},
+    providers::{FiltersAndClusters, corrosion::push::LocalState},
+};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+use uuid::Uuid;
+
+// ── ProviderHarness trait ────────────────────────────────────────────────────
+
+trait ProviderHarness {
+    async fn upsert(&self, addr: SocketAddr, tokens: Vec<Vec<u8>>);
+    async fn remove(&self, addr: SocketAddr);
+    async fn clear(&self);
+    /// Number of endpoints currently visible to the provider's local state.
+    async fn endpoint_count(&self) -> usize;
+
+    /// Replace the entire endpoint set in a single operation.
+    ///
+    /// Providers with a native bulk API (HTTP `PUT /endpoints`) override this;
+    /// others fall back to clear + individual upserts.
+    async fn bulk_upsert(&self, addrs: &[SocketAddr]) {
+        self.clear().await;
+        for &addr in addrs {
+            self.upsert(addr, vec![]).await;
+        }
+    }
+
+    /// Remove a specific set of endpoints in a single operation.
+    ///
+    /// Providers with a native bulk API (HTTP `DELETE /endpoints` with body)
+    /// override this; others fall back to individual removes.
+    async fn bulk_remove(&self, addrs: &[SocketAddr]) {
+        for &addr in addrs {
+            self.remove(addr).await;
+        }
+    }
+}
+
+// ── Shared address generation ─────────────────────────────────────────────────
+
+fn addrs(n: usize) -> Vec<SocketAddr> {
+    assert!(n <= 0xffff, "at most 65535 addresses supported");
+    (0..n)
+        .map(|i| {
+            let hi = (i >> 8) as u8;
+            let lo = i as u8;
+            format!("10.1.{hi}.{lo}:7777").parse().unwrap()
+        })
+        .collect()
+}
+
+// ── HTTP harness ──────────────────────────────────────────────────────────────
+
+struct HttpHarness {
+    server: axum_test::TestServer,
+}
+
+impl HttpHarness {
+    fn new() -> Self {
+        let providers = quilkin::Providers::default().http();
+        let service = quilkin::Service::default();
+        let config = quilkin::Config::new(None, Default::default(), &providers, &service);
+        let fc = FiltersAndClusters::new(&config).unwrap();
+        Self {
+            server: axum_test::TestServer::new(quilkin::providers::http::make_router(fc)).unwrap(),
+        }
+    }
+}
+
+impl ProviderHarness for HttpHarness {
+    async fn upsert(&self, addr: SocketAddr, tokens: Vec<Vec<u8>>) {
+        let endpoint = Endpoint::with_metadata(
+            addr.into(),
+            Metadata {
+                tokens: tokens.into_iter().collect(),
+            },
+        );
+        self.server.post("/endpoints").json(&endpoint).await;
+    }
+
+    async fn remove(&self, addr: SocketAddr) {
+        self.server.delete(&format!("/endpoints/{addr}")).await;
+    }
+
+    async fn clear(&self) {
+        self.server.delete("/endpoints").await;
+    }
+
+    async fn endpoint_count(&self) -> usize {
+        let body: Vec<serde_json::Value> = self.server.get("/endpoints").await.json();
+        body.len()
+    }
+
+    async fn bulk_upsert(&self, addrs: &[SocketAddr]) {
+        let endpoints: Vec<Endpoint> = addrs.iter().map(|&a| Endpoint::new(a.into())).collect();
+        self.server.post("/endpoints/bulk").json(&endpoints).await;
+    }
+
+    async fn bulk_remove(&self, addrs: &[SocketAddr]) {
+        let addresses: Vec<quilkin::net::endpoint::EndpointAddress> =
+            addrs.iter().map(|&a| a.into()).collect();
+        self.server.delete("/endpoints").json(&addresses).await;
+    }
+}
+
+// ── Corrosion harness ─────────────────────────────────────────────────────────
+//
+// Uses `ServerMutator::testing` which wires up the mutator against an
+// in-memory `LocalState` with no network connection required.
+
+struct CorrosionHarness {
+    mutator: quilkin::providers::corrosion::ServerMutator,
+    state: Arc<LocalState>,
+    /// Maps each `SocketAddr` to the UUID assigned at upsert time so that
+    /// individual removes can target the right entry.
+    ids: Mutex<HashMap<SocketAddr, Uuid>>,
+}
+
+impl CorrosionHarness {
+    fn new() -> Self {
+        let state = Arc::new(LocalState::default());
+        let (mutator, _rx) = quilkin::providers::corrosion::ServerMutator::testing(state.clone());
+        Self {
+            mutator,
+            state,
+            ids: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn make_endpoint(addr: SocketAddr) -> quilkin_types::Endpoint {
+        quilkin_types::Endpoint::new(addr.ip().into(), addr.port())
+    }
+}
+
+impl ProviderHarness for CorrosionHarness {
+    async fn upsert(&self, addr: SocketAddr, tokens: Vec<Vec<u8>>) {
+        let id = Uuid::new_v4();
+        self.ids.lock().unwrap().insert(addr, id);
+        self.mutator.upsert_server(
+            id,
+            Self::make_endpoint(addr),
+            quilkin_types::TokenSet(tokens.into_iter().collect()),
+        );
+    }
+
+    async fn remove(&self, addr: SocketAddr) {
+        if let Some(id) = self.ids.lock().unwrap().remove(&addr) {
+            self.mutator.remove_server(id);
+        }
+    }
+
+    async fn clear(&self) {
+        let ids: Vec<Uuid> = self.ids.lock().unwrap().drain().map(|(_, v)| v).collect();
+        for id in ids {
+            self.mutator.remove_server(id);
+        }
+    }
+
+    async fn endpoint_count(&self) -> usize {
+        self.state.to_map().len()
+    }
+}
+
+// ── Combined harness (Corrosion MDS service + HTTP provider) ─────────────────
+//
+// Spins up the real Corrosion MDS service — SQLite database in a randomised
+// temp directory, OS-chosen UDP and gRPC ports — alongside the HTTP provider
+// so that both share the same in-memory Config.  Endpoint mutations are driven
+// through the HTTP provider while the Corrosion service watches for filter-chain
+// changes in the background, mirroring production topology.
+
+struct CombinedHarness {
+    /// HTTP provider (sans-IO via `axum_test`, no real socket).
+    server: axum_test::TestServer,
+    /// Kept alive so background service tasks keep running until the harness is
+    /// dropped (which happens when the Criterion runtime tears down).
+    _shutdown_tx: quilkin::signal::ShutdownTx,
+}
+
+impl CombinedHarness {
+    async fn new() -> Self {
+        let providers = quilkin::Providers::default().http();
+        // mds()      — enables the Corrosion DB server + MDS relay
+        // testing()  — uses a randomised temp directory for the SQLite DB
+        // mds_port(0) / corrosion_port(0) — let the OS choose free ports
+        let service = quilkin::Service::default()
+            .mds()
+            .mds_port(0)
+            .corrosion_port(0)
+            .testing();
+        let config = Arc::new(quilkin::Config::new(
+            None,
+            Default::default(),
+            &providers,
+            &service,
+        ));
+
+        let (tx, rx) = quilkin::signal::channel();
+        let shutdown = quilkin::signal::ShutdownHandler::new(tx, rx);
+        // Clone the sender before moving the handler into spawn_services so we
+        // can keep the channel open (and the service alive) for the benchmark.
+        let shutdown_tx = shutdown.shutdown_tx();
+        drop(
+            service
+                .spawn_services(&config, shutdown)
+                .await
+                .expect("failed to start MDS service for benchmark"),
+        );
+
+        let fc = FiltersAndClusters::new(&config).unwrap();
+        Self {
+            server: axum_test::TestServer::new(quilkin::providers::http::make_router(fc)).unwrap(),
+            _shutdown_tx: shutdown_tx,
+        }
+    }
+}
+
+impl ProviderHarness for CombinedHarness {
+    async fn upsert(&self, addr: SocketAddr, tokens: Vec<Vec<u8>>) {
+        let endpoint = Endpoint::with_metadata(
+            addr.into(),
+            Metadata {
+                tokens: tokens.into_iter().collect(),
+            },
+        );
+        self.server.post("/endpoints").json(&endpoint).await;
+    }
+
+    async fn remove(&self, addr: SocketAddr) {
+        self.server.delete(&format!("/endpoints/{addr}")).await;
+    }
+
+    async fn clear(&self) {
+        self.server.delete("/endpoints").await;
+    }
+
+    async fn endpoint_count(&self) -> usize {
+        let body: Vec<serde_json::Value> = self.server.get("/endpoints").await.json();
+        body.len()
+    }
+
+    async fn bulk_upsert(&self, addrs: &[SocketAddr]) {
+        let endpoints: Vec<Endpoint> = addrs.iter().map(|&a| Endpoint::new(a.into())).collect();
+        self.server.post("/endpoints/bulk").json(&endpoints).await;
+    }
+
+    async fn bulk_remove(&self, addrs: &[SocketAddr]) {
+        let addresses: Vec<quilkin::net::endpoint::EndpointAddress> =
+            addrs.iter().map(|&a| a.into()).collect();
+        self.server.delete("/endpoints").json(&addresses).await;
+    }
+}
+
+// ── Benchmark scenarios ───────────────────────────────────────────────────────
+
+/// Upsert N endpoints then clear — measures raw insert throughput.
+async fn scenario_upsert<H: ProviderHarness>(h: &H, addrs: &[SocketAddr]) {
+    for &addr in addrs {
+        h.upsert(addr, vec![]).await;
+    }
+    h.clear().await;
+}
+
+/// Add N endpoints then remove them individually.
+async fn scenario_add_remove_cycle<H: ProviderHarness>(h: &H, addrs: &[SocketAddr]) {
+    for &addr in addrs {
+        h.upsert(addr, vec![]).await;
+    }
+    for &addr in addrs {
+        h.remove(addr).await;
+    }
+    debug_assert_eq!(
+        h.endpoint_count().await,
+        0,
+        "all endpoints must be absent after individual removes — \
+         a non-zero count indicates persisted state that was not cleaned up"
+    );
+}
+
+/// Upsert the same N addresses three times — measures the update-in-place path.
+async fn scenario_repeated_upsert<H: ProviderHarness>(h: &H, addrs: &[SocketAddr]) {
+    for _ in 0..3 {
+        for &addr in addrs {
+            h.upsert(addr, vec![]).await;
+        }
+    }
+    h.clear().await;
+}
+
+/// Add N endpoints in a single bulk call — measures batch insert throughput.
+async fn scenario_bulk_upsert<H: ProviderHarness>(h: &H, addrs: &[SocketAddr]) {
+    h.bulk_upsert(addrs).await;
+    h.clear().await;
+}
+
+/// Add N endpoints in bulk then remove them in a single bulk call.
+///
+/// Complements `add_remove_cycle` (which removes individually) to show the
+/// savings from batching.
+async fn scenario_bulk_add_remove_cycle<H: ProviderHarness>(h: &H, addrs: &[SocketAddr]) {
+    h.bulk_upsert(addrs).await;
+    h.bulk_remove(addrs).await;
+    debug_assert_eq!(
+        h.endpoint_count().await,
+        0,
+        "all endpoints must be absent after bulk remove"
+    );
+}
+
+// ── Criterion groups ──────────────────────────────────────────────────────────
+
+const SIZES: &[usize] = &[10, 100, 1_000];
+
+fn run_scenarios<H: ProviderHarness>(
+    c: &mut Criterion,
+    rt: &tokio::runtime::Runtime,
+    harness: &H,
+    name: &str,
+) {
+    // Scenarios that make N individual round-trips per iteration scale poorly
+    // at N=1000.  Criterion's default is 100 samples; reduce that for large N
+    // so the total bench time stays reasonable.
+    let sample_size = |n: usize| if n >= 1_000 { 10 } else { 100 };
+
+    let mut group = c.benchmark_group(format!("{name}/upsert"));
+    for &n in SIZES {
+        let addrs = addrs(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.sample_size(sample_size(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &addrs, |b, addrs| {
+            b.to_async(rt).iter(|| scenario_upsert(harness, addrs));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group(format!("{name}/add_remove_cycle"));
+    for &n in SIZES {
+        let addrs = addrs(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.sample_size(sample_size(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &addrs, |b, addrs| {
+            b.to_async(rt)
+                .iter(|| scenario_add_remove_cycle(harness, addrs));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group(format!("{name}/repeated_upsert"));
+    for &n in SIZES {
+        let addrs = addrs(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.sample_size(sample_size(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &addrs, |b, addrs| {
+            b.to_async(rt)
+                .iter(|| scenario_repeated_upsert(harness, addrs));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group(format!("{name}/bulk_upsert"));
+    for &n in SIZES {
+        let addrs = addrs(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.sample_size(sample_size(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &addrs, |b, addrs| {
+            b.to_async(rt).iter(|| scenario_bulk_upsert(harness, addrs));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group(format!("{name}/bulk_add_remove_cycle"));
+    for &n in SIZES {
+        let addrs = addrs(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.sample_size(sample_size(n));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &addrs, |b, addrs| {
+            b.to_async(rt)
+                .iter(|| scenario_bulk_add_remove_cycle(harness, addrs));
+        });
+    }
+    group.finish();
+}
+
+fn provider_benchmarks(c: &mut Criterion) {
+    // The Corrosion DB setup calls `block_in_place` internally, which requires
+    // a multi-threaded runtime.  Use `new_multi_thread` for all harnesses so
+    // that the same runtime works regardless of which harness is active.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // The MDS/xDS metrics module requires an explicit registry initialisation
+    // that normally happens in the CLI entry point.  Do it here before any
+    // harness that starts the MDS service.
+    quilkin_xds::metrics::set_registry(quilkin::metrics::registry());
+
+    run_scenarios(c, &rt, &HttpHarness::new(), "http");
+    run_scenarios(c, &rt, &CorrosionHarness::new(), "corrosion");
+
+    // Build the combined harness inside the runtime since spawn_services is async.
+    let combined = rt.block_on(CombinedHarness::new());
+    run_scenarios(c, &rt, &combined, "mds+http");
+}
+
+criterion_group!(benches, provider_benchmarks);
+criterion_main!(benches);

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,6 +18,7 @@
 
 - [Agones](./providers/agones.md)
 - [Filesystem](./providers/filesystem.md)
+- [HTTP](./providers/http.md)
 
 # Filters
 - [Overview](./filters.md)

--- a/docs/src/providers/http.md
+++ b/docs/src/providers/http.md
@@ -1,0 +1,86 @@
+# HTTP Provider
+
+The HTTP provider exposes a REST API that allows game server endpoints and the active
+[filter chain][filters] to be managed over plain HTTP. It is useful when you want to
+drive Quilkin's configuration from an external system — such as a matchmaker, a fleet
+manager, or a test harness — without deploying Kubernetes or a shared database.
+
+By default the server listens on port `9000`:
+
+```sh
+quilkin --provider.http
+```
+
+A custom address can be specified with `--provider.http.address`:
+
+```sh
+quilkin --provider.http --provider.http.address 0.0.0.0:9000
+```
+
+## Endpoints API
+
+Quilkin routes incoming UDP packets to one or more [endpoints][endpoints]. The HTTP
+provider lets you add, replace, and remove endpoints at runtime.
+
+| Method   | Path                   | Description                                     |
+|----------|------------------------|-------------------------------------------------|
+| `GET`    | `/endpoints`           | List all current endpoints                      |
+| `POST`   | `/endpoints`           | Upsert an endpoint (add or replace by address)  |
+| `DELETE` | `/endpoints`           | Remove all endpoints                            |
+| `DELETE` | `/endpoints/{address}` | Remove the endpoint at `{address}`              |
+
+Endpoints are represented as JSON objects with an `address` field and an optional
+`metadata` field containing [access tokens][tokens]:
+
+```json
+{
+  "address": "203.0.113.1:7777",
+  "metadata": {
+    "quilkin.dev": {
+      "tokens": ["MXg3aWp5Ng=="]
+    }
+  }
+}
+```
+
+`POST /endpoints` performs an **upsert**: if an endpoint with the same address already
+exists its metadata is replaced; otherwise a new endpoint is added.
+
+To remove a single endpoint, include its address in the path:
+
+```sh
+curl -X DELETE http://localhost:9000/endpoints/203.0.113.1:7777
+```
+
+## Filter Chain API
+
+The filter chain determines how packets are processed before they are forwarded to an
+endpoint. See [Filters][filters] for the full list of available filters and their
+configuration options.
+
+| Method   | Path           | Description                       |
+|----------|----------------|-----------------------------------|
+| `GET`    | `/filterchain` | Get the current filter chain      |
+| `PUT`    | `/filterchain` | Replace the filter chain          |
+| `DELETE` | `/filterchain` | Reset the filter chain to empty   |
+
+The filter chain is expressed in the same JSON/YAML format used by the
+[configuration file][configuration]:
+
+```sh
+curl -X PUT http://localhost:9000/filterchain \
+  -H 'Content-Type: application/json' \
+  -d '[{"name":"quilkin.filters.debug.v1alpha1.Debug","config":{"id":"http-provider"}}]'
+```
+
+`DELETE /filterchain` resets the chain to empty — packets are forwarded without
+any processing.
+
+> Changes made through the HTTP provider are applied immediately and affect all
+> in-flight configuration readers. They are not persisted to disk; if Quilkin
+> restarts the provider starts with an empty configuration again.
+
+[endpoints]: ../services/udp.md#endpoints
+[tokens]: ../services/udp.md#specialist-endpoint-metadata
+[filters]: ../filters.md
+[configuration]: ../deployment/configuration.md

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -247,7 +247,6 @@ mod tests {
 
     use quilkin_xds::locality::Locality;
 
-    use crate::collections::BufferPool;
     use crate::net::Endpoint;
     use crate::test::alloc_buffer;
 
@@ -261,14 +260,21 @@ mod tests {
         let nl1 = Locality::with_region("nl-1");
         let endpoint = Endpoint::new((Ipv4Addr::LOCALHOST, 7777).into());
 
-        let config = Arc::new(Config::default_agent().cluster(
-            None,
-            Some(nl1.clone()),
-            [endpoint.clone()].into(),
-        ));
-        let buffer_pool = Arc::new(BufferPool::new(1, 10));
-        let session_manager = SessionPool::new(config.clone(), vec![], buffer_pool.clone());
+        let providers = crate::Providers::default();
+        let service = crate::Service::default();
+        let mut config = Config::new(None, Default::default(), &providers, &service);
+        // FilterChain is not inserted by Service::default() unless a network
+        // service is enabled; insert it manually for this test.
+        crate::config::insert_default::<crate::filters::FilterChain>(&mut config.dyn_cfg.typemap);
+        config.dyn_cfg.clusters().unwrap().modify(|clusters| {
+            clusters.insert(None, Some(nl1.clone()), [endpoint.clone()].into());
+        });
+        let config = Arc::new(config);
 
+        let cached_filter_chain = config.dyn_cfg.cached_filter_chain().unwrap();
+        let session_manager = SessionPool::new(vec![], cached_filter_chain);
+
+        let filter_chain = crate::filters::FilterChain::default();
         let packet_data: [u8; 4] = [1, 2, 3, 4];
         for ip in [
             IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -286,6 +292,7 @@ mod tests {
                     IpAddr::V4(ipv4) => SocketAddr::V4(SocketAddrV4::new(ipv4, 0)),
                     IpAddr::V6(ipv6) => SocketAddr::V6(SocketAddrV6::new(ipv6, 0, 0, 0)),
                 },
+                filters: &filter_chain,
             };
 
             let mut endpoints = vec![endpoint.address.clone()];

--- a/src/providers.rs
+++ b/src/providers.rs
@@ -16,6 +16,7 @@
 
 pub mod corrosion;
 pub mod fs;
+pub mod http;
 pub mod k8s;
 
 use std::{
@@ -26,7 +27,10 @@ use std::{
     },
 };
 
-use crate::{config, metrics::provider_task_failures_total, providers::k8s::EventProcessor, net::EndpointAddress};
+use crate::{
+    config, metrics::provider_task_failures_total, net::EndpointAddress,
+    providers::k8s::EventProcessor,
+};
 use eyre::Context;
 use futures::TryStreamExt;
 
@@ -191,6 +195,21 @@ pub struct Providers {
         env = "QUILKIN_PROVIDERS_CORROSION_MODE"
     )]
     corrosion_mode: Option<corrosion::CorrosionMode>,
+    /// Enable the HTTP provider, which exposes a REST API for managing endpoints
+    /// and the filter chain.
+    #[arg(
+        long = "provider.http",
+        env = "QUILKIN_PROVIDERS_HTTP",
+        default_value_t = false
+    )]
+    http_enabled: bool,
+    /// The socket address the HTTP provider listens on.
+    #[arg(
+        long = "provider.http.address",
+        env = "QUILKIN_PROVIDERS_HTTP_ADDRESS",
+        requires("http_enabled")
+    )]
+    http_address: Option<SocketAddr>,
 }
 
 #[derive(Clone)]
@@ -285,6 +304,16 @@ impl Providers {
 
     pub fn corrosion_endpoints(mut self, endpoints: impl Into<Vec<SocketAddr>>) -> Self {
         self.corrosion_endpoints = endpoints.into();
+        self
+    }
+
+    pub fn http(mut self) -> Self {
+        self.http_enabled = true;
+        self
+    }
+
+    pub fn http_address(mut self, addr: SocketAddr) -> Self {
+        self.http_address = Some(addr);
         self
     }
 
@@ -672,11 +701,16 @@ impl Providers {
             .is_some_and(|_cm| !self.corrosion_endpoints.is_empty())
     }
 
+    pub fn http_enabled(&self) -> bool {
+        self.http_enabled
+    }
+
     pub fn any_provider_enabled(&self) -> bool {
         self.agones_enabled()
             || self.fs_enabled()
             || self.grpc_pull_enabled()
             || self.grpc_push_enabled()
+            || self.http_enabled()
             || self.k8s_enabled()
             || self.mmdb_enabled()
             || self.static_enabled()
@@ -715,6 +749,7 @@ impl Providers {
             self.fs_enabled().then_some("fs"),
             self.grpc_pull_enabled().then_some("mDS"),
             self.grpc_push_enabled().then_some("xDS"),
+            self.http_enabled().then_some("http"),
             self.k8s_enabled().then_some("k8s"),
             self.mmdb_enabled().then_some("mmdb"),
             self.static_enabled().then_some("static"),
@@ -778,6 +813,21 @@ impl Providers {
                         )
                     }
                 },
+            ));
+        }
+
+        if self.http_enabled()
+            && let Some(fc) = FiltersAndClusters::new(config)
+        {
+            let address = self
+                .http_address
+                .unwrap_or_else(|| (std::net::Ipv6Addr::UNSPECIFIED, http::DEFAULT_PORT).into());
+            let health_check = health_check.clone();
+
+            providers.spawn(Self::task(
+                "http_provider".into(),
+                health_check.clone(),
+                move || http::serve(fc.clone(), address, health_check.clone()),
             ));
         }
 

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -1,0 +1,521 @@
+//! HTTP provider — exposes a CRUD API for managing game server endpoints and
+//! the active filter chain over plain HTTP/JSON.
+//!
+//! # Endpoints
+//!
+//! | Method   | Path                     | Description                                                           |
+//! |----------|--------------------------|-----------------------------------------------------------------------|
+//! | `GET`    | `/endpoints`             | List all current endpoints                                            |
+//! | `POST`   | `/endpoints`             | Upsert (add or replace) one endpoint                                  |
+//! | `PUT`    | `/endpoints`             | Replace the entire endpoint set atomically (bulk upsert)              |
+//! | `DELETE` | `/endpoints`             | Remove all endpoints; or, with a JSON array body, remove those listed |
+//! | `POST`   | `/endpoints/bulk`       | Upsert multiple endpoints without touching others (bulk add)          |
+//! | `DELETE` | `/endpoints/{address}`   | Remove the endpoint at `{address}`                                    |
+//! | `GET`    | `/filterchain`           | Get the current filter chain                                          |
+//! | `PUT`    | `/filterchain`           | Replace the filter chain                                              |
+//! | `DELETE` | `/filterchain`           | Reset the filter chain to empty                                       |
+
+use std::{
+    collections::BTreeSet,
+    net::SocketAddr,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Json},
+    routing,
+};
+
+use crate::{
+    config,
+    config::filter::FilterChainConfig,
+    filters::FilterChain,
+    net::{ClusterMap, endpoint::Endpoint},
+    providers::FiltersAndClusters,
+};
+
+pub const DEFAULT_PORT: u16 = 9000;
+
+#[derive(Clone)]
+struct HttpState {
+    filters: FilterChainConfig,
+    clusters: config::Watch<ClusterMap>,
+}
+
+impl HttpState {
+    fn router(self) -> axum::Router {
+        axum::Router::new()
+            .route(
+                "/endpoints",
+                routing::get(list_endpoints)
+                    .post(upsert_endpoint)
+                    .put(replace_endpoints)
+                    .delete(remove_endpoints),
+            )
+            .route("/endpoints/bulk", routing::post(bulk_add_endpoints))
+            .route("/endpoints/{address}", routing::delete(remove_endpoint))
+            .route(
+                "/filterchain",
+                routing::get(get_filterchain)
+                    .put(replace_filterchain)
+                    .delete(clear_filterchain),
+            )
+            .with_state(self)
+    }
+}
+
+async fn list_endpoints(State(state): State<HttpState>) -> Json<Vec<Endpoint>> {
+    let clusters = state.clusters.read();
+    let endpoints: Vec<Endpoint> = clusters
+        .get(&None)
+        .map(|es| es.endpoint_iter().collect())
+        .unwrap_or_default();
+    Json(endpoints)
+}
+
+async fn upsert_endpoint(
+    State(state): State<HttpState>,
+    Json(endpoint): Json<Endpoint>,
+) -> StatusCode {
+    state.clusters.modify(|clusters| {
+        // Collect first to release the DashMap read lock before calling insert_default.
+        let mut endpoints: BTreeSet<Endpoint> = clusters
+            .get(&None)
+            .map(|es| es.endpoint_iter().collect())
+            .unwrap_or_default();
+        endpoints.replace(endpoint);
+        clusters.insert_default(endpoints);
+    });
+    StatusCode::OK
+}
+
+/// `POST /endpoints/bulk` — upsert multiple endpoints without touching others.
+async fn bulk_add_endpoints(
+    State(state): State<HttpState>,
+    Json(incoming): Json<Vec<Endpoint>>,
+) -> StatusCode {
+    state.clusters.modify(|clusters| {
+        let mut endpoints: BTreeSet<Endpoint> = clusters
+            .get(&None)
+            .map(|es| es.endpoint_iter().collect())
+            .unwrap_or_default();
+        for ep in incoming {
+            endpoints.replace(ep);
+        }
+        clusters.insert_default(endpoints);
+    });
+    StatusCode::OK
+}
+
+async fn remove_endpoint(
+    State(state): State<HttpState>,
+    Path(address): Path<String>,
+) -> impl IntoResponse {
+    let Ok(addr) = address.parse::<crate::net::endpoint::EndpointAddress>() else {
+        return StatusCode::BAD_REQUEST;
+    };
+    state.clusters.modify(|clusters| {
+        let endpoints: BTreeSet<Endpoint> = clusters
+            .get(&None)
+            .map(|es| es.endpoint_iter().filter(|ep| ep.address != addr).collect())
+            .unwrap_or_default();
+        clusters.insert_default(endpoints);
+    });
+    StatusCode::OK
+}
+
+/// `PUT /endpoints` — replace the entire endpoint set atomically.
+async fn replace_endpoints(
+    State(state): State<HttpState>,
+    Json(endpoints): Json<Vec<Endpoint>>,
+) -> StatusCode {
+    let endpoints: BTreeSet<Endpoint> = endpoints.into_iter().collect();
+    state.clusters.modify(|clusters| {
+        clusters.insert_default(endpoints);
+    });
+    StatusCode::OK
+}
+
+/// `DELETE /endpoints` — remove all endpoints, or just the listed ones.
+///
+/// * No body → clears the entire set.
+/// * JSON body `["ip:port", ...]` → removes only those addresses, leaving
+///   all others intact.
+async fn remove_endpoints(
+    State(state): State<HttpState>,
+    addrs: Option<Json<Vec<crate::net::endpoint::EndpointAddress>>>,
+) -> StatusCode {
+    state.clusters.modify(|clusters| match addrs {
+        None => {
+            clusters.insert_default(BTreeSet::new());
+        }
+        Some(Json(addrs)) => {
+            let to_remove: std::collections::HashSet<_> = addrs.into_iter().collect();
+            let remaining: BTreeSet<Endpoint> = clusters
+                .get(&None)
+                .map(|es| {
+                    es.endpoint_iter()
+                        .filter(|ep| !to_remove.contains(&ep.address))
+                        .collect()
+                })
+                .unwrap_or_default();
+            clusters.insert_default(remaining);
+        }
+    });
+    StatusCode::OK
+}
+
+async fn get_filterchain(State(state): State<HttpState>) -> Json<Arc<FilterChain>> {
+    Json(state.filters.load().clone())
+}
+
+async fn replace_filterchain(
+    State(state): State<HttpState>,
+    Json(chain): Json<FilterChain>,
+) -> StatusCode {
+    state.filters.store(chain);
+    StatusCode::OK
+}
+
+async fn clear_filterchain(State(state): State<HttpState>) -> StatusCode {
+    state.filters.store(FilterChain::default());
+    StatusCode::OK
+}
+
+/// Builds the HTTP provider axum router from a [`FiltersAndClusters`].
+///
+/// Exposed for benchmarking and integration testing; normal usage goes through [`serve`].
+pub fn make_router(fc: FiltersAndClusters) -> axum::Router {
+    HttpState {
+        filters: fc.filters,
+        clusters: fc.clusters,
+    }
+    .router()
+}
+
+/// Runs the HTTP provider server, updating `clusters` and `filters` in response to incoming
+/// requests. Sets `health_check` to `true` once the listener is bound.
+pub async fn serve(
+    fc: FiltersAndClusters,
+    address: SocketAddr,
+    health_check: Arc<AtomicBool>,
+) -> crate::Result<()> {
+    let state = HttpState {
+        filters: fc.filters,
+        clusters: fc.clusters,
+    };
+
+    let router = state.router();
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    tracing::info!(%address, "HTTP provider listening");
+    health_check.store(true, Ordering::SeqCst);
+
+    quilkin_system::net::http::serve("http_provider", listener, router, std::future::pending())
+        .await
+        .map_err(eyre::Error::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum_test::TestServer;
+    use pretty_assertions::assert_eq;
+
+    fn make_server() -> (TestServer, crate::Config) {
+        // Enable the HTTP provider so that init_config inserts both FilterChain
+        // and ClusterMap into the typemap.
+        let providers = crate::Providers::default().http();
+        let service = crate::Service::default();
+        let config = crate::Config::new(None, Default::default(), &providers, &service);
+
+        let fc = FiltersAndClusters::new(&config).unwrap();
+        let state = HttpState {
+            filters: fc.filters,
+            clusters: fc.clusters,
+        };
+        let server = TestServer::new(state.router()).unwrap();
+        (server, config)
+    }
+
+    // ── endpoints ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_endpoints_empty() {
+        let (server, _cfg) = make_server();
+        let resp = server.get("/endpoints").await;
+        resp.assert_status_ok();
+        let body: Vec<Endpoint> = resp.json();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn upsert_then_list() {
+        let (server, _cfg) = make_server();
+        let ep = Endpoint::new("127.0.0.1:1234".parse().unwrap());
+
+        server.post("/endpoints").json(&ep).await.assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert_eq!(body.len(), 1);
+        assert_eq!(body[0].address, ep.address);
+    }
+
+    #[tokio::test]
+    async fn upsert_updates_metadata() {
+        let (server, _cfg) = make_server();
+        let addr: crate::net::endpoint::EndpointAddress = "127.0.0.1:9999".parse().unwrap();
+
+        let ep1 = Endpoint::with_metadata(
+            addr.clone(),
+            crate::net::endpoint::Metadata {
+                tokens: [b"token_a".to_vec()].into(),
+            },
+        );
+        server
+            .post("/endpoints")
+            .json(&ep1)
+            .await
+            .assert_status_ok();
+
+        // Same address, different metadata — should replace.
+        let ep2 = Endpoint::with_metadata(
+            addr,
+            crate::net::endpoint::Metadata {
+                tokens: [b"token_b".to_vec()].into(),
+            },
+        );
+        server
+            .post("/endpoints")
+            .json(&ep2)
+            .await
+            .assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert_eq!(body.len(), 1, "upsert should not duplicate the endpoint");
+        assert_eq!(body[0].metadata.known.tokens, ep2.metadata.known.tokens);
+    }
+
+    #[tokio::test]
+    async fn upsert_multiple_then_list() {
+        let (server, _cfg) = make_server();
+        let ep1 = Endpoint::new("127.0.0.1:1111".parse().unwrap());
+        let ep2 = Endpoint::new("127.0.0.1:2222".parse().unwrap());
+
+        server
+            .post("/endpoints")
+            .json(&ep1)
+            .await
+            .assert_status_ok();
+        server
+            .post("/endpoints")
+            .json(&ep2)
+            .await
+            .assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert_eq!(body.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn bulk_add_does_not_remove_existing() {
+        let (server, _cfg) = make_server();
+        let ep1 = Endpoint::new("127.0.0.1:1111".parse().unwrap());
+        let ep2 = Endpoint::new("127.0.0.1:2222".parse().unwrap());
+        let ep3 = Endpoint::new("127.0.0.1:3333".parse().unwrap());
+
+        server
+            .post("/endpoints")
+            .json(&ep1)
+            .await
+            .assert_status_ok();
+
+        // Bulk-add ep2 and ep3 — ep1 must still be present.
+        server
+            .post("/endpoints/bulk")
+            .json(&[&ep2, &ep3])
+            .await
+            .assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert_eq!(body.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn remove_specific_endpoint() {
+        let (server, _cfg) = make_server();
+        let ep1 = Endpoint::new("127.0.0.1:1111".parse().unwrap());
+        let ep2 = Endpoint::new("127.0.0.1:2222".parse().unwrap());
+
+        server
+            .post("/endpoints")
+            .json(&ep1)
+            .await
+            .assert_status_ok();
+        server
+            .post("/endpoints")
+            .json(&ep2)
+            .await
+            .assert_status_ok();
+
+        server
+            .delete("/endpoints/127.0.0.1:1111")
+            .await
+            .assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert_eq!(body.len(), 1);
+        assert_eq!(body[0].address, ep2.address);
+    }
+
+    #[tokio::test]
+    async fn remove_nonexistent_endpoint_is_ok() {
+        let (server, _cfg) = make_server();
+        server
+            .delete("/endpoints/10.0.0.1:5000")
+            .await
+            .assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn remove_endpoint_bad_address_returns_400() {
+        let (server, _cfg) = make_server();
+        server
+            .delete("/endpoints/not-a-valid-address")
+            .await
+            .assert_status(StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn clear_endpoints() {
+        let (server, _cfg) = make_server();
+        let ep = Endpoint::new("127.0.0.1:1111".parse().unwrap());
+        server.post("/endpoints").json(&ep).await.assert_status_ok();
+
+        server.delete("/endpoints").await.assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn replace_all_endpoints() {
+        let (server, _cfg) = make_server();
+        let ep1 = Endpoint::new("127.0.0.1:1111".parse().unwrap());
+        let ep2 = Endpoint::new("127.0.0.1:2222".parse().unwrap());
+        let ep3 = Endpoint::new("127.0.0.1:3333".parse().unwrap());
+
+        server
+            .post("/endpoints")
+            .json(&ep1)
+            .await
+            .assert_status_ok();
+        server
+            .post("/endpoints")
+            .json(&ep2)
+            .await
+            .assert_status_ok();
+
+        // PUT replaces the entire set — ep1/ep2 disappear, ep3 takes their place.
+        server
+            .put("/endpoints")
+            .json(&[&ep3])
+            .await
+            .assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert_eq!(body.len(), 1);
+        assert_eq!(body[0].address, ep3.address);
+    }
+
+    #[tokio::test]
+    async fn replace_with_empty_clears_all() {
+        let (server, _cfg) = make_server();
+        let ep = Endpoint::new("127.0.0.1:1111".parse().unwrap());
+        server.post("/endpoints").json(&ep).await.assert_status_ok();
+
+        server
+            .put("/endpoints")
+            .json(&Vec::<Endpoint>::new())
+            .await
+            .assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert!(body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bulk_remove_specific_endpoints() {
+        let (server, _cfg) = make_server();
+        let ep1 = Endpoint::new("127.0.0.1:1111".parse().unwrap());
+        let ep2 = Endpoint::new("127.0.0.1:2222".parse().unwrap());
+        let ep3 = Endpoint::new("127.0.0.1:3333".parse().unwrap());
+
+        for ep in [&ep1, &ep2, &ep3] {
+            server.post("/endpoints").json(ep).await.assert_status_ok();
+        }
+
+        // Remove ep1 and ep3 in one DELETE call; ep2 must survive.
+        let to_remove = vec![ep1.address.to_string(), ep3.address.to_string()];
+        server
+            .delete("/endpoints")
+            .json(&to_remove)
+            .await
+            .assert_status_ok();
+
+        let body: Vec<Endpoint> = server.get("/endpoints").await.json();
+        assert_eq!(body.len(), 1);
+        assert_eq!(body[0].address, ep2.address);
+    }
+
+    // ── filter chain ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_filterchain_returns_ok() {
+        let (server, _cfg) = make_server();
+        server.get("/filterchain").await.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn replace_filterchain_with_empty() {
+        let (server, _cfg) = make_server();
+        let chain = FilterChain::default();
+        server
+            .put("/filterchain")
+            .json(&chain)
+            .await
+            .assert_status_ok();
+        server.get("/filterchain").await.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn clear_filterchain() {
+        let (server, _cfg) = make_server();
+        server.delete("/filterchain").await.assert_status_ok();
+        server.get("/filterchain").await.assert_status_ok();
+    }
+
+    // ── shared state ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn http_state_shares_underlying_config() {
+        let (server, config) = make_server();
+
+        // Add an endpoint via HTTP.
+        let ep = Endpoint::new("127.0.0.1:4242".parse().unwrap());
+        server.post("/endpoints").json(&ep).await.assert_status_ok();
+
+        // The change should be visible in the shared Config.
+        let clusters = config.dyn_cfg.clusters().unwrap().read();
+        let stored: Vec<Endpoint> = clusters
+            .get(&None)
+            .map(|es| es.endpoint_iter().collect())
+            .unwrap_or_default();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].address, ep.address);
+    }
+}


### PR DESCRIPTION
This PR adds a HTTP API for adding endpoints to Quilkin, this allows other services to more easily integrate with Quilkin if they don't run on kubernetes, and makes it easier for us to add benchmarks for adding and removing endpoints.