### PR TITLE
Increase ring buffer size

### DIFF
--- a/crates/test/tests/uring.rs
+++ b/crates/test/tests/uring.rs
@@ -77,7 +77,9 @@ trace_test!(refreshes_recv_ring, {
 
     let mut buf = [0u8; 4];
 
-    for i in 0..10000u32 {
+    const COUNT: u32 = 10000;
+
+    for i in 0..COUNT {
         client.send_to(&i.to_ne_bytes(), addr).await.unwrap();
 
         let (len, _addr) = sb
@@ -89,4 +91,29 @@ trace_test!(refreshes_recv_ring, {
         assert_eq!(len, 4);
         assert_eq!(u32::from_ne_bytes(buf), i);
     }
+
+    client
+        .send_to(b"QLKN_GET_RECV_RING", addr)
+        .await
+        .expect("failed to send debug request");
+    let mut buf = [0u8; 8];
+    let (len, _addr) = sb
+        .timeout(100, client.recv_from(&mut buf))
+        .await
+        .0
+        .expect("should have debug response packet");
+
+    assert_eq!(len, 8);
+    // We _should_ have excatly 1 outstanding buffer in the buffer ring, the one that has our debug request
+    let count = buf[0] as u16 | (buf[1] as u16) << 8;
+    let len = buf[2] as u16 | (buf[3] as u16) << 8;
+    let alloced =
+        buf[4] as u32 | (buf[5] as u32) << 8 | (buf[6] as u32) << 16 | (buf[7] as u32) << 24;
+
+    assert_eq!(COUNT + 1, alloced);
+    assert_eq!(
+        len,
+        count - 1,
+        "expected to have 1 buffer outstanding in the ring!"
+    );
 });

--- a/src/net/io/completion/io_uring.rs
+++ b/src/net/io/completion/io_uring.rs
@@ -70,7 +70,7 @@ pub fn spawn_listener(
 
     let socket = crate::net::DualStackLocalSocket::new(port).context("failed to bind socket")?;
 
-    let io_loop = IoUringLoop::new(512, socket)?;
+    let io_loop = IoUringLoop::new(2048, socket)?;
     io_loop
         .spawn_io_loop(
             format!("packet-router-{worker_id}"),
@@ -604,7 +604,7 @@ impl IoUringLoop {
                                             let mut data = bytes::BytesMut::new();
                                             data.put_u16_ne(rb.count);
                                             data.put_u16_ne(rb.len(id));
-                                            data.put_u64_ne(alloced);
+                                            data.put_u32_ne(alloced);
                                             loop_ctx.enqueue_send(SendPacket { destination: packet.source, data: data.freeze(), asn_info: None });
                                             continue;
                                         }

--- a/src/net/io/completion/io_uring.rs
+++ b/src/net/io/completion/io_uring.rs
@@ -555,6 +555,8 @@ impl IoUringLoop {
                 loop_ctx.sync();
 
                 let mut last_received_at = None;
+                #[cfg(debug_assertions)]
+                let mut alloced = 0;
 
                 // The core io uring loop
                 'io: loop {
@@ -590,6 +592,23 @@ impl IoUringLoop {
                                     let Some(packet) = loop_ctx.pop_recv(cqe, &rb) else { continue; };
 
                                     let id = packet.buffer.id();
+
+                                    // When testing we check if this is a special packet that's querying our state
+                                    #[cfg(debug_assertions)]
+                                    {
+                                        alloced += 1;
+
+                                        if &packet.buffer[..] == b"QLKN_GET_RECV_RING" {
+                                            use bytes::BufMut;
+
+                                            let mut data = bytes::BytesMut::new();
+                                            data.put_u16_ne(rb.count);
+                                            data.put_u16_ne(rb.len(id));
+                                            data.put_u64_ne(alloced);
+                                            loop_ctx.enqueue_send(SendPacket { destination: packet.source, data: data.freeze(), asn_info: None });
+                                            continue;
+                                        }
+                                    }
 
                                     process_packet(&mut ctx, filters, packet, &mut last_received_at);
 

--- a/src/net/io/completion/ring.rs
+++ b/src/net/io/completion/ring.rs
@@ -140,7 +140,7 @@ impl BufferRing {
 
     #[cfg(debug_assertions)]
     pub fn len(&self, id: u16) -> u16 {
-        let tail = dbg!(dbg!(self.tail.load(Ordering::Relaxed)) & self.mask);
+        let tail = self.tail.load(Ordering::Relaxed) & self.mask;
         if tail > id {
             tail - id
         } else {

--- a/src/net/io/completion/ring.rs
+++ b/src/net/io/completion/ring.rs
@@ -138,6 +138,16 @@ impl BufferRing {
         }
     }
 
+    #[cfg(debug_assertions)]
+    pub fn len(&self, id: u16) -> u16 {
+        let tail = dbg!(dbg!(self.tail.load(Ordering::Relaxed)) & self.mask);
+        if tail > id {
+            tail - id
+        } else {
+            (self.count - id).wrapping_add(tail).saturating_sub(1)
+        }
+    }
+
     #[inline]
     pub fn enqueue(&self) -> BufferRingEnqueuer<'_> {
         BufferRingEnqueuer {


### PR DESCRIPTION
I had forgotten that I did have a test for the ring buffer used for receives in io-uring, so I'm fairly confident that the issue is not that there is a bug in the implementation, merely that the ring buffer was too small at 512, so I've bumped it to 2048. Ideally this would be configurable similar to xdp, but that would be a more invasive change.

Resolves: #1405 