### PR TITLE
fix: add udp session limit to prevent unbounded growth

### DIFF
--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -119,6 +119,7 @@ trace_test!(uring_receiver, {
         sessions: quilkin::net::sessions::SessionPool::new(
             vec![pending_sends.0.clone()],
             config.dyn_cfg.cached_filter_chain().unwrap(),
+            usize::MAX,
         ),
     }
     .spawn_io_loop(pending_sends, config.dyn_cfg.cached_filter_chain().unwrap())
@@ -167,6 +168,7 @@ trace_test!(
         let sessions = net::SessionPool::new(
             pending_sends.iter().map(|ps| ps.0.clone()).collect(),
             config.dyn_cfg.cached_filter_chain().unwrap(),
+            usize::MAX,
         );
 
         const WORKER_COUNT: usize = 3;

--- a/src/net/error.rs
+++ b/src/net/error.rs
@@ -23,6 +23,7 @@ pub enum PipelineError {
     Session(super::sessions::SessionError),
     Io(std::io::Error),
     DisallowedSourceIP(std::net::IpAddr),
+    SessionLimit,
 }
 
 impl PipelineError {
@@ -49,6 +50,7 @@ impl PipelineError {
             Self::Session(_) => "session",
             Self::Io(_) => "io",
             Self::DisallowedSourceIP(_) => "disallowed source ip",
+            Self::SessionLimit => "session limit",
         }
     }
 }
@@ -63,6 +65,7 @@ impl fmt::Display for PipelineError {
             Self::Session(session) => write!(f, "session error: {session}"),
             Self::Io(io) => write!(f, "OS level error: {io}"),
             Self::DisallowedSourceIP(ip) => write!(f, "disallowed ip: {ip}"),
+            Self::SessionLimit => f.write_str("session limit reached"),
         }
     }
 }
@@ -82,11 +85,12 @@ impl From<super::sessions::SessionError> for PipelineError {
 impl PartialEq for PipelineError {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::NoUpstreamEndpoints, Self::NoUpstreamEndpoints) => true,
             (Self::Filter(fa), Self::Filter(fb)) => fa.eq(fb),
             (Self::Session(sa), Self::Session(sb)) => sa.eq(sb),
             (Self::Io(ia), Self::Io(ib)) => ia.kind().eq(&ib.kind()),
             (Self::DisallowedSourceIP(ia), Self::DisallowedSourceIP(ib)) => ia.eq(ib),
+            (Self::NoUpstreamEndpoints, Self::NoUpstreamEndpoints)
+            | (Self::SessionLimit, Self::SessionLimit) => true,
             _ => false,
         }
     }
@@ -103,7 +107,7 @@ impl Hash for PipelineError {
             Self::Filter(fe) => Hash::hash(&fe, state),
             Self::Session(se) => Hash::hash(&se, state),
             Self::Io(io) => Hash::hash(&io.kind(), state),
-            Self::NoUpstreamEndpoints => {}
+            Self::NoUpstreamEndpoints | Self::SessionLimit => {}
             Self::DisallowedSourceIP(ip) => Hash::hash(&ip, state),
         }
     }

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -272,7 +272,7 @@ mod tests {
         let config = Arc::new(config);
 
         let cached_filter_chain = config.dyn_cfg.cached_filter_chain().unwrap();
-        let session_manager = SessionPool::new(vec![], cached_filter_chain);
+        let session_manager = SessionPool::new(vec![], cached_filter_chain, usize::MAX);
 
         let filter_chain = crate::filters::FilterChain::default();
         let packet_data: [u8; 4] = [1, 2, 3, 4];

--- a/src/net/sessions.rs
+++ b/src/net/sessions.rs
@@ -94,6 +94,7 @@ pub struct SessionPool {
     downstream_sends: Vec<PacketQueueSender>,
     downstream_index: atomic::AtomicUsize,
     cached_filter_chain: CachedFilterChain,
+    max_sessions: usize,
 }
 
 /// The wrapper struct responsible for holding all of the socket related mappings.
@@ -112,6 +113,7 @@ impl SessionPool {
     pub fn new(
         downstream_sends: Vec<PacketQueueSender>,
         cached_filter_chain: CachedFilterChain,
+        max_sessions: usize,
     ) -> Arc<Self> {
         const SESSION_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
         const SESSION_EXPIRY_POLL_INTERVAL: Duration = Duration::from_secs(60);
@@ -123,6 +125,7 @@ impl SessionPool {
             downstream_sends,
             downstream_index: atomic::AtomicUsize::new(0),
             cached_filter_chain,
+            max_sessions,
         })
     }
 
@@ -221,11 +224,21 @@ impl SessionPool {
         tracing::trace!(source=%key.source, dest=%key.dest, "SessionPool::get");
         // If we already have a session for the key pairing, return that session.
         if let Some(entry) = self.session_map.get(&key) {
-            tracing::trace!("returning existing session");
             return Ok((
                 entry.asn_info.as_ref().map(MetricsIpNetEntry::from),
                 entry.pending_sends.clone(),
             ));
+        }
+
+        if self.session_map.len() >= self.max_sessions {
+            tracing::warn!(
+                limit = self.max_sessions,
+                source = %key.source,
+                dest = %key.dest,
+                "session limit reached, dropping packet"
+            );
+            inner_metrics::sessions_rejected_total().inc();
+            return Err(super::PipelineError::SessionLimit);
         }
 
         // If there's a socket_set available, it means there are sockets
@@ -557,7 +570,7 @@ mod tests {
         let (pending_sends, _srecv) = crate::net::queue(1).unwrap();
         let fake = crate::config::filter::FilterChainConfig::default();
         (
-            SessionPool::new(vec![pending_sends.clone()], fake.cached()),
+            SessionPool::new(vec![pending_sends.clone()], fake.cached(), usize::MAX),
             pending_sends,
         )
     }
@@ -699,6 +712,68 @@ mod tests {
         let _socket2 = pool.get(key2).unwrap();
 
         task.await.unwrap();
+    }
+
+    fn pool_with_limit(limit: usize) -> (Arc<SessionPool>, PacketQueueSender) {
+        let (pending_sends, _srecv) = crate::net::queue(1).unwrap();
+        let fake = crate::config::filter::FilterChainConfig::default();
+        (
+            SessionPool::new(vec![pending_sends.clone()], fake.cached(), limit),
+            pending_sends,
+        )
+    }
+
+    fn key(source_port: u16, dest_port: u16) -> SessionKey {
+        (
+            (std::net::Ipv4Addr::LOCALHOST, source_port).into(),
+            (std::net::Ipv4Addr::UNSPECIFIED, dest_port).into(),
+        )
+            .into()
+    }
+
+    #[tokio::test]
+    async fn session_limit_rejects_new_sessions_at_capacity() {
+        let (pool, _receiver) = pool_with_limit(2);
+
+        assert!(pool.get(key(8080, 9000)).is_ok());
+        assert!(pool.get(key(8081, 9000)).is_ok());
+
+        assert!(matches!(
+            pool.get(key(8082, 9000)),
+            Err(super::super::PipelineError::SessionLimit)
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_limit_allows_existing_session_at_capacity() {
+        let (pool, _receiver) = pool_with_limit(1);
+
+        assert!(pool.get(key(8080, 9000)).is_ok());
+
+        // Limit hit — new session rejected.
+        assert!(matches!(
+            pool.get(key(8081, 9000)),
+            Err(super::super::PipelineError::SessionLimit)
+        ));
+
+        // But re-fetching the existing session must still succeed.
+        assert!(pool.get(key(8080, 9000)).is_ok());
+    }
+
+    #[tokio::test]
+    async fn session_limit_recovers_after_session_removed() {
+        let (pool, _receiver) = pool_with_limit(1);
+
+        assert!(pool.get(key(8080, 9000)).is_ok());
+        assert!(matches!(
+            pool.get(key(8081, 9000)),
+            Err(super::super::PipelineError::SessionLimit)
+        ));
+
+        pool.drop_session(key(8080, 9000)).await;
+
+        // Slot freed — a new session should be accepted.
+        assert!(pool.get(key(8081, 9000)).is_ok());
     }
 
     #[tokio::test]

--- a/src/net/sessions/inner_metrics.rs
+++ b/src/net/sessions/inner_metrics.rs
@@ -60,6 +60,24 @@ pub(crate) fn total_sessions() -> &'static IntCounter {
     &TOTAL_SESSIONS
 }
 
+pub(crate) fn sessions_rejected_total() -> &'static IntCounter {
+    static SESSIONS_REJECTED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+        register(
+            IntCounter::with_opts(
+                Opts::new(
+                    "rejected_total",
+                    "total number of sessions rejected due to the session limit",
+                )
+                .subsystem(SUBSYSTEM)
+                .namespace("quilkin"),
+            )
+            .unwrap(),
+        )
+    });
+
+    &SESSIONS_REJECTED_TOTAL
+}
+
 pub(crate) fn duration_secs() -> &'static Histogram {
     static DURATION_SECS: Lazy<Histogram> = Lazy::new(|| {
         register(

--- a/src/service.rs
+++ b/src/service.rs
@@ -78,6 +78,14 @@ pub struct Service {
     /// Amount of UDP workers to run.
     #[clap(long = "service.udp.workers", env = "QUILKIN_SERVICE_UDP_WORKERS", default_value_t = std::num::NonZeroUsize::new(num_cpus::get()).unwrap())]
     pub udp_workers: std::num::NonZeroUsize,
+    /// Maximum number of concurrent UDP sessions. New sessions are rejected with a
+    /// metric increment once the limit is reached, preventing unbounded memory growth.
+    #[clap(
+        long = "service.udp.sessions.limit",
+        env = "QUILKIN_SERVICE_UDP_SESSIONS_LIMIT",
+        default_value_t = 5_000
+    )]
+    pub udp_session_limit: usize,
     /// Whether to serve xDS requests.
     #[arg(
         long = "service.xds",
@@ -196,6 +204,7 @@ impl Default for Service {
             udp_enabled: <_>::default(),
             udp_port: 7777,
             udp_workers: std::num::NonZeroUsize::new(num_cpus::get()).unwrap(),
+            udp_session_limit: 10_000,
             xds_enabled: <_>::default(),
             xds_port: 7800,
             grpc_enabled: false,
@@ -730,7 +739,7 @@ impl Service {
             .cached_filter_chain()
             .context("a cached FilterChain should have been configured")?;
 
-        let sessions = SessionPool::new(session_sends, cached_filters);
+        let sessions = SessionPool::new(session_sends, cached_filters, self.udp_session_limit);
         crate::net::packet::spawn_receivers(config, socket, worker_sends, &sessions)?;
 
         let finished = shutdown.push("udp");


### PR DESCRIPTION
Currently sessions can grow until memory or file descriptors are exhausted this adds a limit that leads to packet drops instead of the host killing the proxy.