### PR TITLE
Remove sub DBs when streams are terminated

### DIFF
--- a/crates/corrosion-tests/tests/quic.rs
+++ b/crates/corrosion-tests/tests/quic.rs
@@ -215,7 +215,7 @@ async fn test_quic_stream() {
     };
 
     // We should have bytes on disk even if we haven't actually mutated it yet
-    assert!(dbg!(bytes_on_disk().unwrap()) > 0);
+    assert!(bytes_on_disk().unwrap() > 0);
 
     let mut srx = sub.rx;
 
@@ -364,7 +364,18 @@ async fn test_quic_stream() {
     insta::assert_snapshot!("disconnect", ip.print().await);
     subscriber.shutdown(ErrorCode::Ok).await;
 
-    assert!(bytes_on_disk().is_none());
+    // On my local machine this is "instant", but CI runs on potatoes, so...
+    //assert!(bytes_on_disk().is_none());
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        loop {
+            if bytes_on_disk().is_none() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("failed to cleanup sub dir in expected time");
 
     assert_eq!(expected, actual);
 }

--- a/crates/corrosion-tests/tests/quic.rs
+++ b/crates/corrosion-tests/tests/quic.rs
@@ -192,6 +192,31 @@ async fn test_quic_stream() {
     .await
     .unwrap();
 
+    let sub_dir = db.sub_path.join(sub.id.simple().to_string());
+
+    let bytes_on_disk = || -> Option<u64> {
+        if !sub_dir.exists() {
+            return None;
+        };
+
+        let mut total = 0;
+
+        for entry in std::fs::read_dir(&sub_dir).ok()? {
+            if let Ok(entry) = entry
+                && let Ok(ft) = entry.file_type()
+                && ft.is_file()
+                && let Ok(md) = entry.metadata()
+            {
+                total += md.len();
+            }
+        }
+
+        Some(total)
+    };
+
+    // We should have bytes on disk even if we haven't actually mutated it yet
+    assert!(dbg!(bytes_on_disk().unwrap()) > 0);
+
     let mut srx = sub.rx;
 
     let mut mutate = async |sc: &[p::ServerChange]| {
@@ -338,6 +363,8 @@ async fn test_quic_stream() {
     mutator.shutdown().await;
     insta::assert_snapshot!("disconnect", ip.print().await);
     subscriber.shutdown(ErrorCode::Ok).await;
+
+    assert!(bytes_on_disk().is_none());
 
     assert_eq!(expected, actual);
 }

--- a/crates/corrosion-tests/tests/quic.rs
+++ b/crates/corrosion-tests/tests/quic.rs
@@ -136,24 +136,6 @@ impl server::DbMutator for InstaPrinter {
     }
 }
 
-#[derive(Clone)]
-struct ServerSub {
-    ctx: pubsub::PubsubContext,
-}
-
-#[async_trait::async_trait]
-impl server::SubManager for ServerSub {
-    async fn subscribe(
-        &self,
-        subp: pubsub::SubParamsv1,
-    ) -> Result<pubsub::Subscription, pubsub::MatcherUpsertError> {
-        self.ctx.subscribe(subp).await
-    }
-    async fn remove(&self, sub_id: &uuid::Uuid) -> bool {
-        self.ctx.remove(sub_id).await
-    }
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn test_quic_stream() {
     let db = ct::TestSubsDb::new(corrosion::schema::SCHEMA, "test_quic_stream").await;
@@ -163,17 +145,13 @@ async fn test_quic_stream() {
         btx: db.btx.clone(),
     };
 
-    let ss = ServerSub {
-        ctx: db.pubsub_ctx(),
-    };
-
     static SERVER_REG: std::sync::OnceLock<prometheus::Registry> = std::sync::OnceLock::new();
     let sreg = SERVER_REG.get_or_init(prometheus::Registry::new);
 
     let server = server::Server::new_unencrypted(
         (std::net::Ipv6Addr::LOCALHOST, 0).into(),
         ip.clone(),
-        ss,
+        db.pubsub_ctx(),
         corrosion::persistent::Metrics::new(sreg),
     )
     .unwrap();

--- a/crates/corrosion-tests/tests/quic.rs
+++ b/crates/corrosion-tests/tests/quic.rs
@@ -149,6 +149,9 @@ impl server::SubManager for ServerSub {
     ) -> Result<pubsub::Subscription, pubsub::MatcherUpsertError> {
         self.ctx.subscribe(subp).await
     }
+    async fn remove(&self, sub_id: &uuid::Uuid) -> bool {
+        self.ctx.remove(sub_id).await
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/crates/corrosion/src/persistent/mutator.rs
+++ b/crates/corrosion/src/persistent/mutator.rs
@@ -425,7 +425,7 @@ pub async fn broadcast_changes(
         for changes_seqs in chunked {
             match changes_seqs {
                 Ok((changes, seqs)) => {
-                    tracing::trace!(num_changes = changes.len(), ?seqs, "broadcasting changes");
+                    tracing::debug!(num_changes = changes.len(), ?seqs, "broadcasting changes");
 
                     let changeset = corro_types::broadcast::Changeset::FullV2 {
                         actor_id,

--- a/crates/corrosion/src/persistent/server.rs
+++ b/crates/corrosion/src/persistent/server.rs
@@ -1,4 +1,8 @@
-use crate::{Peer, codec, persistent::proto, pubsub};
+use crate::{
+    Peer, codec,
+    persistent::proto,
+    pubsub::{self, PubsubContext},
+};
 use quilkin_types::IcaoCode;
 use quinn::{RecvStream, SendStream};
 use std::net::{IpAddr, SocketAddr};
@@ -30,20 +34,11 @@ pub trait DbMutator: Sync + Send + Clone {
     async fn disconnected(&self, peer: Peer);
 }
 
-/// Trait used by a server implementation to perform database subscriptions
-#[async_trait::async_trait]
-pub trait SubManager: Sync + Send + Clone {
-    async fn subscribe(
-        &self,
-        subp: pubsub::SubParamsv1,
-    ) -> Result<pubsub::Subscription, pubsub::MatcherUpsertError>;
-    async fn remove(&self, sub_id: &uuid::Uuid) -> bool;
-}
-
 pub struct Server {
     endpoint: quinn::Endpoint,
     task: tokio::task::JoinHandle<()>,
     local_addr: SocketAddr,
+    pubsub_ctx: PubsubContext,
 }
 
 struct ValidRequest {
@@ -102,7 +97,7 @@ impl Server {
     pub fn new_unencrypted(
         addr: SocketAddr,
         mutator: impl DbMutator + 'static,
-        subs: impl SubManager + 'static,
+        subs: PubsubContext,
         metrics: super::Metrics,
     ) -> std::io::Result<Self> {
         let mut sc = quinn_plaintext::server_config();
@@ -112,6 +107,8 @@ impl Server {
 
         let local_addr = endpoint.local_addr()?;
         let ep = endpoint.clone();
+        let pubsub_ctx = subs.clone();
+
         let task = tokio::task::spawn(async move {
             while let Some(inc) = ep.accept().await {
                 if !inc.remote_address_validated() {
@@ -199,6 +196,7 @@ impl Server {
             endpoint,
             task,
             local_addr,
+            pubsub_ctx,
         })
     }
 
@@ -236,7 +234,7 @@ impl Server {
     async fn handle_request(
         req: ValidRequest,
         mutator: impl DbMutator + 'static,
-        subs: impl SubManager + 'static,
+        subs: PubsubContext,
     ) {
         let ValidRequest {
             mut send,
@@ -276,6 +274,9 @@ impl Server {
         self.endpoint
             .close(quinn::VarInt::from_u32(0), reason.as_bytes());
         drop(self.task.await);
+
+        // Cleans up all of the subscription databases
+        self.pubsub_ctx.shutdown().await;
     }
 
     #[inline]
@@ -332,7 +333,7 @@ mod v1_impl {
         req: v1::SubscribeRequest,
         peer: Peer,
         send: &mut SendStream,
-        subs: impl SubManager + 'static,
+        subs: PubsubContext,
     ) -> Result<(), IoLoopError> {
         let max_buffer = req.0.max_buffer;
         let max_time = req.0.max_time;
@@ -429,7 +430,7 @@ mod v1_impl {
         send: &mut SendStream,
         recv: &mut RecvStream,
         mutator: impl DbMutator + 'static,
-        subs: impl SubManager + 'static,
+        subs: PubsubContext,
     ) -> Result<(), IoLoopError> {
         match request {
             v1::Request::Mutate(mreq) => handle_mutate(mreq, peer, send, recv, mutator).await,

--- a/crates/corrosion/src/persistent/server.rs
+++ b/crates/corrosion/src/persistent/server.rs
@@ -37,6 +37,7 @@ pub trait SubManager: Sync + Send + Clone {
         &self,
         subp: pubsub::SubParamsv1,
     ) -> Result<pubsub::Subscription, pubsub::MatcherUpsertError>;
+    async fn remove(&self, sub_id: &uuid::Uuid) -> bool;
 }
 
 pub struct Server {
@@ -380,6 +381,13 @@ mod v1_impl {
 
                 let res = io_loop().await;
                 tracing::debug!(result = ?res, "subscription stream ended");
+
+                // For now we don't care about restoring subscriptions and just always do state of the world on initial
+                // connection for simplicity
+                if !subs.remove(&sub_id).await {
+                    tracing::warn!(%peer, %sub_id, "failed to find subscription for termination stream");
+                }
+
                 res
             }
             Err(err) => {

--- a/crates/corrosion/src/pubsub.rs
+++ b/crates/corrosion/src/pubsub.rs
@@ -798,12 +798,26 @@ impl PubsubContext {
 
         Ok(Subscription { id, query_hash, rx })
     }
+
+    pub async fn remove(&self, uuid: &uuid::Uuid) -> bool {
+        let Some(matcher) = self.subs.remove(uuid) else {
+            return false;
+        };
+
+        matcher.cleanup().await;
+
+        true
+    }
 }
 
 #[async_trait::async_trait]
 impl crate::persistent::server::SubManager for PubsubContext {
     async fn subscribe(&self, subp: SubParamsv1) -> Result<Subscription, MatcherUpsertError> {
         self.subscribe(subp).await
+    }
+
+    async fn remove(&self, uuid: &uuid::Uuid) -> bool {
+        self.remove(uuid).await
     }
 }
 

--- a/crates/corrosion/src/pubsub.rs
+++ b/crates/corrosion/src/pubsub.rs
@@ -827,7 +827,7 @@ impl PubsubContext {
         match std::fs::remove_dir_all(&self.path) {
             Ok(_) => tracing::info!(path = %self.path, "removed subscription directory"),
             Err(error) => {
-                tracing::error!(path = %self.path, %error, "failed to remove subscription directory")
+                tracing::error!(path = %self.path, %error, "failed to remove subscription directory");
             }
         }
     }

--- a/crates/corrosion/src/pubsub.rs
+++ b/crates/corrosion/src/pubsub.rs
@@ -755,10 +755,21 @@ impl PubsubContext {
         pool: SplitPool,
         schema: Arc<Schema>,
         tripwire: Tripwire,
-        loop_config: MatcherLoopConfig,
+        _loop_config: MatcherLoopConfig,
     ) -> eyre::Result<Self> {
-        let cache =
-            restore_subscriptions(&subs, &path, &pool, &schema, &tripwire, loop_config).await?;
+        // For now we never restore subscriptions and require state of the world for both
+        // mutators and subscribers
+        // let cache =
+        //     restore_subscriptions(&subs, &path, &pool, &schema, &tripwire, loop_config).await?;
+        let cache = Arc::new(tokio::sync::RwLock::new(MatcherCache(
+            MatcherCacheInner::default(),
+        )));
+
+        if path.exists() {
+            use eyre::WrapErr;
+            std::fs::remove_dir_all(&path)
+                .wrap_err_with(|| format!("failed to cleanup existing subscription path {path}"))?;
+        }
 
         Ok(Self {
             subs,
@@ -808,16 +819,17 @@ impl PubsubContext {
 
         true
     }
-}
 
-#[async_trait::async_trait]
-impl crate::persistent::server::SubManager for PubsubContext {
-    async fn subscribe(&self, subp: SubParamsv1) -> Result<Subscription, MatcherUpsertError> {
-        self.subscribe(subp).await
-    }
+    pub async fn shutdown(&self) {
+        self.subs.drop_handles().await;
 
-    async fn remove(&self, uuid: &uuid::Uuid) -> bool {
-        self.remove(uuid).await
+        // Just to be sure, completely nuke the entire subscription directory
+        match std::fs::remove_dir_all(&self.path) {
+            Ok(_) => tracing::info!(path = %self.path, "removed subscription directory"),
+            Err(error) => {
+                tracing::error!(path = %self.path, %error, "failed to remove subscription directory")
+            }
+        }
     }
 }
 

--- a/crates/test/src/lib.rs
+++ b/crates/test/src/lib.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 #[cfg(target_os = "linux")]
 pub mod xdp_util;
 
-pub const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(2);
+pub const MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
 
 #[inline]
 pub fn alloc_buffer(data: impl AsRef<[u8]>) -> bytes::BytesMut {

--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -253,6 +253,9 @@ trace_test!(xds_bridge_to_corrosion, {
     let (local_addr, _rx) = sb.proxy("proxy");
     let (mut rx, server_addr) = sb.server("server");
 
+    // TODO: this should not be here but want to see if it mitigates the CI flakiness
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
     let mut agent_config = sb.config_file("agent");
     agent_config.update(|config| {
         config.clusters.insert_default(

--- a/src/config/corro.rs
+++ b/src/config/corro.rs
@@ -24,7 +24,7 @@ impl Drop for BridgeInner {
             let count = statements.len();
 
             if self.tx.tx.send(statements).is_ok() {
-                tracing::trace!(count, "sent statements from bridge");
+                tracing::debug!(count, "sent statements from bridge");
             } else {
                 use std::sync::atomic;
 

--- a/src/config/corro.rs
+++ b/src/config/corro.rs
@@ -21,7 +21,24 @@ impl Drop for BridgeInner {
         let statements = std::mem::take(&mut self.statements);
 
         if !statements.is_empty() {
-            let _rx_dropped = self.tx.tx.send(statements);
+            let count = statements.len();
+
+            if self.tx.tx.send(statements).is_ok() {
+                tracing::trace!(count, "sent statements from bridge");
+            } else {
+                use std::sync::atomic;
+
+                static OUTPUT: atomic::AtomicBool = atomic::AtomicBool::new(false);
+
+                if OUTPUT.load(atomic::Ordering::Relaxed) {
+                    return;
+                }
+
+                tracing::error!("xds bridge can no longer send updates, the receiver was closed");
+                OUTPUT.store(true, atomic::Ordering::Relaxed);
+            }
+        } else {
+            tracing::trace!("no statements to send");
         }
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1134,6 +1134,7 @@ impl Service {
 
             trip.shutdown().await;
 
+            tracing::info!("shutting down corrosion server")
             udp_server.shutdown("graceful shutdown").await;
 
             drop(finished.send(Ok(())));

--- a/src/service.rs
+++ b/src/service.rs
@@ -1134,7 +1134,7 @@ impl Service {
 
             trip.shutdown().await;
 
-            tracing::info!("shutting down corrosion server")
+            tracing::info!("shutting down corrosion server");
             udp_server.shutdown("graceful shutdown").await;
 
             drop(finished.send(Ok(())));

--- a/src/service.rs
+++ b/src/service.rs
@@ -983,8 +983,8 @@ impl Service {
                     .await;
 
                 match res {
-                    Ok((_, version, elapsed)) => {
-                        tracing::debug!(?version, ?elapsed, "updated servers");
+                    Ok((count, version, elapsed)) => {
+                        tracing::debug!(count, ?version, ?elapsed, "broadcasted server update");
                     }
                     Err(error) => {
                         tracing::error!(%error, "failed to update servers");


### PR DESCRIPTION
We previously weren't explicitly cleaning up subscriptions when the subscriber connection was closed, and we now completely remove all subscription databases both on start and shutdown.