### PR TITLE
feat!: make UDP IO backend runtime configurable

### DIFF
--- a/.ci/xdp/integration-test.sh
+++ b/.ci/xdp/integration-test.sh
@@ -34,7 +34,7 @@ spec:
     ports:
     - containerPort: 7777
       hostPort: 7777
-    args: ["--service.udp", "--provider.static.endpoints=${server_ip}:8078", "--service.udp.xdp"]
+    args: ["--service.udp", "--provider.static.endpoints=${server_ip}:8078", "--service.udp.backend", "kernel"]
     securityContext:
       capabilities:
         add:

--- a/.ci/xdp/veth-integ-test.sh
+++ b/.ci/xdp/veth-integ-test.sh
@@ -49,7 +49,7 @@ echo "Adding dummy program"
 ip -n cs link set veth-cs xdpgeneric obj "$ROOT/crates/xdp/bin/dummy.bin" sec xdp
 
 ip netns exec cs fortio udp-echo&
-ip netns exec proxy ./target/debug/quilkin --service.udp --service.qcmp --provider.static.endpoints=$OUTSIDE_IP:8078 --service.udp.xdp --service.udp.xdp.network-interface veth-proxy&
+ip netns exec proxy ./target/debug/quilkin --service.udp --service.qcmp --provider.static.endpoints=$OUTSIDE_IP:8078 --service.udp.backend kernel --service.udp.xdp.network-interface veth-proxy&
 
 echo "::notice file=$source,line=$LINENO::Launching client"
 ip netns exec cs fortio load -n 10 udp://$PROXY_IP:7777 2> ./target/logs.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ Configuration sources are controlled separately via `--provider.*` flags (e.g. `
 
 ## New features
 
-**XDP I/O path.** Quilkin can now use Linux eXpress Data Path (XDP) for packet processing, bypassing much of the kernel network stack. Enable with `--service.udp.xdp`. Additional flags allow pinning the NIC (`--service.udp.xdp.network-interface`), requiring zero-copy mode (`--service.udp.xdp.zerocopy`), and requiring TX checksum offload (`--service.udp.xdp.tco`). This provides a substantial throughput improvement on supported hardware.
+**XDP I/O path.** Quilkin can now use Linux eXpress Data Path (XDP) for packet processing, bypassing much of the kernel network stack. Select with `--service.udp.backend kernel`. Additional flags allow pinning the NIC (`--service.udp.xdp.network-interface`), requiring zero-copy mode (`--service.udp.xdp.zerocopy`), and requiring TX checksum offload (`--service.udp.xdp.tco`). This provides a substantial throughput improvement on supported hardware.
 
 **Corrosion backend.** A new distributed state backend powered by [Corrosion](https://github.com/superfly/corrosion) (SQLite-based) is available as an alternative to the relay/mDS topology. It can also run locally for development without any external dependencies.
 

--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -109,7 +109,18 @@ trace_test!(uring_receiver, {
     let socket = sb.client();
     let (ws, addr) = sb.socket();
 
-    let pending_sends = net::queue(1).unwrap();
+    // XDP doesn't go through spawn_io_loop — use the best user-space backend.
+    let backend = {
+        #[cfg(target_os = "linux")]
+        {
+            quilkin::net::io::UdpBackend::probe_user_space()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            quilkin::net::io::UdpBackend::Poll
+        }
+    };
+    let pending_sends = net::queue(1, backend).unwrap();
 
     // we'll test a single DownstreamReceiveWorkerConfig
     quilkin::net::io::Listener {
@@ -120,7 +131,9 @@ trace_test!(uring_receiver, {
             vec![pending_sends.0.clone()],
             config.dyn_cfg.cached_filter_chain().unwrap(),
             usize::MAX,
+            backend,
         ),
+        backend,
     }
     .spawn_io_loop(pending_sends, config.dyn_cfg.cached_filter_chain().unwrap())
     .expect("failed to spawn task");
@@ -157,10 +170,20 @@ trace_test!(
             .unwrap()
             .modify(|clusters| clusters.insert_default([endpoint.into()].into()));
 
+        let backend = {
+            #[cfg(target_os = "linux")]
+            {
+                quilkin::net::io::UdpBackend::probe_user_space()
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                quilkin::net::io::UdpBackend::Poll
+            }
+        };
         let pending_sends: Vec<_> = [
-            net::queue(1).unwrap(),
-            net::queue(1).unwrap(),
-            net::queue(1).unwrap(),
+            net::queue(1, backend).unwrap(),
+            net::queue(1, backend).unwrap(),
+            net::queue(1, backend).unwrap(),
         ]
         .into_iter()
         .collect();
@@ -169,12 +192,13 @@ trace_test!(
             pending_sends.iter().map(|ps| ps.0.clone()).collect(),
             config.dyn_cfg.cached_filter_chain().unwrap(),
             usize::MAX,
+            backend,
         );
 
         const WORKER_COUNT: usize = 3;
 
         let (socket, addr) = sb.socket();
-        net::packet::spawn_receivers(config, socket, pending_sends, &sessions).unwrap();
+        net::packet::spawn_receivers(config, socket, pending_sends, &sessions, backend).unwrap();
 
         let socket = std::sync::Arc::new(sb.client());
         let msg = "recv-from";

--- a/src/net.rs
+++ b/src/net.rs
@@ -45,7 +45,7 @@ pub use {
         cluster::ClusterMap,
         endpoint::{Endpoint, EndpointAddress},
         error::PipelineError,
-        packet::{Packet, PacketMut, PacketQueue, PacketQueueSender, queue},
+        packet::{Packet, PacketMut, PacketQueue, PacketQueueReceiver, PacketQueueSender, queue},
         sessions::SessionPool,
     },
     quilkin_xds as xds,
@@ -215,6 +215,14 @@ impl DualStackEpollSocket {
     pub fn new(port: u16) -> IoResult<Self> {
         Ok(Self {
             socket: epoll_socket_with_reuse(port)?,
+        })
+    }
+
+    /// Construct from a raw `socket2::Socket` (converts via `std::net::UdpSocket`).
+    pub fn from_raw(socket: socket2::Socket) -> IoResult<Self> {
+        let std_sock: std::net::UdpSocket = socket.into();
+        Ok(Self {
+            socket: tokio::net::UdpSocket::from_std(std_sock)?,
         })
     }
 

--- a/src/net/io.rs
+++ b/src/net/io.rs
@@ -37,8 +37,71 @@ use crate::Config;
 #[cfg(target_os = "linux")]
 pub mod completion;
 pub mod nic;
-#[cfg(not(target_os = "linux"))]
 pub mod poll;
+
+/// Runtime-selected UDP I/O backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum UdpBackend {
+    /// Auto-select: kernel (XDP) -> completion (io-uring) -> poll (epoll).
+    #[default]
+    Auto,
+    /// Tokio epoll — available on all platforms.
+    Poll,
+    /// io-uring completion I/O (Linux only).
+    #[cfg(target_os = "linux")]
+    Completion,
+    /// XDP kernel-bypass (Linux only).
+    #[cfg(target_os = "linux")]
+    Kernel,
+}
+
+impl UdpBackend {
+    /// Resolve `Auto` to the best concrete backend. Never returns `Auto`.
+    pub fn resolve(self) -> Self {
+        match self {
+            Self::Auto => Self::probe(),
+            other => other,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn probe() -> Self {
+        if nic::xdp::is_available() {
+            Self::Kernel
+        } else {
+            Self::probe_user_space()
+        }
+    }
+
+    /// Probe for the best user-space backend (io-uring or epoll), skipping XDP.
+    ///
+    /// Use this when a socket-based listener is required regardless of XDP availability.
+    #[cfg(target_os = "linux")]
+    pub fn probe_user_space() -> Self {
+        if io_uring::IoUring::new(2).is_ok() {
+            Self::Completion
+        } else {
+            Self::Poll
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn probe() -> Self {
+        Self::Poll
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Poll => "poll",
+            #[cfg(target_os = "linux")]
+            Self::Completion => "completion",
+            #[cfg(target_os = "linux")]
+            Self::Kernel => "kernel",
+        }
+    }
+}
 
 /// Represents the required arguments to run a worker task that
 /// processes packets received downstream.
@@ -48,4 +111,24 @@ pub struct Listener {
     pub port: u16,
     pub config: Arc<Config>,
     pub sessions: Arc<crate::net::sessions::SessionPool>,
+    pub backend: UdpBackend,
+}
+
+impl Listener {
+    pub fn spawn_io_loop(
+        self,
+        queue: crate::net::PacketQueue,
+        fc: crate::config::filter::CachedFilterChain,
+    ) -> eyre::Result<()> {
+        match self.backend {
+            UdpBackend::Poll => poll::tokio::spawn_listener(self, queue, fc),
+            #[cfg(target_os = "linux")]
+            UdpBackend::Completion => completion::io_uring::spawn_listener(self, queue, fc),
+            #[cfg(target_os = "linux")]
+            UdpBackend::Kernel => {
+                unreachable!("XDP runs via spawn_xdp and never reaches the queue-based listener")
+            }
+            UdpBackend::Auto => unreachable!("UdpBackend must be resolved before spawning"),
+        }
+    }
 }

--- a/src/net/io/completion/io_uring.rs
+++ b/src/net/io/completion/io_uring.rs
@@ -31,43 +31,59 @@ use io_uring::{squeue::Entry, types::Fd};
 use crate::{
     config::filter::CachedFilterChain,
     metrics,
-    net::{PacketQueue, error::PipelineError, packet::queue::SendPacket, sessions::SessionPool},
+    net::{error::PipelineError, packet::queue::SendPacket, sessions::SessionPool},
     time::UtcTimestamp,
 };
 
+/// The internal queue type used by the io-uring backend.
+///
+/// Unlike the general `PacketQueue`, this tuple always contains an `EventFd`
+/// as the receiver, which is what the io-uring loop requires.
+type IoUringQueue = (crate::net::PacketQueueSender, EventFd);
+
 static SESSION_COUNTER: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 
-impl crate::net::io::Listener {
-    pub fn spawn_io_loop(
-        self,
-        pending_sends: crate::net::PacketQueue,
-        filter_chain: CachedFilterChain,
-    ) -> eyre::Result<()> {
-        let Self {
-            worker_id,
-            port,
-            config,
-            sessions,
-        } = self;
+/// Spawn an io-uring listener worker for the given `Listener`.
+///
+/// `pending_sends` must be a `PacketQueueReceiver::EventFd` queue; if it is
+/// a Watch queue this returns an error.
+pub fn spawn_listener(
+    listener: crate::net::io::Listener,
+    pending_sends: crate::net::PacketQueue,
+    filter_chain: CachedFilterChain,
+) -> eyre::Result<()> {
+    let crate::net::io::Listener {
+        worker_id,
+        port,
+        config,
+        sessions,
+        ..
+    } = listener;
 
-        let socket =
-            crate::net::DualStackLocalSocket::new(port).context("failed to bind socket")?;
+    let (pqs, pqr) = pending_sends;
+    let event_fd = match pqr {
+        crate::net::PacketQueueReceiver::EventFd(efd) => efd,
+        crate::net::PacketQueueReceiver::Watch(_) => {
+            eyre::bail!("completion backend requires an EventFd packet queue receiver")
+        }
+    };
 
-        let io_loop = IoUringLoop::new(512, socket)?;
-        io_loop
-            .spawn_io_loop(
-                format!("packet-router-{worker_id}"),
-                PacketProcessorCtx::Router {
-                    config,
-                    sessions,
-                    worker_id,
-                    destinations: Vec::with_capacity(1),
-                },
-                pending_sends,
-                filter_chain,
-            )
-            .context("failed to spawn io-uring loop")
-    }
+    let socket = crate::net::DualStackLocalSocket::new(port).context("failed to bind socket")?;
+
+    let io_loop = IoUringLoop::new(512, socket)?;
+    io_loop
+        .spawn_io_loop(
+            format!("packet-router-{worker_id}"),
+            PacketProcessorCtx::Router {
+                config,
+                sessions,
+                worker_id,
+                destinations: Vec::with_capacity(1),
+            },
+            (pqs, event_fd),
+            filter_chain,
+        )
+        .context("failed to spawn io-uring loop")
 }
 
 /// A simple wrapper around [eventfd](https://man7.org/linux/man-pages/man2/eventfd.2.html)
@@ -81,7 +97,7 @@ pub struct EventFd {
 
 impl EventFd {
     #[inline]
-    pub(crate) fn new() -> std::io::Result<Self> {
+    pub fn new() -> std::io::Result<Self> {
         // SAFETY: We have no invariants to uphold, but we do need to check the
         // return value
         let fd = unsafe { libc::eventfd(0, 0) };
@@ -101,7 +117,7 @@ impl EventFd {
     }
 
     #[inline]
-    pub(crate) fn writer(&self) -> EventFdWriter {
+    pub fn writer(&self) -> EventFdWriter {
         EventFdWriter {
             fd: self.fd.as_raw_fd(),
         }
@@ -109,7 +125,7 @@ impl EventFd {
 
     /// Constructs an io-uring entry to read (ie wait) on this eventfd
     #[inline]
-    pub(crate) fn io_uring_entry(&mut self) -> Entry {
+    pub fn io_uring_entry(&mut self) -> Entry {
         io_uring::opcode::Read::new(
             Fd(self.fd.as_raw_fd()),
             (&mut self.val as *mut u64).cast(),
@@ -120,13 +136,13 @@ impl EventFd {
 }
 
 #[derive(Clone)]
-pub(crate) struct EventFdWriter {
+pub struct EventFdWriter {
     fd: i32,
 }
 
 impl EventFdWriter {
     #[inline]
-    pub(crate) fn write(&self, val: u64) {
+    pub fn write(&self, val: u64) {
         // SAFETY: we have a valid descriptor, and most of the errors that apply
         // to the general write call that eventfd_write wraps are not applicable
         //
@@ -456,7 +472,7 @@ impl IoUringLoop {
         self,
         thread_name: String,
         mut ctx: PacketProcessorCtx,
-        pending_sends: PacketQueue,
+        pending_sends: IoUringQueue,
         mut filter_chain: CachedFilterChain,
     ) -> Result<(), PipelineError> {
         let dispatcher = tracing::dispatcher::get_default(|d| d.clone());
@@ -642,27 +658,38 @@ impl IoUringLoop {
     }
 }
 
-impl SessionPool {
-    pub(crate) fn spawn_session(
-        self: Arc<Self>,
-        raw_socket: socket2::Socket,
-        port: u16,
-        pending_sends: crate::net::PacketQueue,
-        filter_chain: CachedFilterChain,
-    ) -> Result<(), PipelineError> {
-        let pool = self;
-        let id = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let _thread_span = uring_span!(tracing::debug_span!("session", id).or_current());
+/// Spawn an io-uring session for the given socket.
+///
+/// `pending_sends` must contain a `PacketQueueReceiver::EventFd` variant; if
+/// it is a Watch queue this returns an error.
+pub fn spawn_session(
+    pool: Arc<SessionPool>,
+    raw_socket: socket2::Socket,
+    port: u16,
+    pending_sends: crate::net::PacketQueue,
+    filter_chain: CachedFilterChain,
+) -> Result<(), PipelineError> {
+    let id = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _thread_span = uring_span!(tracing::debug_span!("session", id).or_current());
 
-        let io_loop = IoUringLoop::new(64, crate::net::DualStackLocalSocket::from_raw(raw_socket))?;
+    let (pqs, pqr) = pending_sends;
+    let event_fd = match pqr {
+        crate::net::PacketQueueReceiver::EventFd(efd) => efd,
+        crate::net::PacketQueueReceiver::Watch(_) => {
+            return Err(PipelineError::Session(
+                crate::net::sessions::SessionError::SocketAddressUnavailable,
+            ));
+        }
+    };
 
-        io_loop.spawn_io_loop(
-            format!("session-{id}"),
-            PacketProcessorCtx::SessionPool { pool, port },
-            pending_sends,
-            filter_chain,
-        )
-    }
+    let io_loop = IoUringLoop::new(64, crate::net::DualStackLocalSocket::from_raw(raw_socket))?;
+
+    io_loop.spawn_io_loop(
+        format!("session-{id}"),
+        PacketProcessorCtx::SessionPool { pool, port },
+        (pqs, event_fd),
+        filter_chain,
+    )
 }
 
 #[cfg(test)]

--- a/src/net/io/nic/xdp.rs
+++ b/src/net/io/nic/xdp.rs
@@ -125,6 +125,27 @@ pub enum XdpSpawnError {
 /// based on user configuration, failing if requirements cannot be met
 ///
 /// This function currently only supports one mode of operation, which is that
+/// Returns `true` if a unique default NIC suitable for XDP is present.
+///
+/// This mirrors the `NicConfig::Default` selection in [`setup_xdp_io`] but
+/// stops before allocating sockets or loading the eBPF program.
+pub fn is_available() -> bool {
+    let Ok(iter) = xdp::nic::InterfaceIter::new() else {
+        return false;
+    };
+    let mut chosen = None;
+    for iface in iter {
+        if let Some(c) = chosen {
+            if iface != c {
+                return false;
+            }
+        } else {
+            chosen = Some(iface);
+        }
+    }
+    chosen.is_some()
+}
+
 /// a socket is bound to every available queue on the NIC, and when [`spawn`]
 /// is invoked, each socket is processed in its own thread
 ///

--- a/src/net/io/poll/tokio.rs
+++ b/src/net/io/poll/tokio.rs
@@ -14,7 +14,7 @@
  *  limitations under the License.
  */
 
-//! The reference implementation is used for non-Linux targets
+//! Tokio epoll-based UDP I/O backend — available on all platforms.
 
 /// On linux spawns a io-uring runtime + thread, everywhere else spawns a regular tokio task.
 macro_rules! uring_spawn {
@@ -44,36 +44,251 @@ macro_rules! uring_inner_spawn {
     };
 }
 
-impl crate::net::io::Listener {
-    pub fn spawn_io_loop(
-        self,
-        packet_queue: crate::net::PacketQueue,
-        mut fc: crate::config::filter::CachedFilterChain,
-    ) -> eyre::Result<()> {
-        let Self {
-            worker_id,
-            port,
-            config,
-            sessions,
-        } = self;
+// On Linux, DualStackEpollSocket wraps a tokio::net::UdpSocket for async I/O.
+// On non-Linux, DualStackLocalSocket already wraps a tokio socket.
+cfg_select! {
+    target_os = "linux" => {
+        type PollSocket = crate::net::DualStackEpollSocket;
+        type PollSocketRc = std::sync::Arc<PollSocket>;
 
-        let thread_span =
-            uring_span!(tracing::debug_span!("receiver", id = worker_id).or_current());
-        let (tx, mut rx) = tokio::sync::oneshot::channel();
+        fn new_poll_socket(port: u16) -> std::io::Result<PollSocketRc> {
+            PollSocket::new(port).map(std::sync::Arc::new)
+        }
 
-        let worker = uring_spawn!(thread_span, async move {
-            crate::metrics::game_traffic_tasks().inc();
+        fn poll_socket_from_raw(socket: socket2::Socket) -> std::io::Result<PollSocketRc> {
+            PollSocket::from_raw(socket).map(std::sync::Arc::new)
+        }
+
+        async fn ps_recv_from(
+            socket: &PollSocket,
+            mut buf: bytes::BytesMut,
+        ) -> (std::io::Result<(usize, std::net::SocketAddr)>, bytes::BytesMut) {
+            let result = socket.recv_from(&mut buf).await;
+            (result, buf)
+        }
+
+        async fn ps_send_to(
+            socket: &PollSocket,
+            data: bytes::Bytes,
+            dest: std::net::SocketAddr,
+        ) -> (std::io::Result<usize>, bytes::Bytes) {
+            let result = socket.send_to(&data, dest).await;
+            (result, data)
+        }
+    }
+    _ => {
+        type PollSocket = crate::net::DualStackLocalSocket;
+        type PollSocketRc = crate::net::DualStackLocalSocketRc;
+
+        fn new_poll_socket(port: u16) -> std::io::Result<PollSocketRc> {
+            PollSocket::new(port).map(|s| s.make_refcnt())
+        }
+
+        fn poll_socket_from_raw(socket: socket2::Socket) -> std::io::Result<PollSocketRc> {
+            Ok(std::sync::Arc::new(PollSocket::from_raw(socket)))
+        }
+
+        async fn ps_recv_from(
+            socket: &PollSocket,
+            buf: bytes::BytesMut,
+        ) -> (std::io::Result<(usize, std::net::SocketAddr)>, bytes::BytesMut) {
+            socket.recv_from(buf).await
+        }
+
+        async fn ps_send_to(
+            socket: &PollSocket,
+            data: bytes::Bytes,
+            dest: std::net::SocketAddr,
+        ) -> (std::io::Result<usize>, bytes::Bytes) {
+            socket.send_to(data, dest).await
+        }
+    }
+}
+
+/// Extract the watch receiver from a `PacketQueueReceiver`.
+fn extract_watch_receiver(
+    pqr: crate::net::PacketQueueReceiver,
+) -> eyre::Result<tokio::sync::watch::Receiver<bool>> {
+    cfg_select! {
+        target_os = "linux" => {
+            match pqr {
+                crate::net::PacketQueueReceiver::Watch(rx) => Ok(rx),
+                crate::net::PacketQueueReceiver::EventFd(_) => eyre::bail!("poll backend requires a Watch packet queue receiver"),
+            }
+        }
+        _ => {
+            Ok(pqr)
+        }
+    }
+}
+
+pub fn spawn_listener(
+    listener: crate::net::io::Listener,
+    packet_queue: crate::net::PacketQueue,
+    fc: crate::config::filter::CachedFilterChain,
+) -> eyre::Result<()> {
+    spawn_poll_listener_impl(listener, packet_queue, fc)
+}
+
+fn spawn_poll_listener_impl(
+    listener: crate::net::io::Listener,
+    packet_queue: crate::net::PacketQueue,
+    mut fc: crate::config::filter::CachedFilterChain,
+) -> eyre::Result<()> {
+    let crate::net::io::Listener {
+        worker_id,
+        port,
+        config,
+        sessions,
+        ..
+    } = listener;
+
+    let thread_span = uring_span!(tracing::debug_span!("receiver", id = worker_id).or_current());
+    let (tx, mut rx) = tokio::sync::oneshot::channel();
+
+    let (pqs, pqr) = packet_queue;
+    let mut sends_rx = extract_watch_receiver(pqr)?;
+
+    let worker = uring_spawn!(thread_span, async move {
+        crate::metrics::game_traffic_tasks().inc();
+        let mut last_received_at = None;
+        let socket = new_poll_socket(port).unwrap();
+
+        tracing::trace!(port, "bound worker");
+        let send_socket = socket.clone();
+
+        let inner_task = async move {
+            let mut sends_double_buffer = Vec::with_capacity(pqs.capacity());
+
+            while sends_rx.changed().await.is_ok() {
+                if !*sends_rx.borrow() {
+                    tracing::trace!("io loop shutdown requested");
+                    break;
+                }
+
+                sends_double_buffer = pqs.swap(sends_double_buffer);
+
+                for packet in sends_double_buffer.drain(..sends_double_buffer.len()) {
+                    let destination = packet.destination;
+                    let (result, _) = ps_send_to(&send_socket, packet.data, destination).await;
+                    let asn_info = packet.asn_info.as_ref().into();
+                    match result {
+                        Ok(size) => {
+                            crate::metrics::packets_total(crate::metrics::WRITE, &asn_info).inc();
+                            crate::metrics::bytes_total(crate::metrics::WRITE, &asn_info)
+                                .inc_by(size as u64);
+                        }
+                        Err(error) => {
+                            let source = error.to_string();
+                            crate::metrics::errors_total(crate::metrics::WRITE, &source, &asn_info)
+                                .inc();
+                            crate::metrics::packets_dropped_total(
+                                crate::metrics::WRITE,
+                                &source,
+                                &asn_info,
+                            )
+                            .inc();
+                        }
+                    }
+                }
+            }
+
+            let _ = tx.send(());
+        };
+
+        cfg_select! {
+            debug_assertions => {
+                uring_inner_spawn!(inner_task.instrument(tracing::debug_span!("upstream").or_current()));
+            }
+            _ => {
+                uring_inner_spawn!(inner_task);
+            }
+        }
+
+        let mut destinations = Vec::with_capacity(1);
+
+        loop {
+            let buffer = bytes::BytesMut::zeroed(2048);
+
+            tokio::select! {
+                received = ps_recv_from(&socket, buffer) => {
+                    let received_at = crate::time::UtcTimestamp::now();
+                    let (result, buffer) = received;
+
+                    match result {
+                        Ok((_size, mut source)) => {
+                            source.set_ip(source.ip().to_canonical());
+                            let filters = fc.load();
+                            let packet = crate::net::packet::DownstreamPacket { contents: buffer, source, filters };
+
+                            if let Some(last_received_at) = last_received_at {
+                                crate::metrics::packet_jitter(
+                                    crate::metrics::READ,
+                                    &crate::metrics::EMPTY,
+                                )
+                                .set((received_at - last_received_at).nanos());
+                            }
+                            last_received_at = Some(received_at);
+
+                            packet.process(
+                                worker_id,
+                                &config,
+                                &sessions,
+                                &mut destinations,
+                            );
+                        }
+                        Err(error) => {
+                            tracing::error!(%error, "error receiving packet");
+                            return;
+                        }
+                    }
+                }
+                _ = &mut rx => {
+                    crate::metrics::game_traffic_task_closed().inc();
+                    tracing::debug!("Closing downstream socket loop, shutdown requested");
+                    return;
+                }
+            }
+        }
+    });
+
+    use eyre::WrapErr as _;
+    worker.recv().context("failed to spawn receiver task")?;
+    Ok(())
+}
+
+pub fn spawn_session(
+    pool: std::sync::Arc<crate::net::sessions::SessionPool>,
+    raw_socket: socket2::Socket,
+    port: u16,
+    pending_sends: crate::net::PacketQueue,
+    mut filters: crate::config::filter::CachedFilterChain,
+) -> Result<(), crate::net::error::PipelineError> {
+    let (pqs, pqr) = pending_sends;
+    let mut sends_rx = match extract_watch_receiver(pqr) {
+        Ok(rx) => rx,
+        Err(_) => {
+            return Err(crate::net::error::PipelineError::Session(
+                crate::net::sessions::SessionError::SocketAddressUnavailable,
+            ));
+        }
+    };
+
+    let socket = match poll_socket_from_raw(raw_socket) {
+        Ok(s) => s,
+        Err(e) => return Err(e.into()),
+    };
+
+    uring_spawn!(
+        uring_span!(tracing::debug_span!("session pool")),
+        async move {
             let mut last_received_at = None;
-            let socket = crate::net::DualStackLocalSocket::new(port)
-                .unwrap()
-                .make_refcnt();
 
-            tracing::trace!(port, "bound worker");
-            let send_socket = socket.clone();
+            let socket2 = socket.clone();
+            let (tx, mut rx) = tokio::sync::oneshot::channel();
 
-            let inner_task = async move {
-                let (packet_queue, mut sends_rx) = packet_queue;
-                let mut sends_double_buffer = Vec::with_capacity(packet_queue.capacity());
+            uring_inner_spawn!(async move {
+                let mut sends_double_buffer = Vec::with_capacity(pqs.capacity());
 
                 while sends_rx.changed().await.is_ok() {
                     if !*sends_rx.borrow() {
@@ -81,29 +296,35 @@ impl crate::net::io::Listener {
                         break;
                     }
 
-                    sends_double_buffer = packet_queue.swap(sends_double_buffer);
+                    sends_double_buffer = pqs.swap(sends_double_buffer);
 
                     for packet in sends_double_buffer.drain(..sends_double_buffer.len()) {
-                        let (result, _) =
-                            send_socket.send_to(packet.data, packet.destination).await;
+                        let destination = packet.destination;
+                        tracing::trace!(
+                            %destination,
+                            length = packet.data.len(),
+                            "sending packet upstream"
+                        );
+                        let (result, _) = ps_send_to(&socket2, packet.data, destination).await;
                         let asn_info = packet.asn_info.as_ref().into();
                         match result {
                             Ok(size) => {
-                                crate::metrics::packets_total(crate::metrics::WRITE, &asn_info)
+                                crate::metrics::packets_total(crate::metrics::READ, &asn_info)
                                     .inc();
-                                crate::metrics::bytes_total(crate::metrics::WRITE, &asn_info)
+                                crate::metrics::bytes_total(crate::metrics::READ, &asn_info)
                                     .inc_by(size as u64);
                             }
                             Err(error) => {
+                                tracing::trace!(%error, "sending packet upstream failed");
                                 let source = error.to_string();
                                 crate::metrics::errors_total(
-                                    crate::metrics::WRITE,
+                                    crate::metrics::READ,
                                     &source,
                                     &asn_info,
                                 )
                                 .inc();
                                 crate::metrics::packets_dropped_total(
-                                    crate::metrics::WRITE,
+                                    crate::metrics::READ,
                                     &source,
                                     &asn_info,
                                 )
@@ -114,166 +335,32 @@ impl crate::net::io::Listener {
                 }
 
                 let _ = tx.send(());
-            };
-
-            cfg_select! {
-                debug_assertions => {
-                    uring_inner_spawn!(inner_task.instrument(tracing::debug_span!("upstream").or_current()));
-                }
-                _ => {
-                    uring_inner_spawn!(inner_task);
-                }
-            }
-
-            let mut destinations = Vec::with_capacity(1);
+            });
 
             loop {
-                let buffer = bytes::BytesMut::zeroed(2048);
-
+                let buf = bytes::BytesMut::zeroed(2048);
                 tokio::select! {
-                    received = socket.recv_from(buffer) => {
-                        let received_at = crate::time::UtcTimestamp::now();
-                        let (result, buffer) = received;
-
+                    received = ps_recv_from(&socket, buf) => {
+                        let (result, buf) = received;
                         match result {
-                            Ok((_size, mut source)) => {
-                                source.set_ip(source.ip().to_canonical());
-                                let filters = fc.load();
-                                let packet = crate::net::packet::DownstreamPacket { contents: buffer, source, filters };
-
-                                if let Some(last_received_at) = last_received_at {
-                                    crate::metrics::packet_jitter(
-                                        crate::metrics::READ,
-                                        &crate::metrics::EMPTY,
-                                    )
-                                    .set((received_at - last_received_at).nanos());
-                                }
-                                last_received_at = Some(received_at);
-
-                                packet.process(
-                                    worker_id,
-                                    &config,
-                                    &sessions,
-                                    &mut destinations,
-                                );
-                            }
                             Err(error) => {
-                                tracing::error!(%error, "error receiving packet");
-                                return;
-                            }
+                                tracing::trace!(%error, "error receiving packet");
+                                crate::metrics::errors_total(crate::metrics::WRITE, &error.to_string(), &crate::metrics::EMPTY).inc();
+                            },
+                            Ok((_size, recv_addr)) => {
+                                let filters = filters.load();
+                                pool.process_received_upstream_packet(buf, recv_addr, port, &mut last_received_at, filters);
+                            },
                         }
                     }
                     _ = &mut rx => {
-                        crate::metrics::game_traffic_task_closed().inc();
-                        tracing::debug!("Closing downstream socket loop, shutdown requested");
+                        tracing::debug!("Closing upstream socket loop, downstream closed");
                         return;
                     }
                 }
             }
-        });
+        }
+    );
 
-        use eyre::WrapErr as _;
-        worker.recv().context("failed to spawn receiver task")?;
-        Ok(())
-    }
-}
-
-impl crate::net::sessions::SessionPool {
-    pub fn spawn_session(
-        self: std::sync::Arc<Self>,
-        raw_socket: socket2::Socket,
-        port: u16,
-        pending_sends: crate::net::PacketQueue,
-        mut filters: crate::config::filter::CachedFilterChain,
-    ) -> Result<(), crate::net::error::PipelineError> {
-        let pool = self;
-
-        uring_spawn!(
-            uring_span!(tracing::debug_span!("session pool")),
-            async move {
-                let mut last_received_at = None;
-
-                let socket =
-                    std::sync::Arc::new(crate::net::DualStackLocalSocket::from_raw(raw_socket));
-                let socket2 = socket.clone();
-                let (tx, mut rx) = tokio::sync::oneshot::channel();
-
-                uring_inner_spawn!(async move {
-                    let (pending_sends, mut sends_rx) = pending_sends;
-                    let mut sends_double_buffer = Vec::with_capacity(pending_sends.capacity());
-
-                    while sends_rx.changed().await.is_ok() {
-                        if !*sends_rx.borrow() {
-                            tracing::trace!("io loop shutdown requested");
-                            break;
-                        }
-
-                        sends_double_buffer = pending_sends.swap(sends_double_buffer);
-
-                        for packet in sends_double_buffer.drain(..sends_double_buffer.len()) {
-                            let destination = packet.destination;
-                            tracing::trace!(
-                                %destination,
-                                length = packet.data.len(),
-                                "sending packet upstream"
-                            );
-                            let (result, _) = socket2.send_to(packet.data, destination).await;
-                            let asn_info = packet.asn_info.as_ref().into();
-                            match result {
-                                Ok(size) => {
-                                    crate::metrics::packets_total(crate::metrics::READ, &asn_info)
-                                        .inc();
-                                    crate::metrics::bytes_total(crate::metrics::READ, &asn_info)
-                                        .inc_by(size as u64);
-                                }
-                                Err(error) => {
-                                    tracing::trace!(%error, "sending packet upstream failed");
-                                    let source = error.to_string();
-                                    crate::metrics::errors_total(
-                                        crate::metrics::READ,
-                                        &source,
-                                        &asn_info,
-                                    )
-                                    .inc();
-                                    crate::metrics::packets_dropped_total(
-                                        crate::metrics::READ,
-                                        &source,
-                                        &asn_info,
-                                    )
-                                    .inc();
-                                }
-                            }
-                        }
-                    }
-
-                    let _ = tx.send(());
-                });
-
-                loop {
-                    let buf = bytes::BytesMut::zeroed(2048);
-                    tokio::select! {
-                        received = socket.recv_from(buf) => {
-                            let (result, buf) = received;
-                            match result {
-                                Err(error) => {
-                                    tracing::trace!(%error, "error receiving packet");
-                                    crate::metrics::errors_total(crate::metrics::WRITE, &error.to_string(), &crate::metrics::EMPTY).inc();
-                                },
-                                Ok((_size, recv_addr)) => {
-                                    let filters = filters.load();
-                                    pool.process_received_upstream_packet(buf, recv_addr, port, &mut last_received_at, filters);
-                                },
-                            }
-                        }
-                        _ = &mut rx => {
-                            tracing::debug!("Closing upstream socket loop, downstream closed");
-                            return;
-                        }
-                    }
-                }
-            }
-        );
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 use std::{net::SocketAddr, sync::Arc};
 
-pub use self::queue::{PacketQueue, PacketQueueSender, queue};
+pub use self::queue::{PacketQueue, PacketQueueReceiver, PacketQueueSender, queue};
 
 /// Representation of an immutable set of bytes pulled from the network, this trait
 /// provides an abstraction over however the packet was received (epoll, io-uring, xdp)
@@ -220,6 +220,7 @@ pub fn spawn_receivers(
     socket: socket2::Socket,
     worker_sends: Vec<crate::net::PacketQueue>,
     sessions: &Arc<SessionPool>,
+    backend: crate::net::io::UdpBackend,
 ) -> crate::Result<()> {
     let port = crate::net::socket_port(&socket);
 
@@ -233,6 +234,7 @@ pub fn spawn_receivers(
             port,
             config: config.clone(),
             sessions: sessions.clone(),
+            backend,
         };
 
         worker.spawn_io_loop(ws, pfc.clone())?;
@@ -272,7 +274,12 @@ mod tests {
         let config = Arc::new(config);
 
         let cached_filter_chain = config.dyn_cfg.cached_filter_chain().unwrap();
-        let session_manager = SessionPool::new(vec![], cached_filter_chain, usize::MAX);
+        let session_manager = SessionPool::new(
+            vec![],
+            cached_filter_chain,
+            usize::MAX,
+            crate::net::io::UdpBackend::default(),
+        );
 
         let filter_chain = crate::filters::FilterChain::default();
         let packet_data: [u8; 4] = [1, 2, 3, 4];

--- a/src/net/packet/queue.rs
+++ b/src/net/packet/queue.rs
@@ -2,16 +2,66 @@ use std::sync::Arc;
 
 pub type PacketQueue = (PacketQueueSender, PacketQueueReceiver);
 
-pub fn queue(capacity: usize) -> std::io::Result<PacketQueue> {
-    let (notify, rx) = packet_queue()?;
+pub fn queue(capacity: usize, backend: crate::net::io::UdpBackend) -> std::io::Result<PacketQueue> {
+    cfg_select! {
+        target_os = "linux" => {
+            if matches!(backend, crate::net::io::UdpBackend::Completion) {
+                let efd = crate::net::io::completion::io_uring::EventFd::new()?;
+                return Ok((
+                    PacketQueueSender {
+                        packets: Arc::new(parking_lot::Mutex::new(Vec::with_capacity(capacity))),
+                        notify: Notify::EventFd(efd.writer()),
+                    },
+                    PacketQueueReceiver::EventFd(efd),
+                ));
+            }
+            make_watch_queue(capacity)
+        }
+        _ => {
+            let _ = backend;
+            make_watch_queue(capacity)
+        }
+    }
+}
 
+fn make_watch_queue(capacity: usize) -> std::io::Result<PacketQueue> {
+    let (tx, rx) = tokio::sync::watch::channel(true);
     Ok((
         PacketQueueSender {
             packets: Arc::new(parking_lot::Mutex::new(Vec::with_capacity(capacity))),
-            notify,
+            notify: {
+                cfg_select! {
+                    target_os = "linux" => { Notify::Watch(tx) }
+                    _ => { tx }
+                }
+            },
         },
-        rx,
+        {
+            cfg_select! {
+                target_os = "linux" => { PacketQueueReceiver::Watch(rx) }
+                _ => { rx }
+            }
+        },
     ))
+}
+
+cfg_select! {
+    target_os = "linux" => {
+        enum Notify {
+            EventFd(crate::net::io::completion::io_uring::EventFdWriter),
+            Watch(tokio::sync::watch::Sender<bool>),
+        }
+
+        pub enum PacketQueueReceiver {
+            EventFd(crate::net::io::completion::io_uring::EventFd),
+            Watch(tokio::sync::watch::Receiver<bool>),
+        }
+    }
+    _ => {
+        type Notify = tokio::sync::watch::Sender<bool>;
+
+        pub type PacketQueueReceiver = tokio::sync::watch::Receiver<bool>;
+    }
 }
 
 /// A simple packet queue that signals when a packet is pushed
@@ -21,7 +71,7 @@ pub fn queue(capacity: usize) -> std::io::Result<PacketQueue> {
 #[derive(Clone)]
 pub struct PacketQueueSender {
     packets: Arc<parking_lot::Mutex<Vec<SendPacket>>>,
-    notify: PacketQueueNotifier,
+    notify: Notify,
 }
 
 impl PacketQueueSender {
@@ -35,7 +85,17 @@ impl PacketQueueSender {
     #[inline]
     pub fn push(&self, packet: SendPacket) {
         self.packets.lock().push(packet);
-        push(&self.notify);
+        cfg_select! {
+            target_os = "linux" => {
+                match &self.notify {
+                    Notify::EventFd(efd) => efd.write(1),
+                    Notify::Watch(tx) => { let _ = tx.send(true); }
+                }
+            }
+            _ => {
+                let _ = self.notify.send(true);
+            }
+        }
     }
 
     /// Swaps the current queue with an empty one so we only lock for a pointer swap
@@ -46,6 +106,20 @@ impl PacketQueueSender {
     }
 }
 
+cfg_select! {
+    target_os = "linux" => {
+        impl Clone for Notify {
+            fn clone(&self) -> Self {
+                match self {
+                    Self::EventFd(w) => Self::EventFd(w.clone()),
+                    Self::Watch(tx) => Self::Watch(tx.clone()),
+                }
+            }
+        }
+    }
+    _ => {}
+}
+
 pub struct SendPacket {
     /// The destination address of the packet
     pub destination: std::net::SocketAddr,
@@ -53,34 +127,4 @@ pub struct SendPacket {
     pub data: bytes::Bytes,
     /// The asn info for the sender, used for metrics
     pub asn_info: Option<crate::net::maxmind_db::MetricsIpNetEntry>,
-}
-
-cfg_select! {
-    target_os = "linux" => {
-        pub type PacketQueueReceiver = crate::net::io::completion::io_uring::EventFd;
-        type PacketQueueNotifier = crate::net::io::completion::io_uring::EventFdWriter;
-
-        fn packet_queue() -> std::io::Result<(PacketQueueNotifier, PacketQueueReceiver)> {
-            let rx = crate::net::io::completion::io_uring::EventFd::new()?;
-            Ok((rx.writer(), rx))
-        }
-
-        #[inline]
-        fn push(notify: &PacketQueueNotifier) {
-            notify.write(1);
-        }
-    }
-    _ => {
-        pub type PacketQueueReceiver = tokio::sync::watch::Receiver<bool>;
-        type PacketQueueNotifier = tokio::sync::watch::Sender<bool>;
-
-        fn packet_queue() -> std::io::Result<(PacketQueueNotifier, PacketQueueReceiver)> {
-            Ok(tokio::sync::watch::channel(true))
-        }
-
-        #[inline]
-        fn push(notify: &PacketQueueNotifier) {
-            let _ = notify.send(true);
-        }
-    }
 }

--- a/src/net/sessions.rs
+++ b/src/net/sessions.rs
@@ -95,6 +95,7 @@ pub struct SessionPool {
     downstream_index: atomic::AtomicUsize,
     cached_filter_chain: CachedFilterChain,
     max_sessions: usize,
+    backend: crate::net::io::UdpBackend,
 }
 
 /// The wrapper struct responsible for holding all of the socket related mappings.
@@ -114,6 +115,7 @@ impl SessionPool {
         downstream_sends: Vec<PacketQueueSender>,
         cached_filter_chain: CachedFilterChain,
         max_sessions: usize,
+        backend: crate::net::io::UdpBackend,
     ) -> Arc<Self> {
         const SESSION_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
         const SESSION_EXPIRY_POLL_INTERVAL: Duration = Duration::from_secs(60);
@@ -126,6 +128,7 @@ impl SessionPool {
             downstream_index: atomic::AtomicUsize::new(0),
             cached_filter_chain,
             max_sessions,
+            backend,
         })
     }
 
@@ -142,7 +145,7 @@ impl SessionPool {
             .ok_or(SessionError::SocketAddressUnavailable)?
             .port();
 
-        let (pending_sends, srecv) = crate::net::queue(15)?;
+        let (pending_sends, srecv) = crate::net::queue(15, self.backend)?;
         self.clone().spawn_session(
             raw_socket,
             port,
@@ -393,6 +396,35 @@ impl SessionPool {
         Ok(sender)
     }
 
+    /// Spawns a session I/O loop for the given socket, dispatching to the
+    /// correct backend based on the pool's configured backend.
+    pub(crate) fn spawn_session(
+        self: Arc<Self>,
+        raw_socket: socket2::Socket,
+        port: u16,
+        pending_sends: crate::net::PacketQueue,
+        filters: crate::config::filter::CachedFilterChain,
+    ) -> Result<(), super::PipelineError> {
+        use crate::net::io::UdpBackend;
+        match self.backend {
+            #[cfg(target_os = "linux")]
+            UdpBackend::Completion => crate::net::io::completion::io_uring::spawn_session(
+                self,
+                raw_socket,
+                port,
+                pending_sends,
+                filters,
+            ),
+            _ => crate::net::io::poll::tokio::spawn_session(
+                self,
+                raw_socket,
+                port,
+                pending_sends,
+                filters,
+            ),
+        }
+    }
+
     /// Returns whether the pool contains any sockets allocated to a destination.
     #[cfg(test)]
     fn has_no_allocated_sockets(&self) -> bool {
@@ -567,10 +599,16 @@ mod tests {
     use std::sync::Arc;
 
     async fn new_pool() -> (Arc<SessionPool>, PacketQueueSender) {
-        let (pending_sends, _srecv) = crate::net::queue(1).unwrap();
+        let backend = crate::net::io::UdpBackend::default();
+        let (pending_sends, _srecv) = crate::net::queue(1, backend).unwrap();
         let fake = crate::config::filter::FilterChainConfig::default();
         (
-            SessionPool::new(vec![pending_sends.clone()], fake.cached(), usize::MAX),
+            SessionPool::new(
+                vec![pending_sends.clone()],
+                fake.cached(),
+                usize::MAX,
+                backend,
+            ),
             pending_sends,
         )
     }
@@ -715,10 +753,11 @@ mod tests {
     }
 
     fn pool_with_limit(limit: usize) -> (Arc<SessionPool>, PacketQueueSender) {
-        let (pending_sends, _srecv) = crate::net::queue(1).unwrap();
+        let backend = crate::net::io::UdpBackend::default();
+        let (pending_sends, _srecv) = crate::net::queue(1, backend).unwrap();
         let fake = crate::config::filter::FilterChainConfig::default();
         (
-            SessionPool::new(vec![pending_sends.clone()], fake.cached(), limit),
+            SessionPool::new(vec![pending_sends.clone()], fake.cached(), limit, backend),
             pending_sends,
         )
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -86,6 +86,14 @@ pub struct Service {
         default_value_t = 5_000
     )]
     pub udp_session_limit: usize,
+    /// The UDP I/O backend to use.
+    /// auto selects the best available: kernel (XDP) -> completion (io-uring) -> poll (epoll).
+    #[clap(
+        long = "service.udp.backend",
+        env = "QUILKIN_SERVICE_UDP_BACKEND",
+        default_value = "auto"
+    )]
+    udp_backend: crate::net::io::UdpBackend,
     /// Whether to serve xDS requests.
     #[arg(
         long = "service.xds",
@@ -222,6 +230,7 @@ impl Default for Service {
             udp_port: 7777,
             udp_workers: std::num::NonZeroUsize::new(num_cpus::get()).unwrap(),
             udp_session_limit: 10_000,
+            udp_backend: crate::net::io::UdpBackend::Auto,
             xds_enabled: <_>::default(),
             xds_port: 7800,
             grpc_enabled: false,
@@ -333,6 +342,12 @@ impl Service {
 
     pub fn testing(mut self) -> Self {
         self.testing = true;
+        self
+    }
+
+    /// Sets the UDP I/O backend.
+    pub fn udp_backend(mut self, backend: crate::net::io::UdpBackend) -> Self {
+        self.udp_backend = backend;
         self
     }
 
@@ -639,11 +654,16 @@ impl Service {
 
         #[cfg(target_os = "linux")]
         {
-            match self.spawn_xdp(config.clone(), self.xdp.force_xdp) {
-                Ok(xdp) => {
-                    if let Some(xdp) = xdp {
-                        // Disable this so that we don't create a separate user-space
-                        // QCMP service since we are handling QCMP messsages in XDP
+            let explicit_kernel = matches!(self.udp_backend, crate::net::io::UdpBackend::Kernel);
+            if explicit_kernel
+                || matches!(
+                    self.udp_backend.resolve(),
+                    crate::net::io::UdpBackend::Kernel
+                )
+            {
+                match self.spawn_xdp(config.clone()) {
+                    Ok(xdp) => {
+                        // XDP handles QCMP in-kernel; disable the user-space QCMP service.
                         self.qcmp_enabled = false;
 
                         assert!(self.qcmp_port != 0, "don't use ephemeral ports with XDP");
@@ -665,19 +685,18 @@ impl Service {
                         });
 
                         return Ok(());
-                    } else if self.xdp.force_xdp {
-                        eyre::bail!("XDP was forced on, but failed to initialize");
                     }
-                }
-                Err(err) => {
-                    if self.xdp.force_xdp {
-                        return Err(err);
+                    Err(err) => {
+                        if explicit_kernel {
+                            return Err(err);
+                        }
+                        // Auto probed XDP as available but setup failed — fall back.
+                        tracing::debug!(
+                            ?err,
+                            "XDP setup failed, falling back to user-space backend"
+                        );
+                        self.udp_backend = crate::net::io::UdpBackend::probe_user_space();
                     }
-
-                    tracing::warn!(
-                        ?err,
-                        "failed to spawn XDP I/O loop, falling back to io-uring"
-                    );
                 }
             }
         }
@@ -693,8 +712,9 @@ impl Service {
     /// sockets.
     ///
     /// This implementation uses a pool of buffers and sockets to manage UDP
-    /// sessions and sockets. On Linux this will use `io-uring`, and `epoll`
-    /// interfaces on non-Linux platforms.
+    /// sessions and sockets. On Linux this will prefer `io-uring`, falling
+    /// back to `epoll` if io-uring is unavailable. The backend can also be
+    /// overridden via the `--service.udp.backend` CLI flag.
     #[allow(clippy::type_complexity)]
     pub fn spawn_user_space_router(
         &self,
@@ -702,44 +722,51 @@ impl Service {
         shutdown: &mut ShutdownHandler,
         ports: &mut ServicePorts,
     ) -> crate::Result<()> {
-        // If we're on linux, we're using io-uring, but we're probably running in a container
-        // and may not be allowed to call io-uring related syscalls due to seccomp
-        // profiles, so do a quick check here to validate that we can call io_uring_setup
-        // https://www.man7.org/linux/man-pages/man2/io_uring_setup.2.html
-        #[cfg(target_os = "linux")]
-        {
-            if let Err(err) = io_uring::IoUring::new(2) {
-                fn in_container() -> bool {
-                    let sched = match std::fs::read_to_string("/proc/1/sched") {
-                        Ok(s) => s,
-                        Err(error) => {
-                            tracing::warn!(
-                                %error,
-                                "unable to read /proc/1/sched to determine if quilkin is in a container"
-                            );
-                            return false;
-                        }
-                    };
-                    let Some(line) = sched.lines().next() else {
-                        tracing::warn!("/proc/1/sched was empty");
-                        return false;
-                    };
-                    let Some(proc) = line.split(' ').next() else {
-                        tracing::warn!("first line of /proc/1/sched was empty");
-                        return false;
-                    };
-                    proc != "init" && proc != "systemd"
-                }
-
-                if err.kind() == std::io::ErrorKind::PermissionDenied && in_container() {
-                    eyre::bail!(
-                        "failed to call `io_uring_setup` due to EPERM ({err}), quilkin seems to be running inside a container meaning this is likely due to the seccomp profile not allowing the syscall"
-                    );
-                } else {
-                    eyre::bail!("failed to call `io_uring_setup` due to {err}");
-                }
+        let backend = match self.udp_backend {
+            crate::net::io::UdpBackend::Auto => {
+                let resolved = crate::net::io::UdpBackend::Auto.resolve();
+                tracing::debug!(backend = resolved.name(), "selected UDP backend");
+                resolved
             }
-        }
+            explicit => {
+                // Validate explicit Completion selection on Linux
+                #[cfg(target_os = "linux")]
+                if matches!(explicit, crate::net::io::UdpBackend::Completion)
+                    && let Err(err) = io_uring::IoUring::new(2)
+                {
+                    fn in_container() -> bool {
+                        let sched = match std::fs::read_to_string("/proc/1/sched") {
+                            Ok(s) => s,
+                            Err(error) => {
+                                tracing::warn!(
+                                    %error,
+                                    "unable to read /proc/1/sched to determine if quilkin is in a container"
+                                );
+                                return false;
+                            }
+                        };
+                        let Some(line) = sched.lines().next() else {
+                            tracing::warn!("/proc/1/sched was empty");
+                            return false;
+                        };
+                        let Some(proc) = line.split(' ').next() else {
+                            tracing::warn!("first line of /proc/1/sched was empty");
+                            return false;
+                        };
+                        proc != "init" && proc != "systemd"
+                    }
+
+                    if err.kind() == std::io::ErrorKind::PermissionDenied && in_container() {
+                        eyre::bail!(
+                            "failed to call `io_uring_setup` due to EPERM ({err}), quilkin seems to be running inside a container meaning this is likely due to the seccomp profile not allowing the syscall"
+                        );
+                    } else {
+                        eyre::bail!("failed to call `io_uring_setup` due to {err}");
+                    }
+                }
+                explicit
+            }
+        };
 
         let socket = crate::net::raw_socket_with_reuse(self.udp_port)?;
         ports.udp = Some(crate::net::socket_port(&socket));
@@ -748,7 +775,7 @@ impl Service {
         let mut worker_sends = Vec::with_capacity(workers);
         let mut session_sends = Vec::with_capacity(workers);
         for _ in 0..workers {
-            let queue = crate::net::queue(15)?;
+            let queue = crate::net::queue(15, backend)?;
             session_sends.push(queue.0.clone());
             worker_sends.push(queue);
         }
@@ -758,8 +785,13 @@ impl Service {
             .cached_filter_chain()
             .context("a cached FilterChain should have been configured")?;
 
-        let sessions = SessionPool::new(session_sends, cached_filters, self.udp_session_limit);
-        crate::net::packet::spawn_receivers(config, socket, worker_sends, &sessions)?;
+        let sessions = SessionPool::new(
+            session_sends,
+            cached_filters,
+            self.udp_session_limit,
+            backend,
+        );
+        crate::net::packet::spawn_receivers(config, socket, worker_sends, &sessions, backend)?;
 
         let finished = shutdown.push("udp");
         let mut srx = shutdown.shutdown_rx();
@@ -805,14 +837,9 @@ impl Service {
     }
 
     #[cfg(target_os = "linux")]
-    fn spawn_xdp(&self, config: Arc<Config>, force_xdp: bool) -> eyre::Result<Option<Finalizer>> {
+    fn spawn_xdp(&self, config: Arc<Config>) -> eyre::Result<Finalizer> {
         use crate::net::io::nic::xdp;
         use eyre::{Context as _, ContextCompat as _};
-
-        // TODO: remove this once it's been more stabilized
-        if !force_xdp {
-            return Ok(None);
-        }
 
         let filters = config
             .dyn_cfg
@@ -845,9 +872,9 @@ impl Service {
         .context("failed to setup XDP")?;
 
         let io_loop = xdp::spawn(workers, config).context("failed to spawn XDP I/O loop")?;
-        Ok(Some(Box::new(move || {
+        Ok(Box::new(move || {
             io_loop.shutdown(true);
-        })))
+        }))
     }
 
     /// Spawn corrosion server
@@ -1190,12 +1217,6 @@ pub struct XdpOptions {
         env = "QUILKIN_SERVICE_UDP_XDP_NETWORK_INTERFACE"
     )]
     pub network_interface: Option<String>,
-    /// Forces the use of XDP.
-    ///
-    /// If XDP is not available on the chosen NIC, Quilkin exits with an error.
-    /// If false, io-uring will be used as the fallback implementation.
-    #[clap(long = "service.udp.xdp", env = "QUILKIN_SERVICE_UDP_XDP")]
-    pub force_xdp: bool,
     /// Forces the use of [`XDP_ZEROCOPY`](https://www.kernel.org/doc/html/latest/networking/af_xdp.html#xdp-copy-and-xdp-zerocopy-bind-flags)
     ///
     /// If zero copy is not available on the chosen NIC, Quilkin exits with an error
@@ -1227,7 +1248,6 @@ impl Default for XdpOptions {
     fn default() -> Self {
         Self {
             network_interface: None,
-            force_xdp: false,
             force_zerocopy: false,
             force_tx_checksum_offload: false,
             maximum_memory: None,


### PR DESCRIPTION
Reattempt from an older PR, makes the IO backend selectable at runtime (which it already partly is).

Unified under `service.udp.backend` option (`auto`, `kernel`, `completion`, `poll`).