### PR TITLE
Requeue io-uring receives even if there is an error

### DIFF
--- a/crates/test/tests/proxy.rs
+++ b/crates/test/tests/proxy.rs
@@ -132,10 +132,15 @@ trace_test!(uring_receiver, {
             config.dyn_cfg.cached_filter_chain().unwrap(),
             usize::MAX,
             backend,
+            4,
         ),
         backend,
     }
-    .spawn_io_loop(pending_sends, config.dyn_cfg.cached_filter_chain().unwrap())
+    .spawn_io_loop(
+        pending_sends,
+        config.dyn_cfg.cached_filter_chain().unwrap(),
+        4,
+    )
     .expect("failed to spawn task");
 
     // Drop the socket, otherwise it can
@@ -193,12 +198,14 @@ trace_test!(
             config.dyn_cfg.cached_filter_chain().unwrap(),
             usize::MAX,
             backend,
+            64,
         );
 
         const WORKER_COUNT: usize = 3;
 
         let (socket, addr) = sb.socket();
-        net::packet::spawn_receivers(config, socket, pending_sends, &sessions, backend).unwrap();
+        net::packet::spawn_receivers(config, socket, pending_sends, &sessions, backend, 64)
+            .unwrap();
 
         let socket = std::sync::Arc::new(sb.client());
         let msg = "recv-from";

--- a/crates/test/tests/uring.rs
+++ b/crates/test/tests/uring.rs
@@ -117,3 +117,93 @@ trace_test!(refreshes_recv_ring, {
         "expected to have 1 buffer outstanding in the ring!"
     );
 });
+
+// Severely constrains the ring buffer length to ensure that we requeue when we run out of recv buffers
+trace_test!(requeues_recv, {
+    let mut sc = qt::sandbox_config!();
+
+    sc.push("server", ServerPailConfig::default(), &[]);
+    let mut sb = sc.spinup().await;
+
+    let (mut packet_rx, endpoint) = sb.server("server");
+
+    let mut service = quilkin::Service::builder().udp();
+    let config = std::sync::Arc::new(quilkin::Config::new(
+        None,
+        Default::default(),
+        &Default::default(),
+        &mut service,
+    ));
+    config
+        .dyn_cfg
+        .clusters()
+        .unwrap()
+        .modify(|clusters| clusters.insert_default([endpoint.into()].into()));
+
+    let socket = sb.client();
+    let (ws, addr) = sb.socket();
+
+    // XDP doesn't go through spawn_io_loop — use the best user-space backend.
+    let backend = {
+        #[cfg(target_os = "linux")]
+        {
+            quilkin::net::io::UdpBackend::probe_user_space()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            quilkin::net::io::UdpBackend::Poll
+        }
+    };
+    let pending_sends = quilkin::net::queue(100, backend).unwrap();
+
+    // we'll test a single DownstreamReceiveWorkerConfig
+    quilkin::net::io::Listener {
+        worker_id: 1,
+        port: addr.port(),
+        config: config.clone(),
+        sessions: quilkin::net::sessions::SessionPool::new(
+            vec![pending_sends.0.clone()],
+            config.dyn_cfg.cached_filter_chain().unwrap(),
+            usize::MAX,
+            backend,
+            4,
+        ),
+        backend,
+    }
+    .spawn_io_loop(
+        pending_sends,
+        config.dyn_cfg.cached_filter_chain().unwrap(),
+        4,
+    )
+    .expect("failed to spawn task");
+
+    // Drop the socket otherwise the test won't exit
+    drop(ws);
+
+    const COUNT: u32 = 1000;
+    const BLOCK_COUNT: u32 = 100;
+    let msg = "hello-downstream";
+    let mut recvd = 0;
+    let start = std::time::Instant::now();
+
+    while recvd < COUNT {
+        for _ in 0..BLOCK_COUNT {
+            if socket.socket.try_send_to(msg.as_bytes(), addr).is_err() {
+                break;
+            }
+        }
+
+        for _ in 0..BLOCK_COUNT {
+            let Ok(out) = packet_rx.try_recv() else {
+                break;
+            };
+
+            recvd += 1;
+            assert_eq!(out, msg);
+        }
+
+        if start.elapsed() > std::time::Duration::from_secs(2) {
+            panic!("timed out {recvd}");
+        }
+    }
+});

--- a/src/net.rs
+++ b/src/net.rs
@@ -208,7 +208,7 @@ cfg_select! {
 /// The same as [`DualStackLocalSocket`] but uses epoll instead of uring.
 #[derive(Debug)]
 pub struct DualStackEpollSocket {
-    socket: tokio::net::UdpSocket,
+    pub socket: tokio::net::UdpSocket,
 }
 
 impl DualStackEpollSocket {

--- a/src/net/io.rs
+++ b/src/net/io.rs
@@ -125,11 +125,14 @@ impl Listener {
         self,
         queue: crate::net::PacketQueue,
         fc: crate::config::filter::CachedFilterChain,
+        _recv_ring_len: u16,
     ) -> eyre::Result<()> {
         match self.backend {
             UdpBackend::Poll => poll::tokio::spawn_listener(self, queue, fc),
             #[cfg(target_os = "linux")]
-            UdpBackend::Completion => completion::io_uring::spawn_listener(self, queue, fc),
+            UdpBackend::Completion => {
+                completion::io_uring::spawn_listener(self, queue, fc, _recv_ring_len)
+            }
             #[cfg(target_os = "linux")]
             UdpBackend::Kernel => {
                 unreachable!("XDP runs via spawn_xdp and never reaches the queue-based listener")

--- a/src/net/io/completion/io_uring.rs
+++ b/src/net/io/completion/io_uring.rs
@@ -51,6 +51,7 @@ pub fn spawn_listener(
     listener: crate::net::io::Listener,
     pending_sends: crate::net::PacketQueue,
     filter_chain: CachedFilterChain,
+    recv_ring_len: u16,
 ) -> eyre::Result<()> {
     let crate::net::io::Listener {
         worker_id,
@@ -70,7 +71,7 @@ pub fn spawn_listener(
 
     let socket = crate::net::DualStackLocalSocket::new(port).context("failed to bind socket")?;
 
-    let io_loop = IoUringLoop::new(2048, socket)?;
+    let io_loop = IoUringLoop::new(recv_ring_len, socket)?;
     io_loop
         .spawn_io_loop(
             format!("packet-router-{worker_id}"),
@@ -324,17 +325,28 @@ impl<'uring> LoopCtx<'uring> {
         &mut self,
         cqe: io_uring::cqueue::Entry,
         br: &'rb super::ring::BufferRing,
-    ) -> Option<RecvPacket<'rb>> {
+    ) -> std::io::Result<Option<RecvPacket<'rb>>> {
         let ret = cqe.result();
+        let flags = cqe.flags();
 
         if ret < 0 {
             let error = std::io::Error::from_raw_os_error(-ret);
             metrics::errors_total(metrics::READ, &error.to_string(), &metrics::EMPTY).inc();
-            tracing::error!(%error, "error receiving packet");
-            return None;
-        }
 
-        let flags = cqe.flags();
+            // For now, only requeue recv if it's ENOBUFS, most of the other errors that could theoretically occur for
+            // recvmsg either can't happen in our io-uring context, or would indicate a terminal error
+            if -ret != libc::ENOBUFS {
+                return Err(error);
+            }
+
+            tracing::debug!(%error, "no buffers available in recv ring buffer");
+
+            if flags & flags::IORING_CQE_F_MORE == 0 {
+                self.enqueue_recvmsg();
+            }
+
+            return Ok(None);
+        }
 
         // Requeue the recv if needed
         if flags & flags::IORING_CQE_F_MORE == 0 {
@@ -344,8 +356,9 @@ impl<'uring> LoopCtx<'uring> {
         // This _should_ theoretically never happen
         if flags & flags::IORING_CQE_F_BUFFER == 0 {
             metrics::errors_total(metrics::READ, "no buffer selected", &metrics::EMPTY).inc();
-            tracing::error!("failed to receive packet, a buffer was not selected");
-            return None;
+
+            // Differentiate this from ENOBUFS
+            return Err(std::io::Error::other("no buffer selected"));
         }
 
         let buffer_id = (flags >> 16) as u16;
@@ -356,14 +369,16 @@ impl<'uring> LoopCtx<'uring> {
             Err(error) => {
                 metrics::errors_total(metrics::READ, &error.to_string(), &metrics::EMPTY).inc();
                 tracing::error!(%error, "failed to extract source address");
-                return None;
+                // TODO: should this be terminal? not having this would indicate that the kernel is not upholding its
+                // API promise of prepending the source address before the packet contents
+                return Ok(None);
             }
         };
 
-        Some(RecvPacket {
+        Ok(Some(RecvPacket {
             buffer: rb,
             source: addr,
-        })
+        }))
     }
 
     /// Enqueues a `send_to` on the socket
@@ -458,16 +473,16 @@ const BUFFER_RING: u16 = 0xfeed;
 
 pub struct IoUringLoop {
     socket: crate::net::DualStackLocalSocket,
-    concurrent_sends: u32,
+    recv_buffer_len: u16,
 }
 
 impl IoUringLoop {
     pub fn new(
-        concurrent_sends: u16,
+        recv_buffer_len: u16,
         socket: crate::net::DualStackLocalSocket,
     ) -> Result<Self, PipelineError> {
         Ok(Self {
-            concurrent_sends: concurrent_sends as _,
+            recv_buffer_len: recv_buffer_len.next_power_of_two(),
             socket,
         })
     }
@@ -482,18 +497,18 @@ impl IoUringLoop {
         let dispatcher = tracing::dispatcher::get_default(|d| d.clone());
 
         let socket = self.socket;
-        let concurrent_sends = self.concurrent_sends;
+        let recv_buffer_len = self.recv_buffer_len as u32;
 
         let mut ring =
             io_uring::IoUring::<io_uring::squeue::Entry, io_uring::cqueue::Entry>::builder()
-                .setup_cqsize(self.concurrent_sends)
-                .build(self.concurrent_sends >> 1)?;
+                .setup_cqsize(recv_buffer_len)
+                .build(recv_buffer_len >> 1)?;
 
         let mut pending_sends_event = pending_sends.1;
         let pending_sends = pending_sends.0;
 
         let rb = super::ring::BufferRing::new(
-            concurrent_sends as u16,
+            self.recv_buffer_len as u16,
             // we only deal with non-fragmented UDP with a presumed MTU of 1500, though we also need to account for the extra metadata for multishot recvmsg, so just round up to the next power of 2
             2048,
         )
@@ -505,7 +520,7 @@ impl IoUringLoop {
                 crate::metrics::game_traffic_tasks().inc();
                 let _guard = tracing::dispatcher::set_default(&dispatcher);
 
-                let queued_sends = slab::Slab::with_capacity(concurrent_sends as usize);
+                let queued_sends = slab::Slab::with_capacity(recv_buffer_len as usize);
 
                 // Just double buffer the pending writes for simplicity
                 let mut double_pending_sends = Vec::with_capacity(pending_sends.capacity());
@@ -589,7 +604,17 @@ impl IoUringLoop {
                             let op = (ud >> 56) as u8;
                             match op {
                                 IORING_OP_RECVMSG => {
-                                    let Some(packet) = loop_ctx.pop_recv(cqe, &rb) else { continue; };
+                                    let packet = match loop_ctx.pop_recv(cqe, &rb) {
+                                        Ok(Some(packet)) => packet,
+                                        Ok(None) => {
+                                            // A (hopefully) transient error occurred
+                                            continue;
+                                        }
+                                        Err(error) => {
+                                            tracing::error!(%error, "terminal error occurred receiving a packet");
+                                            break 'io;
+                                        }
+                                    };
 
                                     let id = packet.buffer.id();
 
@@ -705,7 +730,10 @@ pub fn spawn_session(
         }
     };
 
-    let io_loop = IoUringLoop::new(64, crate::net::DualStackLocalSocket::from_raw(raw_socket))?;
+    let io_loop = IoUringLoop::new(
+        pool.ring_buffer_len,
+        crate::net::DualStackLocalSocket::from_raw(raw_socket),
+    )?;
 
     io_loop.spawn_io_loop(
         format!("session-{id}"),

--- a/src/net/io/completion/io_uring.rs
+++ b/src/net/io/completion/io_uring.rs
@@ -508,7 +508,7 @@ impl IoUringLoop {
         let pending_sends = pending_sends.0;
 
         let rb = super::ring::BufferRing::new(
-            self.recv_buffer_len as u16,
+            recv_buffer_len as u16,
             // we only deal with non-fragmented UDP with a presumed MTU of 1500, though we also need to account for the extra metadata for multishot recvmsg, so just round up to the next power of 2
             2048,
         )

--- a/src/net/packet.rs
+++ b/src/net/packet.rs
@@ -248,6 +248,7 @@ pub fn spawn_receivers(
     worker_sends: Vec<crate::net::PacketQueue>,
     sessions: &Arc<SessionPool>,
     backend: crate::net::io::UdpBackend,
+    recv_ring_len: u16,
 ) -> crate::Result<()> {
     let port = crate::net::socket_port(&socket);
 
@@ -264,7 +265,7 @@ pub fn spawn_receivers(
             backend,
         };
 
-        worker.spawn_io_loop(ws, pfc.clone())?;
+        worker.spawn_io_loop(ws, pfc.clone(), recv_ring_len)?;
     }
 
     Ok(())

--- a/src/net/sessions.rs
+++ b/src/net/sessions.rs
@@ -96,6 +96,7 @@ pub struct SessionPool {
     cached_filter_chain: CachedFilterChain,
     max_sessions: usize,
     backend: crate::net::io::UdpBackend,
+    pub ring_buffer_len: u16,
 }
 
 /// The wrapper struct responsible for holding all of the socket related mappings.
@@ -116,6 +117,7 @@ impl SessionPool {
         cached_filter_chain: CachedFilterChain,
         max_sessions: usize,
         backend: crate::net::io::UdpBackend,
+        ring_buffer_len: u16,
     ) -> Arc<Self> {
         const SESSION_TIMEOUT_SECONDS: Duration = Duration::from_secs(60);
         const SESSION_EXPIRY_POLL_INTERVAL: Duration = Duration::from_secs(60);
@@ -129,6 +131,7 @@ impl SessionPool {
             cached_filter_chain,
             max_sessions,
             backend,
+            ring_buffer_len,
         })
     }
 
@@ -619,6 +622,7 @@ mod tests {
                 fake.cached(),
                 usize::MAX,
                 backend,
+                64,
             ),
             pending_sends,
         )
@@ -768,7 +772,13 @@ mod tests {
         let (pending_sends, _srecv) = crate::net::queue(1, backend).unwrap();
         let fake = crate::config::filter::FilterChainConfig::default();
         (
-            SessionPool::new(vec![pending_sends.clone()], fake.cached(), limit, backend),
+            SessionPool::new(
+                vec![pending_sends.clone()],
+                fake.cached(),
+                limit,
+                backend,
+                64,
+            ),
             pending_sends,
         )
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -86,6 +86,20 @@ pub struct Service {
         default_value_t = 5_000
     )]
     pub udp_session_limit: usize,
+    /// The number of entries allocated in a ring buffer for receives
+    #[clap(
+        long = "service.udp.ringbuffer.len",
+        env = "QUILKIN_SERVICE_UDP_RING_BUFFER_LEN",
+        default_value_t = 2048
+    )]
+    pub udp_ring_buffer: u16,
+    /// The number of entries allocated in a ring buffer for receives per session
+    #[clap(
+        long = "service.udp.session.ringbuffer.len",
+        env = "QUILKIN_SERVICE_UDP_SESSION_RING_BUFFER_LEN",
+        default_value_t = 256
+    )]
+    pub session_pool_ring_buffer: u16,
     /// The UDP I/O backend to use.
     /// auto selects the best available: kernel (XDP) -> completion (io-uring) -> poll (epoll).
     #[clap(
@@ -230,6 +244,8 @@ impl Default for Service {
             udp_port: 7777,
             udp_workers: std::num::NonZeroUsize::new(num_cpus::get()).unwrap(),
             udp_session_limit: 10_000,
+            udp_ring_buffer: 2048,
+            session_pool_ring_buffer: 256,
             udp_backend: crate::net::io::UdpBackend::Auto,
             xds_enabled: <_>::default(),
             xds_port: 7800,
@@ -348,6 +364,16 @@ impl Service {
     /// Sets the UDP I/O backend.
     pub fn udp_backend(mut self, backend: crate::net::io::UdpBackend) -> Self {
         self.udp_backend = backend;
+        self
+    }
+
+    pub fn udp_ring_buffer_len(mut self, len: u16) -> Self {
+        self.udp_ring_buffer = len;
+        self
+    }
+
+    pub fn session_pool_ring_buffer_len(mut self, len: u16) -> Self {
+        self.session_pool_ring_buffer = len;
         self
     }
 
@@ -794,8 +820,16 @@ impl Service {
             cached_filters,
             self.udp_session_limit,
             backend,
+            self.session_pool_ring_buffer,
         );
-        crate::net::packet::spawn_receivers(config, socket, worker_sends, &sessions, backend)?;
+        crate::net::packet::spawn_receivers(
+            config,
+            socket,
+            worker_sends,
+            &sessions,
+            backend,
+            self.udp_ring_buffer,
+        )?;
 
         let finished = shutdown.push("udp");
         let mut srx = shutdown.shutdown_rx();


### PR DESCRIPTION
This also exposes the ring buffer lengths of both the core receive workers and each session pool.

Resolves: #1445 