### PR TITLE
feat(xdp): query queue count dynamically from the system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,6 +1454,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethtool"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f0218cf6f43c8207b24602757c18a43dc8cd71a24ecce4b656489a2f27bc76"
+dependencies = [
+ "futures",
+ "genetlink",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-generic",
+ "netlink-proto",
+ "netlink-sys",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1755,20 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "genetlink"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d8935531e8e0919b17043c668cc18bfac1622f2fab73125f4f018124ee330b8"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-generic",
+ "netlink-proto",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3074,6 +3105,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-generic"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f891b2e0054cac5a684a06628f59568f841c93da4e551239da6e518f539e775"
+dependencies = [
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f7398dddf5f152d2a91a2921a134c6097056e292c0d4b9906007855e7cece6"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,7 +3822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3813,6 +3890,7 @@ dependencies = [
  "dashmap",
  "either",
  "enum_dispatch",
+ "ethtool",
  "eyre",
  "fixedstr",
  "form_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,7 @@ tikv-jemallocator = { workspace = true, optional = true }
 tikv-jemalloc-ctl = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+ethtool = { version = "0.2.9", default-features = false, features = ["tokio_socket"] }
 io-uring = { version = "0.7", default-features = false }
 libc.workspace = true
 pprof = { version = "0.13.1", package = "pprof2" }

--- a/crates/xdp/src/linux.rs
+++ b/crates/xdp/src/linux.rs
@@ -182,11 +182,18 @@ impl EbpfProgram {
         Ok(entries)
     }
 
-    pub fn attach(
-        &mut self,
-        nic: NicIndex,
-        mode: aya::programs::xdp::XdpMode,
-    ) -> Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError> {
+    // We use this entrypoint for now, but in the future we could also use
+    // a round robin mode when the xdp lib supports shared Umem
+    fn program_mut(&mut self) -> &mut aya::programs::Xdp {
+        self.bpf
+            .program_mut("all_queues")
+            .expect("failed to locate 'all_queues' program")
+            .try_into()
+            .expect("'all_queues' is not an xdp program")
+    }
+
+    /// Verifies and loads the program into the kernel; call once, before [`Self::attach`].
+    pub fn load_into_kernel(&mut self) -> Result<(), aya::programs::ProgramError> {
         if let Err(_error) = aya_log::EbpfLogger::init(&mut self.bpf) {
             // Would be good to enable this if we do end up adding log messages to
             // the eBPF program, right now we don't so this will error as the ring
@@ -194,29 +201,22 @@ impl EbpfProgram {
             //tracing::warn!(%error, "failed to initialize eBPF logging");
         }
 
-        // We use this entrypoint for now, but in the future we could also use
-        // a round robin mode when the xdp lib supports shared Umem
-        let program: &mut aya::programs::Xdp = self
-            .bpf
-            .program_mut("all_queues")
-            .expect("failed to locate 'all_queues' program")
-            .try_into()
-            .expect("'all_queues' is not an xdp program");
-        program.load()?;
+        self.program_mut().load()
+    }
 
-        program.attach_to_if_index(nic.into(), mode)
+    /// Attaches the loaded program to `nic`; safe to retry, eg after reconfiguring the NIC.
+    pub fn attach(
+        &mut self,
+        nic: NicIndex,
+        mode: aya::programs::xdp::XdpMode,
+    ) -> Result<aya::programs::xdp::XdpLinkId, aya::programs::ProgramError> {
+        self.program_mut().attach_to_if_index(nic.into(), mode)
     }
 
     pub fn detach(
         &mut self,
         link_id: aya::programs::xdp::XdpLinkId,
     ) -> Result<(), aya::programs::ProgramError> {
-        let program: &mut aya::programs::Xdp = self
-            .bpf
-            .program_mut("all_queues")
-            .expect("failed to locate 'all_queues' program")
-            .try_into()
-            .expect("'all_queues' is not an xdp program");
-        program.detach(link_id)
+        self.program_mut().detach(link_id)
     }
 }

--- a/src/net/io/nic/xdp.rs
+++ b/src/net/io/nic/xdp.rs
@@ -148,6 +148,158 @@ pub fn is_available() -> bool {
     chosen.is_some()
 }
 
+/// Queue channel counts reported by `ETHTOOL_MSG_CHANNELS_GET` (`ethtool -l`).
+#[derive(Debug, Default, Clone, Copy)]
+struct Channels {
+    combined_max: u32,
+    rx_count: u32,
+    tx_count: u32,
+    combined_count: u32,
+}
+
+impl Channels {
+    /// Queues actually in use, whichever reporting style the driver uses.
+    fn current(&self) -> u32 {
+        self.rx_count.max(self.tx_count).max(self.combined_count)
+    }
+
+    /// Some drivers report separate RX/TX queues, others a single combined count.
+    fn uses_combined(&self) -> bool {
+        self.combined_max > 0
+    }
+
+    fn from_nlas(nlas: Vec<ethtool::EthtoolAttr>) -> Self {
+        let mut channels = Self::default();
+        for nla in nlas {
+            let ethtool::EthtoolAttr::Channel(attr) = nla else {
+                continue;
+            };
+            match attr {
+                ethtool::EthtoolChannelAttr::CombinedMax(v) => channels.combined_max = v,
+                ethtool::EthtoolChannelAttr::RxCount(v) => channels.rx_count = v,
+                ethtool::EthtoolChannelAttr::TxCount(v) => channels.tx_count = v,
+                ethtool::EthtoolChannelAttr::CombinedCount(v) => channels.combined_count = v,
+                _ => {}
+            }
+        }
+        channels
+    }
+}
+
+/// Queries `iface`'s current queue channels (`ethtool -l`).
+async fn get_channels(iface: &str) -> Result<Channels, ethtool::EthtoolError> {
+    use futures::TryStreamExt as _;
+
+    let (connection, mut handle, _) =
+        ethtool::new_connection().map_err(|error| ethtool::EthtoolError::Bug(error.to_string()))?;
+    tokio::spawn(connection);
+
+    let mut stream = handle.channel().get(Some(iface)).execute().await;
+    let mut channels = Channels::default();
+    while let Some(msg) = stream.try_next().await? {
+        channels = Channels::from_nlas(msg.payload.nlas);
+    }
+    Ok(channels)
+}
+
+/// Sets `iface`'s queue channels to `count`, matching `channels`' reporting style (`ethtool -L`).
+async fn set_channel_count(
+    iface: &str,
+    channels: Channels,
+    count: u32,
+) -> Result<(), ethtool::EthtoolError> {
+    let (connection, mut handle, _) =
+        ethtool::new_connection().map_err(|error| ethtool::EthtoolError::Bug(error.to_string()))?;
+    tokio::spawn(connection);
+
+    let request = handle.channel().set(iface);
+    if channels.uses_combined() {
+        request.combined_count(count).execute().await
+    } else {
+        request.rx_count(count).tx_count(count).execute().await
+    }
+}
+
+/// Bridges an async ethtool call into this sync setup path; needs a
+/// multi-threaded runtime, same as the rest of XDP setup.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut))
+}
+
+/// Reduces `nic`'s configured queue count to `count` (`ethtool -L`).
+fn shrink_queue_count(nic: NicIndex, count: u32) -> std::io::Result<()> {
+    let name = nic
+        .name()
+        .map_err(|_err| std::io::Error::from(std::io::ErrorKind::NotFound))?;
+    let name = name.as_str().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "interface name is not utf-8",
+        )
+    })?;
+
+    block_on(async {
+        let channels = get_channels(name).await?;
+        set_channel_count(name, channels, count).await
+    })
+    .map_err(std::io::Error::other)
+}
+
+/// Some drivers (eg `gve`) reserve queues for XDP, rejecting attach at the
+/// full count. Returns the next smaller count to retry, or `None` if there's
+/// no room left to shrink.
+fn next_queue_count_to_try(current: u32) -> Option<u32> {
+    let half = current / 2;
+    (half >= 1).then_some(half)
+}
+
+/// Loads and attaches `ebpf_prog` to `nic`, starting at `initial_queue_count`
+/// and only shrinking it reactively on an attach failure — NICs that don't
+/// need it are never touched. Returns the link and the queue count XDP ended
+/// up using.
+fn attach_xdp_program(
+    ebpf_prog: &mut quilkin_xdp::EbpfProgram,
+    nic: NicIndex,
+    initial_queue_count: u32,
+) -> Result<
+    (quilkin_xdp::aya::programs::xdp::XdpLinkId, u32),
+    quilkin_xdp::aya::programs::ProgramError,
+> {
+    ebpf_prog.load_into_kernel()?;
+
+    let mode = quilkin_xdp::aya::programs::xdp::XdpMode::default();
+    let mut queue_count = initial_queue_count;
+
+    loop {
+        match ebpf_prog.attach(nic, mode) {
+            Ok(link) => return Ok((link, queue_count)),
+            Err(error) => {
+                let Some(reduced) = next_queue_count_to_try(queue_count) else {
+                    return Err(error);
+                };
+
+                if let Err(shrink_error) = shrink_queue_count(nic, reduced) {
+                    tracing::warn!(
+                        %shrink_error,
+                        ?nic,
+                        "failed to reduce NIC queue count for XDP, giving up"
+                    );
+                    return Err(error);
+                }
+
+                tracing::warn!(
+                    %error,
+                    ?nic,
+                    from = queue_count,
+                    to = reduced,
+                    "XDP attach rejected at current queue count, retrying with fewer queues"
+                );
+                queue_count = reduced;
+            }
+        }
+    }
+}
+
 /// a socket is bound to every available queue on the NIC, and when [`spawn`]
 /// is invoked, each socket is processed in its own thread
 ///
@@ -185,7 +337,7 @@ pub fn setup_xdp_io(config: XdpConfig<'_>) -> Result<XdpWorkers, XdpSetupError> 
 
     tracing::info!(nic = ?nic_index, "selected NIC");
 
-    let device_caps = nic_index
+    let mut device_caps = nic_index
         .query_capabilities()
         .map_err(|err| XdpSetupError::NicQuery(name, err))?;
 
@@ -264,13 +416,11 @@ pub fn setup_xdp_io(config: XdpConfig<'_>) -> Result<XdpWorkers, XdpSetupError> 
 
     let mut ebpf_prog = quilkin_xdp::EbpfProgram::load(config.external_port, config.qcmp_port)?;
 
-    // Attach before binding sockets: some drivers (eg gve) require XDP
-    // already enabled on the NIC before a socket can bind a queue with
-    // `XDP_ZEROCOPY`. Default flags use driver mode if supported, else SKB.
-    let xdp_link = ebpf_prog.attach(
-        nic_index,
-        quilkin_xdp::aya::programs::xdp::XdpMode::default(),
-    )?;
+    // Attach before binding: some drivers (eg gve) need XDP already enabled
+    // before a socket can bind a queue with `XDP_ZEROCOPY`.
+    let (xdp_link, queue_count) =
+        attach_xdp_program(&mut ebpf_prog, nic_index, device_caps.queue_count)?;
+    device_caps.queue_count = queue_count;
 
     let umem_cfg = xdp::umem::UmemCfgBuilder {
         frame_size: xdp::umem::FrameSize::TwoK,
@@ -544,5 +694,60 @@ fn io_error_to_discriminant(error: std::io::Error) -> std::borrow::Cow<'static, 
         libc::EAGAIN => "EAGAIN".into(),
         libc::ENETDOWN => "ENETDOWN".into(),
         other => format!("{other}").into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_queue_count_halves() {
+        assert_eq!(next_queue_count_to_try(8), Some(4));
+        assert_eq!(next_queue_count_to_try(4), Some(2));
+        assert_eq!(next_queue_count_to_try(3), Some(1));
+    }
+
+    #[test]
+    fn next_queue_count_stops_at_one() {
+        assert_eq!(next_queue_count_to_try(1), None);
+        assert_eq!(next_queue_count_to_try(0), None);
+    }
+
+    #[test]
+    fn channels_current_takes_whichever_style_is_populated() {
+        let separate = Channels {
+            combined_max: 0,
+            rx_count: 4,
+            tx_count: 4,
+            combined_count: 0,
+        };
+        assert_eq!(separate.current(), 4);
+        assert!(!separate.uses_combined());
+
+        let combined = Channels {
+            combined_max: 8,
+            rx_count: 0,
+            tx_count: 0,
+            combined_count: 2,
+        };
+        assert_eq!(combined.current(), 2);
+        assert!(combined.uses_combined());
+    }
+
+    #[test]
+    fn channels_from_nlas_parses_relevant_attrs_and_ignores_others() {
+        let nlas = vec![
+            ethtool::EthtoolAttr::Channel(ethtool::EthtoolChannelAttr::CombinedMax(4)),
+            ethtool::EthtoolAttr::Channel(ethtool::EthtoolChannelAttr::RxCount(2)),
+            ethtool::EthtoolAttr::Channel(ethtool::EthtoolChannelAttr::TxCount(2)),
+            ethtool::EthtoolAttr::Channel(ethtool::EthtoolChannelAttr::OtherCount(0)),
+        ];
+
+        let channels = Channels::from_nlas(nlas);
+        assert_eq!(channels.combined_max, 4);
+        assert_eq!(channels.rx_count, 2);
+        assert_eq!(channels.tx_count, 2);
+        assert_eq!(channels.combined_count, 0);
     }
 }


### PR DESCRIPTION
GVE doesn't give us the all of the available queues, we only have access to half, so we need to query and then reduce if attaching the XDP program fails.