### PR TITLE
Update to Rust 1.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -403,7 +403,7 @@ source = "git+https://github.com/aya-rs/aya?rev=2453204#2453204a9b07a3a92d538f7c
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.17.1",
  "libc",
  "log",
@@ -499,12 +499,6 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -801,7 +795,7 @@ dependencies = [
 [[package]]
 name = "consul-client"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "camino",
  "http",
@@ -854,7 +848,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "corro-api-types"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "camino",
  "compact_str",
@@ -873,7 +867,7 @@ dependencies = [
 [[package]]
 name = "corro-base-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "camino",
  "compact_str",
@@ -893,7 +887,7 @@ dependencies = [
 [[package]]
 name = "corro-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "antithesis_sdk",
  "arc-swap",
@@ -908,7 +902,6 @@ dependencies = [
  "corro-base-types",
  "corro-utils",
  "deadpool",
- "enquote",
  "eyre",
  "fallible-iterator",
  "foca",
@@ -950,7 +943,7 @@ dependencies = [
 [[package]]
 name = "corro-utils"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "eyre",
  "tokio",
@@ -1106,7 +1099,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -1237,47 +1230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
-]
-
-[[package]]
-name = "defmt"
-version = "0.3.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
-dependencies = [
- "defmt 1.1.0",
-]
-
-[[package]]
-name = "defmt"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
-dependencies = [
- "defmt-parser",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1434,15 +1386,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "enquote"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c36cb11dbde389f4096111698d8b567c0720e3452fd5ac3e6b4e47e1939932"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,7 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2349,7 +2292,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -2400,7 +2343,7 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -2444,7 +2387,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2687,7 +2630,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
 ]
 
@@ -3136,7 +3079,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -3192,7 +3135,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3210,7 +3153,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3219,7 +3162,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3740,28 +3683,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3824,7 +3745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -4324,7 +4245,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -4477,7 +4398,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -4541,11 +4462,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4604,7 +4525,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4709,7 +4630,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4733,7 +4654,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4966,13 +4887,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "spawn"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "futures",
  "parking_lot",
@@ -5009,14 +4930,14 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "sqlite-functions"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -5025,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "sqlite-pool"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "arc-swap",
  "deadpool",
@@ -5054,7 +4975,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9add252f9b70a7d493b03127524ed06cdf7480b3dc8c1b2ccfda89384d90a8b7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cc",
  "fallible-iterator",
  "indexmap",
@@ -5199,7 +5120,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5230,7 +5151,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5532,7 +5453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64",
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -5682,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "tripwire"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#89dae0d0f04a9e010cbbb75ee43ebfb0ce61fe19"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "futures",
  "futures-util",
@@ -5758,16 +5679,14 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uhlc"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b6df3f3e948b40e20c38a6d1fd6d8f91b3573922fc164e068ad3331560487e"
+checksum = "55bb25449f66ea76693b51f631fdd190821683c65e65e68d990b36c2d1ae9dd2"
 dependencies = [
- "defmt 0.3.100",
  "humantime",
  "lazy_static",
  "log",
  "rand 0.8.6",
- "serde",
  "spin",
 ]
 
@@ -6009,7 +5928,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -6091,7 +6010,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6456,7 +6375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -286,7 +286,7 @@ xdp = "0.7.1"
 # we also need to depend on should be kept in line with the versions used by corrosion
 camino = "1.2"
 rusqlite = "=0.38"
-uhlc = "0.7"
+uhlc = { version = "0.9", default-features = false }
 
 corro-api-types = { git = "https://github.com/EmbarkStudios/corrosion", branch = "misc" }
 corro-client = { git = "https://github.com/EmbarkStudios/corrosion", branch = "misc" }

--- a/crates/corrosion-tests/tests/db.rs
+++ b/crates/corrosion-tests/tests/db.rs
@@ -50,7 +50,7 @@ fn make_row(i: u32) -> ServerRow {
 
     ServerRow {
         endpoint,
-        icao: IcaoCode::new_testing([b'B', b'O', b'O', b'P']),
+        icao: IcaoCode::new_testing(*b"BOOP"),
         tokens: [i.to_ne_bytes()].into(),
     }
 }

--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -259,7 +259,7 @@ trace_test!(xds_bridge_to_corrosion, {
         "agent",
         AgentPailConfig {
             endpoints: vec![("server", &[])],
-            icao_code: quilkin::config::IcaoCode::new_testing([b'A', b'B', b'C', b'D']),
+            icao_code: quilkin::config::IcaoCode::new_testing(*b"ABCD"),
             corrosion: false,
         },
         &["server", "relay"],

--- a/crates/types/src/icao.rs
+++ b/crates/types/src/icao.rs
@@ -32,7 +32,7 @@ impl AsRef<str> for IcaoCode {
 
 impl Default for IcaoCode {
     fn default() -> Self {
-        Self([b'X', b'X', b'X', b'X'])
+        Self(*b"XXXX")
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.0"
 components = ["rustfmt", "clippy"]

--- a/tests/provider_k8s.rs
+++ b/tests/provider_k8s.rs
@@ -386,7 +386,7 @@ fn handles_multiple_namespaces() {
         let guard = clusters.read();
         let endpoint_set = guard.get(&locality).unwrap();
         assert_eq!(endpoint_set.len(), gameservers.len());
-        for (_id, gs) in gameservers.iter() {
+        for gs in gameservers.values() {
             assert!(endpoint_set.contains(&get_endpoint(gs)));
         }
     }
@@ -420,7 +420,7 @@ fn handles_multiple_namespaces() {
         let guard = clusters.read();
         let endpoint_set = guard.get(&locality).unwrap();
         assert_eq!(endpoint_set.len(), gameservers.len());
-        for (_id, gs) in gameservers.iter() {
+        for gs in gameservers.values() {
             assert!(endpoint_set.contains(&get_endpoint(gs)));
         }
     }
@@ -452,7 +452,7 @@ fn handles_multiple_namespaces() {
         let guard = clusters.read();
         let endpoint_set = guard.get(&locality).unwrap();
         assert_eq!(endpoint_set.len(), gameservers.len());
-        for (_id, gs) in gameservers.iter() {
+        for gs in gameservers.values() {
             assert!(endpoint_set.contains(&get_endpoint(gs)));
         }
     }


### PR DESCRIPTION
Updates to Rust 1.97 and fixes the new lints that were triggered. There was also a compiler warning about the proc-macro-error2 crate having code that will be rejected in future versions of the compiler, which was no longer used by the latest version of uhlc, but noticed that uhlc was using defmt for...no reason so just removed it entirely since it was the only crate pulling it in.