### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,67 @@
 
 ### Other
 
+- set gitattributes to keep lf line endings ([#1401](https://github.com/EmbarkStudios/quilkin/pull/1401))
+- release v0.10.1 ([#1400](https://github.com/EmbarkStudios/quilkin/pull/1400))
+- googleforgames -> EmbarkStudios ([#1398](https://github.com/EmbarkStudios/quilkin/pull/1398))
+- *(deps)* bump openssl from 0.10.79 to 0.10.80 ([#1397](https://github.com/EmbarkStudios/quilkin/pull/1397))
+- remove .* from .gitignore, set version of corrosion dependency
+- Remove sub DB when streams are terminated ([#1393](https://github.com/EmbarkStudios/quilkin/pull/1393))
+- try explicit latest version
+- try setting workspace explicitly
+- set file protocol to allow in release-plz
+- *(deps)* bump openssl from 0.10.78 to 0.10.79 ([#1392](https://github.com/EmbarkStudios/quilkin/pull/1392))
+- rm benches from dockerignore
+- fix benches missing in dockerfile
+- Foward xDS events to corrosion ([#1376](https://github.com/EmbarkStudios/quilkin/pull/1376))
+- update UE5 plugin ([#1384](https://github.com/EmbarkStudios/quilkin/pull/1384))
+- update changelog for 0.10.0 ([#1385](https://github.com/EmbarkStudios/quilkin/pull/1385))
+- *(deps)* bump openssl from 0.10.75 to 0.10.78 ([#1382](https://github.com/EmbarkStudios/quilkin/pull/1382))
+- Bind corrosion client to unspecified address ([#1381](https://github.com/EmbarkStudios/quilkin/pull/1381))
+- Replace `cfg_if!` with `cfg_select!` ([#1380](https://github.com/EmbarkStudios/quilkin/pull/1380))
+- try git_only in release-plz.toml
+- add debug steps to release-plz.yaml
+- don't checkout submodules in release-plz.yaml
+- remove fetch-depth from release-plz.yaml
+- remove persist-credentials in release-plz.yaml
+- *(deps)* bump rustls-webpki from 0.103.8 to 0.103.10 ([#1375](https://github.com/EmbarkStudios/quilkin/pull/1375))
+- Support static provider with corrosion and enable running locally ([#1373](https://github.com/EmbarkStudios/quilkin/pull/1373))
+- Use Non Negative Least Squares for latency measurement ([#1367](https://github.com/EmbarkStudios/quilkin/pull/1367))
+- io-uring changes ([#1361](https://github.com/EmbarkStudios/quilkin/pull/1361))
+- Fix cpu profiling endpoint ([#1368](https://github.com/EmbarkStudios/quilkin/pull/1368))
+- Upgrade `kube` dep to 3.x ([#1360](https://github.com/EmbarkStudios/quilkin/pull/1360))
+- checkout submodules in image build ([#1366](https://github.com/EmbarkStudios/quilkin/pull/1366))
+- Fix `aarch64-linux-unknown-gnu` compilation ([#1365](https://github.com/EmbarkStudios/quilkin/pull/1365))
+- refactor dockerfile to use buildx actions and chef ([#1363](https://github.com/EmbarkStudios/quilkin/pull/1363))
+- Update `time` crate and workaround yq issue ([#1359](https://github.com/EmbarkStudios/quilkin/pull/1359))
+- Add quilkin_allocated_xdp_packets metric ([#1357](https://github.com/EmbarkStudios/quilkin/pull/1357))
+- Add test_success job ([#1355](https://github.com/EmbarkStudios/quilkin/pull/1355))
+- Don't stop admin server on graceful shutdown ([#1354](https://github.com/EmbarkStudios/quilkin/pull/1354))
+- Refactor documentation workflow to use mise action ([#1346](https://github.com/EmbarkStudios/quilkin/pull/1346))
+- fix mdbook build, refactor, layout, remove xDS references ([#1345](https://github.com/EmbarkStudios/quilkin/pull/1345))
+- set submodules true in checkout ([#1344](https://github.com/EmbarkStudios/quilkin/pull/1344))
+- set absolute path ([#1343](https://github.com/EmbarkStudios/quilkin/pull/1343))
+
+## [0.10.1](https://github.com/EmbarkStudios/quilkin/compare/quilkin-v0.10.0...quilkin-v0.10.1) - 2026-05-26
+
+### Added
+
+- add http provider + provider benchmarks ([#1379](https://github.com/EmbarkStudios/quilkin/pull/1379))
+- Batch k8s events to prevent excessive calls to `EndpointSet::update()` ([#1370](https://github.com/EmbarkStudios/quilkin/pull/1370))
+- Initial corrosion integration ([#1348](https://github.com/EmbarkStudios/quilkin/pull/1348))
+- Add decryptor filter ([#1035](https://github.com/EmbarkStudios/quilkin/pull/1035))
+
+### Fixed
+
+- add udp session limit to prevent unbounded growth ([#1396](https://github.com/EmbarkStudios/quilkin/pull/1396))
+- compose example
+- rustdoc errors & warnings
+- reject invalid ports ([#1372](https://github.com/EmbarkStudios/quilkin/pull/1372))
+- fix issue when watching multiple k8s namespaces ([#1369](https://github.com/EmbarkStudios/quilkin/pull/1369))
+- Change how latency to other nodes is measured ([#1364](https://github.com/EmbarkStudios/quilkin/pull/1364))
+
+### Other
+
 - *(deps)* bump openssl from 0.10.79 to 0.10.80 ([#1397](https://github.com/EmbarkStudios/quilkin/pull/1397))
 - remove .* from .gitignore, set version of corrosion dependency
 - Remove sub DB when streams are terminated ([#1393](https://github.com/EmbarkStudios/quilkin/pull/1393))

--- a/crates/corrosion/CHANGELOG.md
+++ b/crates/corrosion/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/EmbarkStudios/quilkin/releases/tag/quilkin-corrosion-v0.1.0) - 2026-05-26
+
+### Added
+
+- Initial corrosion integration ([#1348](https://github.com/EmbarkStudios/quilkin/pull/1348))
+
+### Fixed
+
+- rustdoc errors & warnings
+
+### Other
+
+- set corrosion to publish = true
+- remove .* from .gitignore, set version of corrosion dependency
+- Remove sub DB when streams are terminated ([#1393](https://github.com/EmbarkStudios/quilkin/pull/1393))
+- Foward xDS events to corrosion ([#1376](https://github.com/EmbarkStudios/quilkin/pull/1376))
+- Bind corrosion client to unspecified address ([#1381](https://github.com/EmbarkStudios/quilkin/pull/1381))
+- Fix FromSqlValue for DatacenterRow ([#1374](https://github.com/EmbarkStudios/quilkin/pull/1374))
+- fixup Cargo.toml's in packages ([#1341](https://github.com/EmbarkStudios/quilkin/pull/1341))
+- remove unused dependencies ([#1335](https://github.com/EmbarkStudios/quilkin/pull/1335))
+- update dependencies ([#1321](https://github.com/EmbarkStudios/quilkin/pull/1321))
+- Update crates and rust version ([#1313](https://github.com/EmbarkStudios/quilkin/pull/1313))
+- Subscription I/O ([#1308](https://github.com/EmbarkStudios/quilkin/pull/1308))
+- Add support for subscriptions ([#1296](https://github.com/EmbarkStudios/quilkin/pull/1296))
+- Add version 1 handshake test ([#1273](https://github.com/EmbarkStudios/quilkin/pull/1273))
+- Add persistent UDP stream ([#1271](https://github.com/EmbarkStudios/quilkin/pull/1271))
+- Add corrosion ([#1261](https://github.com/EmbarkStudios/quilkin/pull/1261))


### PR DESCRIPTION



## 🤖 New release

* `quilkin-corrosion`: 0.1.0
* `quilkin`: 0.10.0 -> 0.10.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `quilkin-corrosion`

<blockquote>

## [0.1.0](https://github.com/EmbarkStudios/quilkin/releases/tag/quilkin-corrosion-v0.1.0) - 2026-05-26

### Added

- Initial corrosion integration ([#1348](https://github.com/EmbarkStudios/quilkin/pull/1348))

### Fixed

- rustdoc errors & warnings

### Other

- set corrosion to publish = true
- remove .* from .gitignore, set version of corrosion dependency
- Remove sub DB when streams are terminated ([#1393](https://github.com/EmbarkStudios/quilkin/pull/1393))
- Foward xDS events to corrosion ([#1376](https://github.com/EmbarkStudios/quilkin/pull/1376))
- Bind corrosion client to unspecified address ([#1381](https://github.com/EmbarkStudios/quilkin/pull/1381))
- Fix FromSqlValue for DatacenterRow ([#1374](https://github.com/EmbarkStudios/quilkin/pull/1374))
- fixup Cargo.toml's in packages ([#1341](https://github.com/EmbarkStudios/quilkin/pull/1341))
- remove unused dependencies ([#1335](https://github.com/EmbarkStudios/quilkin/pull/1335))
- update dependencies ([#1321](https://github.com/EmbarkStudios/quilkin/pull/1321))
- Update crates and rust version ([#1313](https://github.com/EmbarkStudios/quilkin/pull/1313))
- Subscription I/O ([#1308](https://github.com/EmbarkStudios/quilkin/pull/1308))
- Add support for subscriptions ([#1296](https://github.com/EmbarkStudios/quilkin/pull/1296))
- Add version 1 handshake test ([#1273](https://github.com/EmbarkStudios/quilkin/pull/1273))
- Add persistent UDP stream ([#1271](https://github.com/EmbarkStudios/quilkin/pull/1271))
- Add corrosion ([#1261](https://github.com/EmbarkStudios/quilkin/pull/1261))
</blockquote>

## `quilkin`

<blockquote>

## v0.10.0 (2026-04-30)

## [0.10.1](https://github.com/EmbarkStudios/quilkin/compare/quilkin-v0.10.0...quilkin-v0.10.1) - 2026-05-26

### Added

- add http provider + provider benchmarks ([#1379](https://github.com/EmbarkStudios/quilkin/pull/1379))
- Batch k8s events to prevent excessive calls to `EndpointSet::update()` ([#1370](https://github.com/EmbarkStudios/quilkin/pull/1370))
- Initial corrosion integration ([#1348](https://github.com/EmbarkStudios/quilkin/pull/1348))
- Add decryptor filter ([#1035](https://github.com/EmbarkStudios/quilkin/pull/1035))

### Fixed

- add udp session limit to prevent unbounded growth ([#1396](https://github.com/EmbarkStudios/quilkin/pull/1396))
- compose example
- rustdoc errors & warnings
- reject invalid ports ([#1372](https://github.com/EmbarkStudios/quilkin/pull/1372))
- fix issue when watching multiple k8s namespaces ([#1369](https://github.com/EmbarkStudios/quilkin/pull/1369))
- Change how latency to other nodes is measured ([#1364](https://github.com/EmbarkStudios/quilkin/pull/1364))

### Other

- set gitattributes to keep lf line endings ([#1401](https://github.com/EmbarkStudios/quilkin/pull/1401))
- release v0.10.1 ([#1400](https://github.com/EmbarkStudios/quilkin/pull/1400))
- googleforgames -> EmbarkStudios ([#1398](https://github.com/EmbarkStudios/quilkin/pull/1398))
- *(deps)* bump openssl from 0.10.79 to 0.10.80 ([#1397](https://github.com/EmbarkStudios/quilkin/pull/1397))
- remove .* from .gitignore, set version of corrosion dependency
- Remove sub DB when streams are terminated ([#1393](https://github.com/EmbarkStudios/quilkin/pull/1393))
- try explicit latest version
- try setting workspace explicitly
- set file protocol to allow in release-plz
- *(deps)* bump openssl from 0.10.78 to 0.10.79 ([#1392](https://github.com/EmbarkStudios/quilkin/pull/1392))
- rm benches from dockerignore
- fix benches missing in dockerfile
- Foward xDS events to corrosion ([#1376](https://github.com/EmbarkStudios/quilkin/pull/1376))
- update UE5 plugin ([#1384](https://github.com/EmbarkStudios/quilkin/pull/1384))
- update changelog for 0.10.0 ([#1385](https://github.com/EmbarkStudios/quilkin/pull/1385))
- *(deps)* bump openssl from 0.10.75 to 0.10.78 ([#1382](https://github.com/EmbarkStudios/quilkin/pull/1382))
- Bind corrosion client to unspecified address ([#1381](https://github.com/EmbarkStudios/quilkin/pull/1381))
- Replace `cfg_if!` with `cfg_select!` ([#1380](https://github.com/EmbarkStudios/quilkin/pull/1380))
- try git_only in release-plz.toml
- add debug steps to release-plz.yaml
- don't checkout submodules in release-plz.yaml
- remove fetch-depth from release-plz.yaml
- remove persist-credentials in release-plz.yaml
- *(deps)* bump rustls-webpki from 0.103.8 to 0.103.10 ([#1375](https://github.com/EmbarkStudios/quilkin/pull/1375))
- Support static provider with corrosion and enable running locally ([#1373](https://github.com/EmbarkStudios/quilkin/pull/1373))
- Use Non Negative Least Squares for latency measurement ([#1367](https://github.com/EmbarkStudios/quilkin/pull/1367))
- io-uring changes ([#1361](https://github.com/EmbarkStudios/quilkin/pull/1361))
- Fix cpu profiling endpoint ([#1368](https://github.com/EmbarkStudios/quilkin/pull/1368))
- Upgrade `kube` dep to 3.x ([#1360](https://github.com/EmbarkStudios/quilkin/pull/1360))
- checkout submodules in image build ([#1366](https://github.com/EmbarkStudios/quilkin/pull/1366))
- Fix `aarch64-linux-unknown-gnu` compilation ([#1365](https://github.com/EmbarkStudios/quilkin/pull/1365))
- refactor dockerfile to use buildx actions and chef ([#1363](https://github.com/EmbarkStudios/quilkin/pull/1363))
- Update `time` crate and workaround yq issue ([#1359](https://github.com/EmbarkStudios/quilkin/pull/1359))
- Add quilkin_allocated_xdp_packets metric ([#1357](https://github.com/EmbarkStudios/quilkin/pull/1357))
- Add test_success job ([#1355](https://github.com/EmbarkStudios/quilkin/pull/1355))
- Don't stop admin server on graceful shutdown ([#1354](https://github.com/EmbarkStudios/quilkin/pull/1354))
- Refactor documentation workflow to use mise action ([#1346](https://github.com/EmbarkStudios/quilkin/pull/1346))
- fix mdbook build, refactor, layout, remove xDS references ([#1345](https://github.com/EmbarkStudios/quilkin/pull/1345))
- set submodules true in checkout ([#1344](https://github.com/EmbarkStudios/quilkin/pull/1344))
- set absolute path ([#1343](https://github.com/EmbarkStudios/quilkin/pull/1343))

## [0.10.1](https://github.com/EmbarkStudios/quilkin/compare/quilkin-v0.10.0...quilkin-v0.10.1) - 2026-05-26

### Added

- add http provider + provider benchmarks ([#1379](https://github.com/EmbarkStudios/quilkin/pull/1379))
- Batch k8s events to prevent excessive calls to `EndpointSet::update()` ([#1370](https://github.com/EmbarkStudios/quilkin/pull/1370))
- Initial corrosion integration ([#1348](https://github.com/EmbarkStudios/quilkin/pull/1348))
- Add decryptor filter ([#1035](https://github.com/EmbarkStudios/quilkin/pull/1035))

### Fixed

- add udp session limit to prevent unbounded growth ([#1396](https://github.com/EmbarkStudios/quilkin/pull/1396))
- compose example
- rustdoc errors & warnings
- reject invalid ports ([#1372](https://github.com/EmbarkStudios/quilkin/pull/1372))
- fix issue when watching multiple k8s namespaces ([#1369](https://github.com/EmbarkStudios/quilkin/pull/1369))
- Change how latency to other nodes is measured ([#1364](https://github.com/EmbarkStudios/quilkin/pull/1364))

### Other

- *(deps)* bump openssl from 0.10.79 to 0.10.80 ([#1397](https://github.com/EmbarkStudios/quilkin/pull/1397))
- remove .* from .gitignore, set version of corrosion dependency
- Remove sub DB when streams are terminated ([#1393](https://github.com/EmbarkStudios/quilkin/pull/1393))
- try explicit latest version
- try setting workspace explicitly
- set file protocol to allow in release-plz
- *(deps)* bump openssl from 0.10.78 to 0.10.79 ([#1392](https://github.com/EmbarkStudios/quilkin/pull/1392))
- rm benches from dockerignore
- fix benches missing in dockerfile
- Foward xDS events to corrosion ([#1376](https://github.com/EmbarkStudios/quilkin/pull/1376))
- update UE5 plugin ([#1384](https://github.com/EmbarkStudios/quilkin/pull/1384))
- update changelog for 0.10.0 ([#1385](https://github.com/EmbarkStudios/quilkin/pull/1385))
- *(deps)* bump openssl from 0.10.75 to 0.10.78 ([#1382](https://github.com/EmbarkStudios/quilkin/pull/1382))
- Bind corrosion client to unspecified address ([#1381](https://github.com/EmbarkStudios/quilkin/pull/1381))
- Replace `cfg_if!` with `cfg_select!` ([#1380](https://github.com/EmbarkStudios/quilkin/pull/1380))
- try git_only in release-plz.toml
- add debug steps to release-plz.yaml
- don't checkout submodules in release-plz.yaml
- remove fetch-depth from release-plz.yaml
- remove persist-credentials in release-plz.yaml
- *(deps)* bump rustls-webpki from 0.103.8 to 0.103.10 ([#1375](https://github.com/EmbarkStudios/quilkin/pull/1375))
- Support static provider with corrosion and enable running locally ([#1373](https://github.com/EmbarkStudios/quilkin/pull/1373))
- Use Non Negative Least Squares for latency measurement ([#1367](https://github.com/EmbarkStudios/quilkin/pull/1367))
- io-uring changes ([#1361](https://github.com/EmbarkStudios/quilkin/pull/1361))
- Fix cpu profiling endpoint ([#1368](https://github.com/EmbarkStudios/quilkin/pull/1368))
- Upgrade `kube` dep to 3.x ([#1360](https://github.com/EmbarkStudios/quilkin/pull/1360))
- checkout submodules in image build ([#1366](https://github.com/EmbarkStudios/quilkin/pull/1366))
- Fix `aarch64-linux-unknown-gnu` compilation ([#1365](https://github.com/EmbarkStudios/quilkin/pull/1365))
- refactor dockerfile to use buildx actions and chef ([#1363](https://github.com/EmbarkStudios/quilkin/pull/1363))
- Update `time` crate and workaround yq issue ([#1359](https://github.com/EmbarkStudios/quilkin/pull/1359))
- Add quilkin_allocated_xdp_packets metric ([#1357](https://github.com/EmbarkStudios/quilkin/pull/1357))
- Add test_success job ([#1355](https://github.com/EmbarkStudios/quilkin/pull/1355))
- Don't stop admin server on graceful shutdown ([#1354](https://github.com/EmbarkStudios/quilkin/pull/1354))
- Refactor documentation workflow to use mise action ([#1346](https://github.com/EmbarkStudios/quilkin/pull/1346))
- fix mdbook build, refactor, layout, remove xDS references ([#1345](https://github.com/EmbarkStudios/quilkin/pull/1345))
- set submodules true in checkout ([#1344](https://github.com/EmbarkStudios/quilkin/pull/1344))
- set absolute path ([#1343](https://github.com/EmbarkStudios/quilkin/pull/1343))

## Breaking changes

**Subcommands replaced by service and provider flags.** The `proxy`, `relay`, `manage`, and `agent` subcommands have been removed. Every quilkin instance now runs the same binary and you opt in to the roles you need via `--service.*` flags:

- `--service.udp` — enable the UDP proxy
- `--service.mds` — enable the mDS relay
- `--service.xds` — enable the xDS management server
- `--service.phoenix` — enable the Phoenix network coordinate service
- `--service.qcmp` — enable QCMP

Configuration sources are controlled separately via `--provider.*` flags (e.g. `--provider.k8s.agones.*` for Agones, static config via file). Any combination of services and providers can be composed in a single instance, replacing the need for distinct deployment roles.

**Compression filter removed.** The built-in compression filter has been removed.

**CLI restructured.** Locality arguments have moved to the top level (`--locality.region`, `--locality.zone`, `--locality.sub-zone`) and admin options are now grouped under `--admin.*`.

**Metric label renames.** The `cluster` label on all metrics has been renamed to `quilkin_cluster` to avoid collisions with other systems. High-cardinality ASN labels have been removed from metrics entirely.

## New features

**XDP I/O path.** Quilkin can now use Linux eXpress Data Path (XDP) for packet processing, bypassing much of the kernel network stack. Enable with `--service.udp.xdp`. Additional flags allow pinning the NIC (`--service.udp.xdp.network-interface`), requiring zero-copy mode (`--service.udp.xdp.zerocopy`), and requiring TX checksum offload (`--service.udp.xdp.tco`). This provides a substantial throughput improvement on supported hardware.

**Corrosion backend.** A new distributed state backend powered by [Corrosion](https://github.com/superfly/corrosion) (SQLite-based) is available as an alternative to the relay/mDS topology. It can also run locally for development without any external dependencies.

**Decryptor filter.** A new `Decryptor` filter has been added for decrypting packets inline in the filter pipeline (ChaCha20).

**xDS config provider.** Configuration can now be sourced from a standard xDS management server, in addition to the existing static and Agones providers.

**TLS support.** TLS options are now available for securing control-plane connections.

**Subscriptions.** Proxies now support a subscription model for receiving incremental config updates, reducing overhead compared to full state refreshes.

**Kubernetes leader election.** When running multiple replicas, quilkin can participate in Kubernetes leader election to coordinate control-plane duties. Enable with `--provider.k8s.leader-election`; optionally override the participant identity with `--provider.k8s.leader-election.id` (defaults to `--service-id`) and the Lease resource name with `--provider.k8s.leader-election.lease-name`.

**Multi-namespace Agones support.** The Agones provider can now watch gameservers across multiple Kubernetes namespaces simultaneously using `--provider.k8s.agones.namespaces` (comma-separated). The old singular `--provider.k8s.agones.namespace` flag is deprecated.

**Origin IP via proxy headers.** When quilkin instances are chained behind a load balancer or another quilkin proxy, the upstream quilkin's real IP can now be read from `X-Forwarded-For` and similar headers rather than the intermediary's address.

**File logging.** Log output can now be directed to a file in addition to (or instead of) stdout. Set `--sys.log.dir` to the target directory and optionally `--sys.log.file-prefix` to control the filename (defaults to `quilkin.log`).

**`--service-id` parameter.** Services now accept an explicit `--service-id` flag to set a stable identity, used as the default Kubernetes leader election ID and the mDS control-plane identifier.

**Phoenix network coordinates.** Phoenix exposes a new `/coordinate` HTTP route returning the node's current network coordinates.

**Improved observability.** Many new metrics have been added:

- `phoenix_distance` — current estimated latency to each peer datacenter
- QCMP server metrics including ASN information
- Kubernetes provider event and queue depth metrics
- HTTP request metrics on the admin and phoenix endpoints
- jemalloc heap statistics exposed as Prometheus metrics
- XDP packet allocation counters
- `quilkin_cluster` label on `active_endpoints`

Continuous memory profiling via pprof is also now enabled in release builds.

**Updated Unreal Engine plugin.** The bundled UE5 plugin has been updated.

## Performance improvements

The filter pipeline is now fully synchronous, eliminating async overhead on the hot path. Additional improvements include: replacing the default hasher with `gxhash`, enabling LTO in release builds, removing async channels for buffer sends, eliminating per-packet destination address allocations, and switching to non-negative least squares (NNLS) for latency estimation in Phoenix.

## Bug fixes

- Config is now preserved locally when the control-plane connection is lost, rather than being cleared
- Shutdown now correctly waits for all active sessions to drain before exiting
- Multiple Kubernetes namespaces can be watched simultaneously without interference
- Agones gameserver watch semantics are consistent across reconnects
- MMDB provider tasks are now correctly managed and do not terminate prematurely
- Invalid port numbers are now rejected at the CLI rather than silently accepted
- Proxies now shut down on panic rather than hanging

## Security

Updated `openssl` (0.10.75 → 0.10.78) and `rustls-webpki` (0.103.8 → 0.103.10).

**Full Changelog**: https://github.com/EmbarkStudios/quilkin/compare/v0.9.0...v0.10.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).