### PR TITLE
Replace forwarded-header-value with inline code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,16 +1654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "forwarded-header-value"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
-dependencies = [
- "nonempty",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,12 +3144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-
-[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,7 +4018,6 @@ dependencies = [
  "async-stream",
  "eyre",
  "fixedstr",
- "forwarded-header-value",
  "futures",
  "h2",
  "http",

--- a/crates/xds/Cargo.toml
+++ b/crates/xds/Cargo.toml
@@ -16,7 +16,6 @@ quilkin-proto.workspace = true
 async-stream.workspace = true
 eyre.workspace = true
 fixedstr.workspace = true
-forwarded-header-value = "0.1.1"
 futures.workspace = true
 h2 = "0.4"
 once_cell.workspace = true

--- a/crates/xds/src/server.rs
+++ b/crates/xds/src/server.rs
@@ -51,12 +51,27 @@ fn get_external_remote_addr<T>(request: &tonic::Request<T>) -> Option<std::net::
     let metadata = request.metadata();
     let forwarded_for = metadata
         .get(FORWARDED)
+        .and_then(|header| header.to_str().ok())
         .and_then(|header| {
-            header.to_str().ok().and_then(|value| {
-                forwarded_header_value::ForwardedHeaderValue::from_forwarded(value).ok()
-            })
-        })
-        .and_then(|header| header.remotest().forwarded_for_ip());
+            let s = header.trim();
+
+            // The old code used the forwarded-header-value crate to do this, we simplify it here since the use case was
+            // to use the remotest (left-most) forwarded-by value, if it was an IP
+
+            let left_most = s.split(';').find_map(|part| {
+                let part = part.trim();
+                (!part.is_empty()).then_some(part)
+            })?;
+
+            if let Some((key, value)) = left_most.split_once('=')
+                && key.eq_ignore_ascii_case("by")
+                && let Ok(ip) = value.parse::<std::net::IpAddr>()
+            {
+                Some(ip)
+            } else {
+                None
+            }
+        });
 
     forwarded_for
         .or_else(|| {


### PR DESCRIPTION
This replaces the forwarded-header-value crate with simpler inline code that only does what we need. This actually removed 2 dependencies since it transitively depended on another crate unused elsewhere.